### PR TITLE
ci: fix jurisdiction coverage gap and lula installation

### DIFF
--- a/.github/workflows/apac-mas-compliance.yml
+++ b/.github/workflows/apac-mas-compliance.yml
@@ -45,7 +45,8 @@ jobs:
   mas-feat-posture:
     name: "MAS FEAT Compliance Posture (APAC_MAS only)"
     runs-on: ubuntu-latest
-    if: vars.CAGE_DEPLOYMENT_REGION == 'APAC_MAS'
+    env:
+      CAGE_DEPLOYMENT_REGION: APAC_MAS
 
     steps:
       - name: Checkout repository
@@ -159,8 +160,9 @@ jobs:
   apac-mas-iso42001-lula:
     name: "ISO 42001 Universal Lula Validation (APAC_MAS context)"
     runs-on: ubuntu-latest
-    if: vars.CAGE_DEPLOYMENT_REGION == 'APAC_MAS'
     needs: [mas-feat-posture]
+    env:
+      CAGE_DEPLOYMENT_REGION: APAC_MAS
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,12 @@ jobs:
           echo "All source files have the required Apache 2.0 licensing headers."
 
   pytest-logic:
-    name: "Pytest Logic Tests"
+    name: "Pytest Logic Tests (${{ matrix.region }})"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        region: [US_FED, EU_ECB, APAC_MAS]
     steps:
       - uses: actions/checkout@v7
       - name: Install uv
@@ -69,6 +73,7 @@ jobs:
         run: uv sync --all-groups --all-extras
       - name: Run Pytest (unit/local)
         env:
+          CAGE_DEPLOYMENT_REGION: ${{ matrix.region }}
           CAGE_ENV: "test"
           OPENAI_API_KEY: "sk-dummy"
           MODEL_REASONING: "casperhansen/deepseek-r1-distill-qwen-14b-awq"

--- a/.github/workflows/compliance-matrix.yml
+++ b/.github/workflows/compliance-matrix.yml
@@ -19,19 +19,19 @@ on:
   workflow_call:
     inputs:
       lula_version:
-        description: "Lula binary version to install (defenseunicorns/lula)"
+        description: "Lula binary version to install (defenseunicorns-labs/lula1)"
         type: string
         required: false
-        default: "v0.9.5"
+        default: "v0.16.0"
 
   # Allow manual triggering from the GitHub Actions UI
   workflow_dispatch:
     inputs:
       lula_version:
-        description: "Lula binary version to install (defenseunicorns/lula)"
+        description: "Lula binary version to install (defenseunicorns-labs/lula1)"
         type: string
         required: false
-        default: "v0.9.5"
+        default: "v0.16.0"
 
   # Run automatically on pushes to integration branches
   push:
@@ -46,9 +46,10 @@ concurrency:
 
 env:
   PYTHON_VERSION: "3.11"
-  # Lula (defenseunicorns/lula) is the Go CLI compliance validator.
-  # Binary releases: https://github.com/defenseunicorns/lula/releases
-  LULA_VERSION: ${{ inputs.lula_version || 'v0.9.5' }}
+  # Lula (defenseunicorns-labs/lula1) is the Go CLI OSCAL compliance validator.
+  # Binary releases: https://github.com/defenseunicorns-labs/lula1/releases
+  # NOTE: github.com/defenseunicorns/lula is a separate TypeScript npm package (lula2).
+  LULA_VERSION: ${{ inputs.lula_version || 'v0.16.0' }}
 
 # ---------------------------------------------------------------------------
 # Job 1: Universal ISO 42001 Gates
@@ -80,20 +81,14 @@ jobs:
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
 
       - name: Install Lula binary
-        # Official Lula Go CLI: https://github.com/defenseunicorns/lula
-        # Falls back to go install if the release asset is unavailable.
+        # Official Lula Go CLI (OSCAL validator): https://github.com/defenseunicorns-labs/lula1
+        # NOTE: github.com/defenseunicorns/lula is a TypeScript npm package (lula2), not this tool.
         run: |
           LULA_VERSION="${{ env.LULA_VERSION }}"
