### PR TITLE
fix(ci): resolve EU_ECB, APAC_MAS, ISO 42001 compliance gate failures

### DIFF
--- a/.github/workflows/apac-mas-compliance.yml
+++ b/.github/workflows/apac-mas-compliance.yml
@@ -170,23 +170,38 @@ jobs:
           python-version: "3.11"
 
       - name: Validate ISO 42001 universal Lula manifests (APAC_MAS context)
+        # ISO 42001 is a universal standard — applies to ALL regions including APAC_MAS.
+        # Only ISO 42001 and AARM (CSA) manifests are validated here.
+        # NIST SP 800-53 (ac*, au*, cm*, ia*, ir*, ra*, sc*, si*) and
+        # NIST AI 600-1 (ai600-*) are US_FED-scoped and must NOT be validated here.
         run: |
           python3 - <<'PYEOF'
           import yaml, sys, pathlib
-          # ISO 42001 manifests are universal — validate structure in APAC_MAS context
-          manifests = sorted(pathlib.Path('compliance/lula').glob('lula-validation-a*.yaml'))
-          if not manifests:
-              print('ERROR: no ISO 42001 Lula manifests found')
-              sys.exit(1)
+          # Explicit list of universal manifests (ISO 42001 + AARM).
+          # Do NOT use a glob — lula-validation-a*.yaml also matches NIST SP 800-53
+          # (ac2, ac3, au12) and NIST AI 600-1 (ai600-*) which are US_FED-only.
+          UNIVERSAL_MANIFESTS = [
+              'compliance/lula/lula-validation-a52.yaml',
+              'compliance/lula/lula-validation-a53.yaml',
+              'compliance/lula/lula-validation-a92.yaml',
+              'compliance/lula/lula-validation-aarm-vectors.yaml',
+          ]
           errors = []
-          for m in manifests:
+          validated = []
+          for path in UNIVERSAL_MANIFESTS:
+              m = pathlib.Path(path)
+              if not m.exists():
+                  errors.append(f'{m.name}: file not found')
+                  continue
               doc = yaml.safe_load(m.read_text())
               if 'component-definition' not in doc:
                   errors.append(f'{m.name}: missing component-definition key')
-              print(f'  OK {m.name}')
+              else:
+                  validated.append(m.name)
+                  print(f'  OK {m.name}')
           if errors:
               for e in errors:
                   print(f'  ERROR: {e}')
               sys.exit(1)
-          print(f'All {len(manifests)} ISO 42001 Lula manifests valid (APAC_MAS context).')
+          print(f'All {len(validated)} universal ISO 42001 / AARM Lula manifests valid (APAC_MAS context).')
           PYEOF

--- a/.github/workflows/eu-ecb-compliance.yml
+++ b/.github/workflows/eu-ecb-compliance.yml
@@ -170,23 +170,38 @@ jobs:
           python-version: "3.11"
 
       - name: Validate ISO 42001 universal Lula manifests (EU_ECB context)
+        # ISO 42001 is a universal standard — applies to ALL regions including EU_ECB.
+        # Only ISO 42001 and AARM (CSA) manifests are validated here.
+        # NIST SP 800-53 (ac*, au*, cm*, ia*, ir*, ra*, sc*, si*) and
+        # NIST AI 600-1 (ai600-*) are US_FED-scoped and must NOT be validated here.
         run: |
           python3 - <<'PYEOF'
           import yaml, sys, pathlib
-          # ISO 42001 manifests are universal — validate structure in EU_ECB context
-          manifests = sorted(pathlib.Path('compliance/lula').glob('lula-validation-a*.yaml'))
-          if not manifests:
-              print('ERROR: no ISO 42001 Lula manifests found')
-              sys.exit(1)
+          # Explicit list of universal manifests (ISO 42001 + AARM).
+          # Do NOT use a glob — lula-validation-a*.yaml also matches NIST SP 800-53
+          # (ac2, ac3, au12) and NIST AI 600-1 (ai600-*) which are US_FED-only.
+          UNIVERSAL_MANIFESTS = [
+              'compliance/lula/lula-validation-a52.yaml',
+              'compliance/lula/lula-validation-a53.yaml',
+              'compliance/lula/lula-validation-a92.yaml',
+              'compliance/lula/lula-validation-aarm-vectors.yaml',
+          ]
           errors = []
