### PR TITLE
ci: fix compliance gate tfvars string match and matrix skip

### DIFF
--- a/.github/workflows/apac-mas-compliance.yml
+++ b/.github/workflows/apac-mas-compliance.yml
@@ -113,7 +113,7 @@ jobs:
               sys.exit(1)
           print(f'cage_deployment_region=APAC_MAS — OK')
           # Verify enable_apac_mas_compliance is true
-          if 'enable_apac_mas_compliance = true' not in content:
+          if not re.search(r'enable_apac_mas_compliance\s*=\s*true', content):
               print('ERROR: enable_apac_mas_compliance must be true in apac-prod.tfvars')
               sys.exit(1)
           print('enable_apac_mas_compliance=true — OK')

--- a/.github/workflows/compliance-matrix.yml
+++ b/.github/workflows/compliance-matrix.yml
@@ -130,6 +130,7 @@ jobs:
   regional-posture:
     name: "Regional Posture (${{ matrix.region }} / ${{ matrix.environment }})"
     needs: [universal-iso42001]
+    if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 30
 

--- a/.github/workflows/eu-ecb-compliance.yml
+++ b/.github/workflows/eu-ecb-compliance.yml
@@ -113,7 +113,7 @@ jobs:
               sys.exit(1)
           print(f'cage_deployment_region=EU_ECB — OK')
           # Verify enable_eu_ecb_compliance is true
-          if 'enable_eu_ecb_compliance = true' not in content:
+          if not re.search(r'enable_eu_ecb_compliance\s*=\s*true', content):
               print('ERROR: enable_eu_ecb_compliance must be true in eu-prod.tfvars')
               sys.exit(1)
           print('enable_eu_ecb_compliance=true — OK')


### PR DESCRIPTION
## Summary

### EU_ECB / APAC_MAS Compliance Gate failures
The Python posture check used a single-space literal string (`'enable_eu_ecb_compliance = true'`) to search tfvars files that use Terraform's aligned formatting with multiple spaces (`enable_eu_ecb_compliance       = true`). The `in` check always returned `False`, causing `sys.exit(1)` after ~7s.

**Fix:** Changed to `re.search(r'enable_eu_ecb_compliance\s*=\s*true', content)` in both `eu-ecb-compliance.yml` and `apac-mas-compliance.yml`.

### Compliance Matrix Regional Posture skipped
The `regional-posture` job had `needs: [universal-iso42001]` with no `if: always()`. When `universal-iso42001` failed, GitHub skipped `regional-posture` before matrix expansion, producing the literal `${{ matrix.region }}` in the skipped job name.

**Fix:** Added `if: always()` to the `regional-posture` job in `compliance-matrix.yml`.