-          LULA_URL="https://github.com/defenseunicorns/lula/releases/download/${LULA_VERSION}/lula_${LULA_VERSION}_Linux_amd64"
-          echo "Installing lula ${LULA_VERSION} from defenseunicorns/lula..."
-          if curl -fsSL "${LULA_URL}" -o /usr/local/bin/lula 2>/dev/null; then
-            chmod +x /usr/local/bin/lula
-            echo "lula installed via release binary"
-          else
-            echo "Release binary not found at ${LULA_URL} — falling back to go install"
-            go install github.com/defenseunicorns/lula/cmd/lula@${LULA_VERSION}
-            cp "$(go env GOPATH)/bin/lula" /usr/local/bin/lula
-          fi
+          LULA_URL="https://github.com/defenseunicorns-labs/lula1/releases/download/${LULA_VERSION}/lula_${LULA_VERSION}_Linux_amd64"
+          echo "Installing lula ${LULA_VERSION} from defenseunicorns-labs/lula1..."
+          curl -fsSL "${LULA_URL}" -o /usr/local/bin/lula
+          chmod +x /usr/local/bin/lula
           lula version
 
       - name: Gate 0.1 — Core unit tests (if tests/core/ exists)
@@ -172,19 +167,14 @@ jobs:
           if [ -f requirements-dev.txt ]; then pip install -r requirements-dev.txt; fi
 
       - name: Install Lula binary
-        # Official Lula Go CLI: https://github.com/defenseunicorns/lula
+        # Official Lula Go CLI (OSCAL validator): https://github.com/defenseunicorns-labs/lula1
+        # NOTE: github.com/defenseunicorns/lula is a TypeScript npm package (lula2), not this tool.
         run: |
           LULA_VERSION="${{ env.LULA_VERSION }}"
-          LULA_URL="https://github.com/defenseunicorns/lula/releases/download/${LULA_VERSION}/lula_${LULA_VERSION}_Linux_amd64"
-          echo "Installing lula ${LULA_VERSION} from defenseunicorns/lula..."
-          if curl -fsSL "${LULA_URL}" -o /usr/local/bin/lula 2>/dev/null; then
-            chmod +x /usr/local/bin/lula
-            echo "lula installed via release binary"
-          else
-            echo "Release binary not found at ${LULA_URL} — falling back to go install"
-            go install github.com/defenseunicorns/lula/cmd/lula@${LULA_VERSION}
-            cp "$(go env GOPATH)/bin/lula" /usr/local/bin/lula
-          fi
+          LULA_URL="https://github.com/defenseunicorns-labs/lula1/releases/download/${LULA_VERSION}/lula_${LULA_VERSION}_Linux_amd64"
+          echo "Installing lula ${LULA_VERSION} from defenseunicorns-labs/lula1..."
+          curl -fsSL "${LULA_URL}" -o /usr/local/bin/lula
+          chmod +x /usr/local/bin/lula
           lula version
 
       - name: Install OPA binary (US_FED only)

--- a/.github/workflows/eu-ecb-compliance.yml
+++ b/.github/workflows/eu-ecb-compliance.yml
@@ -45,7 +45,8 @@ jobs:
   eu-ai-act-posture:
     name: "EU AI Act Compliance Posture (EU_ECB only)"
     runs-on: ubuntu-latest
-    if: vars.CAGE_DEPLOYMENT_REGION == 'EU_ECB'
+    env:
+      CAGE_DEPLOYMENT_REGION: EU_ECB
 
     steps:
       - name: Checkout repository
@@ -159,8 +160,9 @@ jobs:
   eu-ecb-iso42001-lula:
     name: "ISO 42001 Universal Lula Validation (EU_ECB context)"
     runs-on: ubuntu-latest