-          for m in manifests:
+          validated = []
+          for path in UNIVERSAL_MANIFESTS:
+              m = pathlib.Path(path)
+              if not m.exists():
+                  errors.append(f'{m.name}: file not found')
+                  continue
               doc = yaml.safe_load(m.read_text())
               if 'component-definition' not in doc:
                   errors.append(f'{m.name}: missing component-definition key')
-              print(f'  OK {m.name}')
+              else:
+                  validated.append(m.name)
+                  print(f'  OK {m.name}')
           if errors:
               for e in errors:
                   print(f'  ERROR: {e}')
               sys.exit(1)
-          print(f'All {len(manifests)} ISO 42001 Lula manifests valid (EU_ECB context).')
+          print(f'All {len(validated)} universal ISO 42001 / AARM Lula manifests valid (EU_ECB context).')
           PYEOF

--- a/compliance/lula/lula-validation-ai600-cbrn.yaml
+++ b/compliance/lula/lula-validation-ai600-cbrn.yaml
@@ -12,31 +12,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Validates: AI 600-1 §2.6 CBRN / Harmful Content controls
-# Controls: NeMo guardrails active; Tier-1 CBRN keyword list enforced
+# lula-validation-ai600-cbrn.yaml
+# NIST AI 600-1 §2.6 — CBRN / Harmful Content controls
+#
+# Validates: NeMo guardrails active; Tier-1 CBRN keyword list enforced.
 # POAM: AI600-007
-# Phase: 0 (stub) → Phase 3 (real assertions replace stub per §7.2)
+# Phase: 0 (stub — always passes) → Phase 3 (real assertions per §7.2)
 # Region: US_FED (CAGE_DEPLOYMENT_REGION=US_FED)
 # Cat-M flag: NeMo CBRN rail deployment requires AO pre-approval
-domain:
-  type: kubernetes
-  kubernetes:
-    resources: []   # populated in Phase 3
-    # Phase 3 will assert:
-    #   - nemo Deployment has NEMO_CBRN_RAILS_ENABLED=true
-    #   - cbrn_rails.co is mounted in the NeMo container
-provider:
-  type: opa
-  opa:
-    policy: |
-      # stub — always passes until Phase 3
-      # Phase 3 real assertion (see §7.2 of AI_600_1_IMPLEMENTATION_PLAN.md):
-      #   allow if {
-      #     some container in input["nemo-deployment"].spec.template.spec.containers
-      #     container.name == "nemo"
-      #     some env in container.env
-      #     env.name == "NEMO_CBRN_RAILS_ENABLED"
-      #     env.value == "true"
-      #   }
-      package validate
-      default allow = true
+
+component-definition:
+  uuid: b1c2d3e4-f5a6-7890-abcd-ef1234567890
+  metadata:
+    title: CAGE Validation — AI600-CBRN
+    last-modified: '2026-07-09T00:00:00Z'
+    version: 1.0.0
+    oscal-version: 1.1.2
+    remarks: 'Phase-0 stub for AI 600-1 §2.6 CBRN / Harmful Content controls.
+      Always passes until Phase 3 real assertions are implemented per §7.2.
+      Region: US_FED. POAM: AI600-007.'
+  components:
+  - uuid: c2d3e4f5-a6b7-8901-bcde-f12345678901
+    type: software
+    title: CAGE Cybernetic Governance Engine
+    description: The Cybernetic AI Governance Engine (CAGE) — AI governance gateway, compliance bridge, and governed financial advisor.
+    control-implementations:
+    - uuid: d3e4f5a6-b7c8-9012-cdef-123456789012
+      source: https://airc.nist.gov/Docs/1
+      description: 'Control implementation for AI600-CBRN. Region: US_FED. Phase: 0 stub.'
+      implemented-requirements:
+      - uuid: e4f5a6b7-c8d9-0123-defa-234567890123
+        control-id: ai600-cbrn
+        description: Phase-0 stub for AI 600-1 §2.6 CBRN harmful content controls.
+        links:
+        - href: '#f5a6b7c8-d9e0-1234-efab-345678901234'
+          rel: lula
+  back-matter:
+    resources:
+    - uuid: f5a6b7c8-d9e0-1234-efab-345678901234
+      title: Lula Validation — AI600-CBRN
+      rlinks:
+      - href: lula.dev
+      description: "domain:\n  type: kubernetes\n  kubernetes:\n    resources: []\n\
+        \    # Phase 3 will assert:\n    #   - nemo Deployment has NEMO_CBRN_RAILS_ENABLED=true\n\
+        \    #   - cbrn_rails.co is mounted in the NeMo container\nprovider:\n  type:\
+        \ opa\n  opa-spec:\n    rego: \"package lula\\n\\n# Phase-0 stub — always\
+        \ passes until Phase 3\\n# Phase 3 real assertion (see §7.2 of AI_600_1_IMPLEMENTATION_PLAN.md):\\\
+        n#   validate if {\\n#     some container in input[\\\"nemo-deployment\\\"\
+        ].spec.template.spec.containers\\n#     container.name == \\\"nemo\\\"\\n\
+        #     some env in container.env\\n#     env.name == \\\"NEMO_CBRN_RAILS_ENABLED\\\
+        \"\\n#     env.value == \\\"true\\\"\\n#   }\\nvalidate := true\\n\"\n"

--- a/compliance/lula/lula-validation-ai600-confabulation.yaml
+++ b/compliance/lula/lula-validation-ai600-confabulation.yaml
@@ -12,23 +12,49 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Validates: AI 600-1 §2.1 Confabulation controls
-# Controls: CTRL_AGT_001 (confidence ≥ 0.95), confabulation_scorer.py
+# lula-validation-ai600-confabulation.yaml
+# NIST AI 600-1 §2.1 — Confabulation controls
+#
+# Validates: CTRL_AGT_001 (confidence ≥ 0.95), confabulation_scorer.py active.
 # POAM: AI600-001
-# Phase: 0 (stub) → Phase 2 (real assertions replace stub)
+# Phase: 0 (stub — always passes) → Phase 2 (real assertions replace stub)
 # Region: US_FED (CAGE_DEPLOYMENT_REGION=US_FED)
-domain:
-  type: kubernetes
-  kubernetes:
-    resources: []   # populated in Phase 2
-provider:
-  type: opa
-  opa:
-    policy: |
-      # stub — always passes until Phase 2
-      # Phase 2 will assert:
-      #   - gateway Deployment has CONFIDENCE_MIN_SCORE env var set
-      #   - confabulation_scorer is active (CONFABULATION_SCORER_ENABLED=true)
-      #   - AgentSight DaemonSet is running with PROVENANCE_SIGNING_ENABLED=true
-      package validate
-      default allow = true
+
+component-definition:
+  uuid: a1b2c3d4-e5f6-7890-abcd-ef0123456789
+  metadata:
+    title: CAGE Validation — AI600-Confabulation
+    last-modified: '2026-07-09T00:00:00Z'
+    version: 1.0.0
+    oscal-version: 1.1.2
+    remarks: 'Phase-0 stub for AI 600-1 §2.1 Confabulation controls.
+      Always passes until Phase 2 real assertions are implemented.
+      Region: US_FED. POAM: AI600-001.'
+  components:
+  - uuid: b2c3d4e5-f6a7-8901-bcde-f01234567890
+    type: software
+    title: CAGE Cybernetic Governance Engine
+    description: The Cybernetic AI Governance Engine (CAGE) — AI governance gateway, compliance bridge, and governed financial advisor.
+    control-implementations:
+    - uuid: c3d4e5f6-a7b8-9012-cdef-012345678901
+      source: https://airc.nist.gov/Docs/1
+      description: 'Control implementation for AI600-Confabulation. Region: US_FED. Phase: 0 stub.'
+      implemented-requirements:
+      - uuid: d4e5f6a7-b8c9-0123-defa-123456789012
+        control-id: ai600-confabulation
+        description: Phase-0 stub for AI 600-1 §2.1 confabulation controls.
+        links:
+        - href: '#e5f6a7b8-c9d0-1234-efab-234567890123'
+          rel: lula
+  back-matter:
+    resources:
+    - uuid: e5f6a7b8-c9d0-1234-efab-234567890123
+      title: Lula Validation — AI600-Confabulation
+      rlinks:
+      - href: lula.dev
+      description: "domain:\n  type: kubernetes\n  kubernetes:\n    resources: []\n\
+        \    # Phase 2 will assert:\n    #   - gateway Deployment has CONFIDENCE_MIN_SCORE\
+        \ env var set\n    #   - confabulation_scorer is active (CONFABULATION_SCORER_ENABLED=true)\n\
+        \    #   - AgentSight DaemonSet is running with PROVENANCE_SIGNING_ENABLED=true\n\
+        provider:\n  type: opa\n  opa-spec:\n    rego: \"package lula\\n\\n# Phase-0\
+        \ stub — always passes until Phase 2\\nvalidate := true\\n\"\n"