-    if: vars.CAGE_DEPLOYMENT_REGION == 'EU_ECB'
     needs: [eu-ai-act-posture]
+    env:
+      CAGE_DEPLOYMENT_REGION: EU_ECB
 
     steps:
       - name: Checkout repository

--- a/scripts/run_matrix_tests.sh
+++ b/scripts/run_matrix_tests.sh
@@ -108,6 +108,18 @@ header "Phase 0 — Universal ISO 42001 Gates"
 
 PHASE0_FAILURES=0
 
+# ---------------------------------------------------------------------------
+# Phase: Pytest unit tests (region-scoped, -m local)
+# Runs before Lula/OPA checks so fast unit failures surface first.
+# ---------------------------------------------------------------------------
+echo "=== Phase: Pytest unit tests (CAGE_DEPLOYMENT_REGION=${CAGE_REGION}) ==="
+mkdir -p pytest-results
+CAGE_DEPLOYMENT_REGION="${CAGE_REGION}" \
+  uv run pytest tests/ -m local \
+    --tb=short -q \
+    --junitxml="pytest-results/pytest-${CAGE_REGION}-${CAGE_ENV}.xml" \
+  || { echo "Pytest failed for region ${CAGE_REGION}"; exit 1; }
+
 # Gate 0.1 — Core unit tests (skip gracefully if directory absent)
 echo ""
 info "Gate 0.1 — Core unit tests (tests/core/)"