--- a/compliance/lula/lula-validation-ai600-data-privacy.yaml
+++ b/compliance/lula/lula-validation-ai600-data-privacy.yaml
@@ -12,27 +12,51 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Validates: AI 600-1 §2.2 Data Privacy controls
-# Controls: Presidio PII sanitizer active; PII audit log encrypted (CMEK)
+# lula-validation-ai600-data-privacy.yaml
+# NIST AI 600-1 §2.2 — Data Privacy controls
+#
+# Validates: Presidio PII sanitizer active; PII audit log encrypted (CMEK).
 # POAM: AI600-002
-# Phase: 0 (stub) → Phase 2 (real assertions replace stub)
+# Phase: 0 (stub — always passes) → Phase 2 (real assertions replace stub)
 # Region: US_FED (CAGE_DEPLOYMENT_REGION=US_FED)
-domain:
-  type: kubernetes
-  kubernetes:
-    resources: []   # populated in Phase 2
-    # Phase 2 will assert:
-    #   - pii-sanitizer-config ConfigMap exists in governance-stack namespace
-    #   - PII_AUDIT_LOG_ENABLED=true in ConfigMap
-    #   - CMEK encryption active via cmek_guard.py health check
-provider:
-  type: opa
-  opa:
-    policy: |
-      # stub — always passes until Phase 2
-      # Phase 2 real assertion (see §5.4 of AI_600_1_IMPLEMENTATION_PLAN.md):
-      #   allow if {
-      #     input["pii-sanitizer-config"].data.PII_AUDIT_LOG_ENABLED == "true"
-      #   }
-      package validate
-      default allow = true
+
+component-definition:
+  uuid: 12345678-9abc-def0-1234-567890abcdef
+  metadata:
+    title: CAGE Validation — AI600-Data-Privacy
+    last-modified: '2026-07-09T00:00:00Z'
+    version: 1.0.0
+    oscal-version: 1.1.2
+    remarks: 'Phase-0 stub for AI 600-1 §2.2 Data Privacy controls.
+      Always passes until Phase 2 real assertions are implemented per §5.4.
+      Region: US_FED. POAM: AI600-002.'
+  components:
+  - uuid: 23456789-abcd-ef01-2345-67890abcdef0
+    type: software
+    title: CAGE Cybernetic Governance Engine
+    description: The Cybernetic AI Governance Engine (CAGE) — AI governance gateway, compliance bridge, and governed financial advisor.
+    control-implementations:
+    - uuid: 3456789a-bcde-f012-3456-7890abcdef01
+      source: https://airc.nist.gov/Docs/1
+      description: 'Control implementation for AI600-Data-Privacy. Region: US_FED. Phase: 0 stub.'
+      implemented-requirements:
+      - uuid: 456789ab-cdef-0123-4567-890abcdef012
+        control-id: ai600-data-privacy
+        description: Phase-0 stub for AI 600-1 §2.2 data privacy controls.
+        links:
+        - href: '#56789abc-def0-1234-5678-90abcdef0123'
+          rel: lula
+  back-matter:
+    resources:
+    - uuid: 56789abc-def0-1234-5678-90abcdef0123
+      title: Lula Validation — AI600-Data-Privacy
+      rlinks:
+      - href: lula.dev
+      description: "domain:\n  type: kubernetes\n  kubernetes:\n    resources: []\n\
+        \    # Phase 2 will assert:\n    #   - pii-sanitizer-config ConfigMap exists\
+        \ in governance-stack namespace\n    #   - PII_AUDIT_LOG_ENABLED=true in ConfigMap\n\
+        \    #   - CMEK encryption active via cmek_guard.py health check\nprovider:\n\
+        \  type: opa\n  opa-spec:\n    rego: \"package lula\\n\\n# Phase-0 stub —\
+        \ always passes until Phase 2\\n# Phase 2 real assertion (see §5.4 of AI_600_1_IMPLEMENTATION_PLAN.md):\\\
+        n#   validate if {\\n#     input[\\\"pii-sanitizer-config\\\"].data.PII_AUDIT_LOG_ENABLED\
+        \ == \\\"true\\\"\\n#   }\\nvalidate := true\\n\"\n"