--- a/tests/infrastructure/test_data_residency_apac_mas.py
+++ b/tests/infrastructure/test_data_residency_apac_mas.py
@@ -1,0 +1,307 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+tests/infrastructure/test_data_residency_apac_mas.py
+=====================================================
+APAC_MAS data-residency gate tests.
+
+These tests assert that all GCS storage paths and bucket references are
+confined to the ``asia-southeast1`` region when ``CAGE_DEPLOYMENT_REGION``
+is set to ``APAC_MAS``.  They are skipped automatically for all other
+deployment regions.
+
+Regulatory basis: MAS TRM §4.2 (data residency), MAS Notice 655 (outsourcing),
+MAS FEAT (fairness, ethics, accountability, transparency).
+
+Run manually against an APAC_MAS posture:
+
+    CAGE_DEPLOYMENT_REGION=APAC_MAS uv run pytest tests/infrastructure/ -v -m apac_mas
+
+Marks
+-----
+- ``apac_mas`` : APAC_MAS jurisdiction-specific test
+- ``local``    : safe to run with no live services (CI default)
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module-level skip guard — entire module is skipped unless APAC_MAS is active
+# ---------------------------------------------------------------------------
+
+_REGION = os.environ.get("CAGE_DEPLOYMENT_REGION", "")
+
+_SKIP_NON_APAC = pytest.mark.skipif(
+    _REGION != "APAC_MAS",
+    reason=(
+        f"APAC_MAS data-residency tests skipped for region {_REGION!r}. "
+        "Set CAGE_DEPLOYMENT_REGION=APAC_MAS to run."
+    ),
+)
+
+# ---------------------------------------------------------------------------
+# Known non-APAC region substrings — any bucket/path containing these is a
+# residency violation when CAGE_DEPLOYMENT_REGION == APAC_MAS.
+# ---------------------------------------------------------------------------
+
+_NON_APAC_REGIONS = (
+    "us-central1",
+    "us-east1",
+    "us-west1",
+    "us-west2",
+    "us-west3",
+    "us-west4",
+    "northamerica-northeast1",
+    "southamerica-east1",
+    "europe-west1",
+    "europe-west2",
+    "europe-west3",
+    "europe-west4",
+    "europe-west6",
+    "europe-north1",
+    "europe-central2",
+    # Short-form aliases
+    "us-",
+    "europe-",
+    "northamerica-",
+    "southamerica-",
+)
+
+_REQUIRED_APAC_REGION = "asia-southeast1"
+
+
+def _assert_apac_region(value: str, label: str) -> None:
+    """Assert that *value* references asia-southeast1 and no non-APAC region."""
+    assert _REQUIRED_APAC_REGION in value, (
+        f"{label} must reference '{_REQUIRED_APAC_REGION}', got: {value!r}"
+    )
+    for bad in _NON_APAC_REGIONS:
+        assert bad not in value, (
+            f"{label} must not reference non-APAC region '{bad}', got: {value!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test class
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.apac_mas
+@pytest.mark.local
+@_SKIP_NON_APAC
+class TestAPACMASDataResidency:
+    """Gate tests for APAC_MAS data-residency compliance (MAS TRM §4.2)."""
+
+    # ------------------------------------------------------------------
+    # 1. Deployment region identity
+    # ------------------------------------------------------------------
+
+    def test_cage_deployment_region_is_apac_mas(self) -> None:
+        """CAGE_DEPLOYMENT_REGION must be exactly 'APAC_MAS' in this posture."""
+        region = os.environ.get("CAGE_DEPLOYMENT_REGION", "")
+        assert region == "APAC_MAS", (
+            f"Expected CAGE_DEPLOYMENT_REGION='APAC_MAS', got {region!r}"
+        )
+
+    # ------------------------------------------------------------------
+    # 2. GCS storage path residency
+    # ------------------------------------------------------------------
+
+    def test_gcs_storage_paths_are_apac_region(self) -> None:
+        """All GCS storage paths configured via env vars must be in asia-southeast1."""
+        gcs_path_vars = [
+            "GCS_BUCKET_PATH",
+            "OSCAL_GCS_PATH",
+            "AUDIT_GCS_PATH",
+            "EVIDENCE_GCS_PATH",
+            "COMPLIANCE_GCS_PATH",
+        ]
+        for var in gcs_path_vars:
+            value = os.environ.get(var, "")
+            if not value:
+                # Variable not set — not a violation; skip this specific var
+                continue
+            _assert_apac_region(value, var)
+
+    def test_google_cloud_location_is_asia_southeast1(self) -> None:
+        """GOOGLE_CLOUD_LOCATION must be asia-southeast1 for APAC_MAS deployments."""
+        location = os.environ.get("GOOGLE_CLOUD_LOCATION", "")
+        if not location:
+            pytest.skip(
+                "GOOGLE_CLOUD_LOCATION not set — skipping location residency check"
+            )
+        assert location == _REQUIRED_APAC_REGION, (
+            f"GOOGLE_CLOUD_LOCATION must be '{_REQUIRED_APAC_REGION}' for APAC_MAS, "
+            f"got {location!r}"
+        )
+
+    # ------------------------------------------------------------------
+    # 3. COLD_TIER_BUCKET residency
+    # ------------------------------------------------------------------
+
+    def test_cold_tier_bucket_does_not_reference_non_apac_region(self) -> None:
+        """COLD_TIER_BUCKET, when set, must not reference a non-APAC region."""
+        bucket = os.environ.get("COLD_TIER_BUCKET", "")
+        if not bucket:
+            pytest.skip("COLD_TIER_BUCKET not set — skipping residency check")
+        for bad in _NON_APAC_REGIONS:
+            assert bad not in bucket, (
+                f"COLD_TIER_BUCKET must not reference non-APAC region '{bad}', "
+                f"got: {bucket!r}"
+            )
+
+    def test_cold_tier_bucket_references_apac_region_when_explicit(self) -> None:
+        """COLD_TIER_BUCKET, when it contains a region string, must be asia-southeast1."""
+        bucket = os.environ.get("COLD_TIER_BUCKET", "")
+        if not bucket:
+            pytest.skip("COLD_TIER_BUCKET not set — skipping residency check")
+        # Only assert the positive APAC region if the bucket name embeds a region
+        # (e.g. "cage-apac-mas-cold-asia-southeast1"). Generic names like
+        # "cage-cold-tier" are acceptable without a region substring.
+        if any(
+            region_hint in bucket
+            for region_hint in ("asia-", "europe-", "us-", "australia-")
+        ):
+            _assert_apac_region(bucket, "COLD_TIER_BUCKET")
+
+    # ------------------------------------------------------------------
+    # 4. OSCAL_S3_BUCKET residency
+    # ------------------------------------------------------------------
+
+    def test_oscal_s3_bucket_does_not_reference_non_apac_region(self) -> None:
+        """OSCAL_S3_BUCKET, when set, must not reference a non-APAC region."""
+        bucket = os.environ.get("OSCAL_S3_BUCKET", "")
+        if not bucket:
+            pytest.skip("OSCAL_S3_BUCKET not set — skipping residency check")
+        for bad in _NON_APAC_REGIONS:
+            assert bad not in bucket, (
+                f"OSCAL_S3_BUCKET must not reference non-APAC region '{bad}', "
+                f"got: {bucket!r}"
+            )
+
+    def test_oscal_s3_bucket_references_apac_region_when_explicit(self) -> None:
+        """OSCAL_S3_BUCKET, when it contains a region string, must be asia-southeast1."""
+        bucket = os.environ.get("OSCAL_S3_BUCKET", "")
+        if not bucket:
+            pytest.skip("OSCAL_S3_BUCKET not set — skipping residency check")
+        if any(
+            region_hint in bucket
+            for region_hint in ("asia-", "europe-", "us-", "australia-")
+        ):
+            _assert_apac_region(bucket, "OSCAL_S3_BUCKET")
+
+    # ------------------------------------------------------------------
+    # 5. Terraform tfvars residency (apac-dev / apac-prod)
+    # ------------------------------------------------------------------
+
+    def test_apac_dev_tfvars_references_asia_southeast1(self) -> None:
+        """infra/targets/gcp-gke/apac-dev.tfvars must reference asia-southeast1."""
+        import pathlib
+
+        tfvars_path = pathlib.Path("infra/targets/gcp-gke/apac-dev.tfvars")
+        if not tfvars_path.exists():
+            pytest.skip(f"{tfvars_path} not found — skipping tfvars residency check")
+        content = tfvars_path.read_text()
+        assert _REQUIRED_APAC_REGION in content, (
+            f"apac-dev.tfvars must reference '{_REQUIRED_APAC_REGION}' for APAC_MAS posture"
+        )
+
+    def test_apac_prod_tfvars_references_asia_southeast1(self) -> None:
+        """infra/targets/gcp-gke/apac-prod.tfvars must reference asia-southeast1."""
+        import pathlib
+
+        tfvars_path = pathlib.Path("infra/targets/gcp-gke/apac-prod.tfvars")
+        if not tfvars_path.exists():
+            pytest.skip(f"{tfvars_path} not found — skipping tfvars residency check")
+        content = tfvars_path.read_text()
+        assert _REQUIRED_APAC_REGION in content, (
+            f"apac-prod.tfvars must reference '{_REQUIRED_APAC_REGION}' for APAC_MAS posture"
+        )
+
+    # ------------------------------------------------------------------
+    # 6. APAC_MAS baseline config residency
+    # ------------------------------------------------------------------
+
+    def test_apac_mas_baseline_config_is_loadable(self) -> None:
+        """config/compliance/APAC_MAS_BASELINE.json must exist and be valid JSON."""
+        import json
+        import pathlib
+
+        baseline_path = pathlib.Path("config/compliance/APAC_MAS_BASELINE.json")
+        if not baseline_path.exists():
+            pytest.skip(
+                f"{baseline_path} not found — skipping baseline loadability check"
+            )
+        content = baseline_path.read_text()
+        # Must be valid JSON
+        data = json.loads(content)
+        assert isinstance(data, dict), (
+            "APAC_MAS_BASELINE.json must be a JSON object at the top level"
+        )
+
+    def test_apac_mas_baseline_config_references_asia_southeast1(self) -> None:
+        """config/compliance/APAC_MAS_BASELINE.json must reference asia-southeast1."""
+        import pathlib
+
+        baseline_path = pathlib.Path("config/compliance/APAC_MAS_BASELINE.json")
+        if not baseline_path.exists():
+            pytest.skip(
+                f"{baseline_path} not found — skipping baseline residency check"
+            )
+        content = baseline_path.read_text()
+        assert _REQUIRED_APAC_REGION in content, (
+            f"APAC_MAS_BASELINE.json must reference '{_REQUIRED_APAC_REGION}'"
+        )
+
+    # ------------------------------------------------------------------
+    # 7. MAS TRM §4.2 data residency reference in shared modules
+    # ------------------------------------------------------------------
+
+    def test_mas_trm_data_residency_referenced_in_compliance_bridge(self) -> None:
+        """MAS TRM §4.2 data residency: asia-southeast1 must appear in compliance_bridge."""
+        import pathlib
+
+        bridge_dir = pathlib.Path("src/compliance_bridge")
+        if not bridge_dir.exists():
+            pytest.skip(
+                "src/compliance_bridge/ not found — skipping MAS TRM §4.2 reference check"
+            )
+        found = False
+        for py_file in bridge_dir.rglob("*.py"):
+            try:
+                if _REQUIRED_APAC_REGION in py_file.read_text():
+                    found = True
+                    break
+            except (OSError, UnicodeDecodeError):
+                continue
+        if not found:
+            # Also check gateway/governance as a fallback
+            governance_dir = pathlib.Path("src/gateway/governance")
+            if governance_dir.exists():
+                for py_file in governance_dir.rglob("*.py"):
+                    try:
+                        if _REQUIRED_APAC_REGION in py_file.read_text():
+                            found = True
+                            break
+                    except (OSError, UnicodeDecodeError):
+                        continue
+        assert found, (
+            f"MAS TRM §4.2 requires '{_REQUIRED_APAC_REGION}' to be referenced in "
+            "src/compliance_bridge/ or src/gateway/governance/ to enforce APAC data residency"
+        )

--- a/tests/test_normative_provider.py
+++ b/tests/test_normative_provider.py
@@ -132,6 +132,7 @@ class TestStubNormativeProvider:
         self, stub_provider: StubNormativeProvider
     ) -> None:
         """StubNormativeProvider reads from config/compliance/ and returns valid baseline."""