--- a/compliance/lula/lula-validation-ai600-human-ai-config.yaml
+++ b/compliance/lula/lula-validation-ai600-human-ai-config.yaml
@@ -12,30 +12,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Validates: AI 600-1 §2.5 Human-AI Configuration controls
-# Controls: Consensus threshold enforced; override audit active; HITL escalator
+# lula-validation-ai600-human-ai-config.yaml
+# NIST AI 600-1 §2.5 — Human-AI Configuration controls
+#
+# Validates: Consensus threshold enforced; override audit active; HITL escalator.
 # POAM: AI600-004
-# Phase: 0 (stub) → Phase 2 (real assertions replace stub per §6.4)
+# Phase: 0 (stub — always passes) → Phase 2 (real assertions replace stub per §6.4)
 # Region: US_FED (CAGE_DEPLOYMENT_REGION=US_FED)
-domain:
-  type: kubernetes
-  kubernetes:
-    resources: []   # populated in Phase 2
-    # Phase 2 will assert:
-    #   - defer-queue Deployment is running in governance-stack namespace
-    #   - CONSENSUS_THRESHOLD_USD env var is set to 10000
-    #   - hitl_escalator is active
-provider:
-  type: opa
-  opa:
-    policy: |
-      # stub — always passes until Phase 2
-      # Phase 2 real assertion (see §6.4 of AI_600_1_IMPLEMENTATION_PLAN.md):
-      #   allow if {
-      #     some container in input["defer-queue-deployment"].spec.template.spec.containers
-      #     some env in container.env
-      #     env.name == "CONSENSUS_THRESHOLD_USD"
-      #     env.value == "10000"
-      #   }
-      package validate
-      default allow = true
+
+component-definition:
+  uuid: 6789abcd-ef01-2345-6789-abcdef012345
+  metadata:
+    title: CAGE Validation — AI600-Human-AI-Config
+    last-modified: '2026-07-09T00:00:00Z'
+    version: 1.0.0
+    oscal-version: 1.1.2
+    remarks: 'Phase-0 stub for AI 600-1 §2.5 Human-AI Configuration controls.
+      Always passes until Phase 2 real assertions are implemented per §6.4.
+      Region: US_FED. POAM: AI600-004.'
+  components:
+  - uuid: 789abcde-f012-3456-789a-bcdef0123456
+    type: software
+    title: CAGE Cybernetic Governance Engine
+    description: The Cybernetic AI Governance Engine (CAGE) — AI governance gateway, compliance bridge, and governed financial advisor.
+    control-implementations:
+    - uuid: 89abcdef-0123-4567-89ab-cdef01234567
+      source: https://airc.nist.gov/Docs/1
+      description: 'Control implementation for AI600-Human-AI-Config. Region: US_FED. Phase: 0 stub.'
+      implemented-requirements:
+      - uuid: 9abcdef0-1234-5678-9abc-def012345678
+        control-id: ai600-human-ai-config
+        description: Phase-0 stub for AI 600-1 §2.5 human-AI configuration controls.
+        links:
+        - href: '#abcdef01-2345-6789-abcd-ef0123456789'
+          rel: lula
+  back-matter:
+    resources:
+    - uuid: abcdef01-2345-6789-abcd-ef0123456789
+      title: Lula Validation — AI600-Human-AI-Config
+      rlinks:
+      - href: lula.dev
+      description: "domain:\n  type: kubernetes\n  kubernetes:\n    resources: []\n\
+        \    # Phase 2 will assert:\n    #   - defer-queue Deployment is running in\
+        \ governance-stack namespace\n    #   - CONSENSUS_THRESHOLD_USD env var is\
+        \ set to 10000\n    #   - hitl_escalator is active\nprovider:\n  type: opa\n\
+        \  opa-spec:\n    rego: \"package lula\\n\\n# Phase-0 stub — always passes\
+        \ until Phase 2\\n# Phase 2 real assertion (see §6.4 of AI_600_1_IMPLEMENTATION_PLAN.md):\\\
+        n#   validate if {\\n#     some container in input[\\\"defer-queue-deployment\\\
+        \"].spec.template.spec.containers\\n#     some env in container.env\\n#  \
+        \   env.name == \\\"CONSENSUS_THRESHOLD_USD\\\"\\n#     env.value == \\\"\
+        10000\\\"\\n#   }\\nvalidate := true\\n\"\n"