+        # US_FED-specific: not parametrized — asserts CTRL_AGT_001 which is US_FED-only
         baseline = await stub_provider.fetch_baseline("US_FED")
         # US_FED_BASELINE.json should exist in the repo
         assert baseline.is_valid, (
@@ -350,19 +351,22 @@ class TestNormativeProviderDaemon:
     """Tests for NormativeProviderDaemon lifecycle."""
 
     @pytest.mark.asyncio
-    async def test_boot_fetch_writes_and_reconfigures(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize("region", ["US_FED", "EU_ECB", "APAC_MAS"])
+    async def test_boot_fetch_writes_and_reconfigures(
+        self, tmp_path: Path, region: str
+    ) -> None:
         """Daemon.boot_fetch() writes profile to disk and calls ControlRegistry.reconfigure()."""
         provider = AsyncMock()
         provider.fetch_baseline = AsyncMock(
             return_value=NormativeBaseline(
-                region="US_FED",
+                region=region,
                 profile={"CTRL_AGT_001": {"internal_id": "THR-CONF-001"}},
             )
         )
 
         daemon = NormativeProviderDaemon(
             provider=provider,
-            region="US_FED",
+            region=region,
             boot_timeout=5.0,
         )
 
@@ -377,7 +381,7 @@ class TestNormativeProviderDaemon:
             await daemon.boot_fetch()
 
             # Profile should be written to disk
-            profile_path = tmp_path / "US_FED_BASELINE.json"
+            profile_path = tmp_path / f"{region}_BASELINE.json"
             assert profile_path.exists()
             with open(profile_path) as fh:
                 written = json.load(fh)
@@ -387,22 +391,25 @@ class TestNormativeProviderDaemon:
             mock_reconfig.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_boot_fetch_fallback_on_failure(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize("region", ["US_FED", "EU_ECB", "APAC_MAS"])
+    async def test_boot_fetch_fallback_on_failure(
+        self, tmp_path: Path, region: str
+    ) -> None:
         """Provider unreachable → falls back to cached local copy."""
         # Create a cached profile
-        profile_path = tmp_path / "US_FED_BASELINE.json"
+        profile_path = tmp_path / f"{region}_BASELINE.json"
         profile_path.write_text(json.dumps({"CTRL_AGT_001": {"cached": True}}))
 
         provider = AsyncMock()
         provider.fetch_baseline = AsyncMock(
             return_value=NormativeBaseline(
-                region="US_FED", profile={}, error="Connection refused"
+                region=region, profile={}, error="Connection refused"
             )
         )
 
         daemon = NormativeProviderDaemon(
             provider=provider,
-            region="US_FED",
+            region=region,
             boot_timeout=5.0,
         )
 
@@ -413,18 +420,21 @@ class TestNormativeProviderDaemon:
             await daemon.boot_fetch()
 
     @pytest.mark.asyncio
-    async def test_boot_fetch_no_fallback_raises(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize("region", ["US_FED", "EU_ECB", "APAC_MAS"])
+    async def test_boot_fetch_no_fallback_raises(
+        self, tmp_path: Path, region: str
+    ) -> None:
         """No profile anywhere → RuntimeError."""
         provider = AsyncMock()
         provider.fetch_baseline = AsyncMock(
             return_value=NormativeBaseline(
-                region="US_FED", profile={}, error="Connection refused"
+                region=region, profile={}, error="Connection refused"
             )
         )
 
         daemon = NormativeProviderDaemon(
             provider=provider,
-            region="US_FED",
+            region=region,
             boot_timeout=5.0,
         )
 
@@ -435,15 +445,18 @@ class TestNormativeProviderDaemon:
                 await daemon.boot_fetch()
 
     @pytest.mark.asyncio
-    async def test_polling_detects_etag_change(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize("region", ["US_FED", "EU_ECB", "APAC_MAS"])
+    async def test_polling_detects_etag_change(
+        self, tmp_path: Path, region: str
+    ) -> None:
         """Changed baseline triggers reconfigure; unchanged is no-op."""
         call_count = 0
 
-        async def changing_baseline(region: str) -> NormativeBaseline:
+        async def changing_baseline(rgn: str) -> NormativeBaseline:
             nonlocal call_count
             call_count += 1
             return NormativeBaseline(
-                region=region,
+                region=rgn,
                 profile={"CTRL_AGT_001": {"version": call_count}},
             )
 
@@ -452,7 +465,7 @@ class TestNormativeProviderDaemon:
 
         daemon = NormativeProviderDaemon(
             provider=provider,
-            region="US_FED",
+            region=region,
             poll_interval=0.1,  # 100ms for test speed
         )
         daemon._last_hash = "initial-hash"
@@ -538,25 +551,29 @@ class TestDeferReasonExternalValidation:
 class TestDataContracts:
     """Tests for data contract validity and behavior."""
 
-    def test_normative_baseline_validity(self) -> None:
+    @pytest.mark.parametrize("region", ["US_FED", "EU_ECB", "APAC_MAS"])
+    def test_normative_baseline_validity(self, region: str) -> None:
         """Valid baseline has no error and non-empty profile."""
-        baseline = NormativeBaseline(region="US_FED", profile={"key": "val"})
+        baseline = NormativeBaseline(region=region, profile={"key": "val"})
         assert baseline.is_valid
 
-    def test_normative_baseline_invalid_on_error(self) -> None:
+    @pytest.mark.parametrize("region", ["US_FED", "EU_ECB", "APAC_MAS"])
+    def test_normative_baseline_invalid_on_error(self, region: str) -> None:
         """Baseline with error is not valid."""
-        baseline = NormativeBaseline(region="US_FED", profile={}, error="fail")
+        baseline = NormativeBaseline(region=region, profile={}, error="fail")
         assert not baseline.is_valid
 
-    def test_normative_baseline_invalid_on_empty_profile(self) -> None:
+    @pytest.mark.parametrize("region", ["US_FED", "EU_ECB", "APAC_MAS"])
+    def test_normative_baseline_invalid_on_empty_profile(self, region: str) -> None:
         """Baseline with empty profile is not valid."""
-        baseline = NormativeBaseline(region="US_FED", profile={})
+        baseline = NormativeBaseline(region=region, profile={})
         assert not baseline.is_valid
 
-    def test_normative_baseline_profile_hash_deterministic(self) -> None:
+    @pytest.mark.parametrize("region", ["US_FED", "EU_ECB", "APAC_MAS"])
+    def test_normative_baseline_profile_hash_deterministic(self, region: str) -> None:
         """Same profile produces same hash."""
-        b1 = NormativeBaseline(region="US_FED", profile={"a": 1, "b": 2})
-        b2 = NormativeBaseline(region="US_FED", profile={"b": 2, "a": 1})
+        b1 = NormativeBaseline(region=region, profile={"a": 1, "b": 2})
+        b2 = NormativeBaseline(region=region, profile={"b": 2, "a": 1})
         assert b1.profile_hash == b2.profile_hash
 
     def test_fria_enforcement_result_fields(self) -> None:


### PR DESCRIPTION
## Summary

### Problem
The CI test suite only ran pytest under the US_FED posture. EU_ECB and APAC_MAS compliance workflows were permanently skipped due to job-level `if: vars.CAGE_DEPLOYMENT_REGION` guards. The Lula installation was broken (wrong repo, wrong version, broken go install fallback).

### Changes

#### CI — Three-region pytest matrix (`ci.yml`)
Added `matrix: {region: [US_FED, EU_ECB, APAC_MAS]}` to the `pytest-logic` job with `CAGE_DEPLOYMENT_REGION: ${{ matrix.region }}`. All shared modules now tested under all three regulatory postures on every push.

#### CI — Activate jurisdiction compliance workflows (`eu-ecb-compliance.yml`, `apac-mas-compliance.yml`)
Removed permanent `if: vars.CAGE_DEPLOYMENT_REGION == '...'` job-level guards that caused all jobs to be skipped. Added `CAGE_DEPLOYMENT_REGION` env var to each job so they run with the correct posture.

#### CI — Fix Lula installation (`compliance-matrix.yml`)
- Wrong repo: `defenseunicorns/lula` (TypeScript npm package) → `defenseunicorns-labs/lula1` (Go CLI)
- Wrong version: `v0.9.5` → `v0.16.0` (latest with verified Linux amd64 binary)
- Removed broken `go install github.com/defenseunicorns/lula/cmd/lula` fallback

#### Tests — APAC_MAS data residency (`tests/infrastructure/test_data_residency_apac_mas.py`)
New test file mirroring the EU_ECB data residency tests. Asserts `asia-southeast1` residency, MAS TRM §4.2 compliance, and APAC_MAS_BASELINE.json loadability.

#### Tests — Normative provider parametrization (`tests/test_normative_provider.py`)
Parametrized key test cases across `[US_FED, EU_ECB, APAC_MAS]` to exercise all three normative baseline fetch paths.

#### Script — Matrix pytest invocation (`scripts/run_matrix_tests.sh`)
Added pytest phase before Lula/OPA checks, writing per-region JUnit XML artifacts.

## Test plan
- `pytest-logic` job now runs 3× (one per region) — all should pass
- `eu-ecb-compliance.yml` and `apac-mas-compliance.yml` jobs now run unconditionally
- Lula installs correctly from `defenseunicorns-labs/lula1` v0.16.0