--- a/compliance/lula/lula-validation-ai600-prompt-injection.yaml
+++ b/compliance/lula/lula-validation-ai600-prompt-injection.yaml
@@ -12,30 +12,52 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Validates: AI 600-1 §2.3 Data Poisoning / Prompt Injection controls
-# Controls: CausalGatekeeper active; WAL integrity verified (CTRL_WAL_002)
+# lula-validation-ai600-prompt-injection.yaml
+# NIST AI 600-1 §2.3 — Data Poisoning / Prompt Injection controls
+#
+# Validates: CausalGatekeeper active; WAL integrity verified (CTRL_WAL_002).
 # POAM: AI600-003
-# Phase: 0 (stub) → Phase 2 (real assertions replace stub per §6.2)
+# Phase: 0 (stub — always passes) → Phase 2 (real assertions replace stub per §6.2)
 # Region: US_FED (CAGE_DEPLOYMENT_REGION=US_FED)
-domain:
-  type: kubernetes
-  kubernetes:
-    resources: []   # populated in Phase 2
-    # Phase 2 will assert:
-    #   - gateway Deployment has PROMPT_INJECTION_DETECTION_ENABLED=true
-    #   - CausalGatekeeper is active in governance-stack namespace
-provider:
-  type: opa
-  opa:
-    policy: |
-      # stub — always passes until Phase 2
-      # Phase 2 real assertion (see §6.2 of AI_600_1_IMPLEMENTATION_PLAN.md):
-      #   allow if {
-      #     some container in input["gateway-deployment"].spec.template.spec.containers
-      #     container.name == "gateway"
-      #     some env in container.env
-      #     env.name == "PROMPT_INJECTION_DETECTION_ENABLED"
-      #     env.value == "true"
-      #   }
-      package validate
-      default allow = true
+
+component-definition:
+  uuid: bcdef012-3456-789a-bcde-f01234567890
+  metadata:
+    title: CAGE Validation — AI600-Prompt-Injection
+    last-modified: '2026-07-09T00:00:00Z'
+    version: 1.0.0
+    oscal-version: 1.1.2
+    remarks: 'Phase-0 stub for AI 600-1 §2.3 Data Poisoning / Prompt Injection controls.
+      Always passes until Phase 2 real assertions are implemented per §6.2.
+      Region: US_FED. POAM: AI600-003.'
+  components:
+  - uuid: cdef0123-4567-89ab-cdef-012345678901
+    type: software
+    title: CAGE Cybernetic Governance Engine
+    description: The Cybernetic AI Governance Engine (CAGE) — AI governance gateway, compliance bridge, and governed financial advisor.
+    control-implementations:
+    - uuid: def01234-5678-9abc-def0-123456789012
+      source: https://airc.nist.gov/Docs/1
+      description: 'Control implementation for AI600-Prompt-Injection. Region: US_FED. Phase: 0 stub.'
+      implemented-requirements:
+      - uuid: ef012345-6789-abcd-ef01-234567890123
+        control-id: ai600-prompt-injection
+        description: Phase-0 stub for AI 600-1 §2.3 prompt injection / data poisoning controls.
+        links:
+        - href: '#f0123456-789a-bcde-f012-345678901234'
+          rel: lula
+  back-matter:
+    resources:
+    - uuid: f0123456-789a-bcde-f012-345678901234
+      title: Lula Validation — AI600-Prompt-Injection
+      rlinks:
+      - href: lula.dev
+      description: "domain:\n  type: kubernetes\n  kubernetes:\n    resources: []\n\
+        \    # Phase 2 will assert:\n    #   - gateway Deployment has PROMPT_INJECTION_DETECTION_ENABLED=true\n\
+        \    #   - CausalGatekeeper is active in governance-stack namespace\nprovider:\n\
+        \  type: opa\n  opa-spec:\n    rego: \"package lula\\n\\n# Phase-0 stub —\
+        \ always passes until Phase 2\\n# Phase 2 real assertion (see §6.2 of AI_600_1_IMPLEMENTATION_PLAN.md):\\\
+        n#   validate if {\\n#     some container in input[\\\"gateway-deployment\\\
+        \"].spec.template.spec.containers\\n#     container.name == \\\"gateway\\\"\
+        \\n#     some env in container.env\\n#     env.name == \\\"PROMPT_INJECTION_DETECTION_ENABLED\\\
+        \"\\n#     env.value == \\\"true\\\"\\n#   }\\nvalidate := true\\n\"\n"

--- a/infra/targets/gcp-gke/apac-dev.tfvars
+++ b/infra/targets/gcp-gke/apac-dev.tfvars
@@ -74,6 +74,9 @@ cage_deployment_region = "APAC_MAS"
 # ─── Security Posture (APAC Dev: Audit logging required by MAS Notice 655) ────
 # MAS Notice 655 §10 mandates audit logging for all AI system operations.
 # MAS TRM Guidelines §6.4 requires continuous monitoring of AI model performance.
+enable_nist_compliance         = false
+enable_eu_ecb_compliance       = false
+enable_apac_mas_compliance     = true  # DEP-20: activates MAS TRM §9.1 encryption + MAS Notice 655 audit logging
 enable_binary_authorization    = false
 enable_audit_logging           = true  # MAS Notice 655 §10 — mandatory
 enable_cmek                    = false

--- a/infra/targets/gcp-gke/eu-dev.tfvars
+++ b/infra/targets/gcp-gke/eu-dev.tfvars
@@ -74,6 +74,9 @@ cage_deployment_region = "EU_ECB"
 # ─── Security Posture (EU Dev: Stricter than US Dev) ──────────────────────────
 # EU AI Act Art. 9 mandates a documented risk management system for High-Risk AI.
 # DORA Art. 10 mandates continuous ICT monitoring. These cannot be disabled.
+enable_nist_compliance         = false
+enable_eu_ecb_compliance       = true  # DEP-20: activates DORA Art. 10 + GDPR Art. 32 controls
+enable_apac_mas_compliance     = false
 enable_binary_authorization    = false
 enable_audit_logging           = true  # DORA Art. 10 — mandatory for EU
 enable_cmek                    = false


### PR DESCRIPTION
## Summary

Fixes three failing CI workflows:
- EU_ECB Compliance Gate (EU AI Act / GDPR / DORA)
- APAC_MAS Compliance Gate (MAS FEAT / Notice 655 / TRM)
- Compliance Matrix / Universal ISO 42001 Gates

## Root Causes

### 1. Broken glob in ISO 42001 Lula validation jobs
The `eu-ecb-iso42001-lula` and `apac-mas-iso42001-lula` jobs used
`glob('lula-validation-a*.yaml')` which also matched NIST AI 600-1
files (`ai600-*.yaml`). These files used an old flat `domain`/`provider`
format without the required OSCAL `component-definition` wrapper,
causing structure validation to fail with exit code 1 within 7 seconds.

### 2. Missing compliance flags in dev tfvars
`eu-dev.tfvars` and `apac-dev.tfvars` were missing
`enable_eu_ecb_compliance` and `enable_apac_mas_compliance` flags,
causing WARNING output in audit logging check steps.

## Changes
- Wrap 5 `ai600-*.yaml` lula manifests in proper OSCAL `component-definition` structure
- Replace broken glob with explicit universal ISO 42001 manifest list in both regional workflows
- Add missing compliance flags to `eu-dev.tfvars` and `apac-dev.tfvars`

## Testing
All fixes verified locally — STPA freshness check, Langfuse posture dry-run, and ISO 42001 manifest structure validation pass with exit code 0.