### PR TITLE
style(compliance): apply ruff format to posture check scripts

### DIFF
--- a/scripts/check_apac_mas_posture.py
+++ b/scripts/check_apac_mas_posture.py
@@ -36,7 +36,9 @@ import yaml
 def check_mas_feat_manifests() -> list[str]:
     """Check MAS FEAT Lula manifest YAML structure."""
     errors = []
-    manifests = sorted(pathlib.Path("compliance/lula").glob("lula-validation-mas-*.yaml"))
+    manifests = sorted(
+        pathlib.Path("compliance/lula").glob("lula-validation-mas-*.yaml")
+    )
     if not manifests:
         print("WARNING: no MAS FEAT Lula manifests found — CA-03 remediation pending")
         return errors
@@ -47,7 +49,9 @@ def check_mas_feat_manifests() -> list[str]:
         else:
             print(f"  OK {m.name}")
     if not errors:
-        print(f"All {len(manifests)} MAS FEAT Lula manifests passed YAML structure check.")
+        print(
+            f"All {len(manifests)} MAS FEAT Lula manifests passed YAML structure check."
+        )
     return errors
 
 
@@ -104,7 +108,9 @@ def check_sr262_sentinel() -> None:
         pathlib.Path("config/thresholds").glob("*.json")
     )
     apac_files = [
-        f for f in threshold_files if "apac" in f.name.lower() or "mas" in f.name.lower()
+        f
+        for f in threshold_files
+        if "apac" in f.name.lower() or "mas" in f.name.lower()
     ]
     if not apac_files:
         print("WARNING: No APAC threshold files found — SR 26-2 sentinel check skipped")

--- a/scripts/check_eu_ecb_posture.py
+++ b/scripts/check_eu_ecb_posture.py
@@ -35,7 +35,9 @@ import yaml
 def check_eu_ai_act_manifests() -> list[str]:
     """Check EU AI Act Lula manifest YAML structure."""
     errors = []
-    manifests = sorted(pathlib.Path("compliance/lula").glob("lula-validation-eu-*.yaml"))
+    manifests = sorted(
+        pathlib.Path("compliance/lula").glob("lula-validation-eu-*.yaml")
+    )
     if not manifests:
         print("WARNING: no EU AI Act Lula manifests found — CA-03 remediation pending")
         return errors
@@ -46,7 +48,9 @@ def check_eu_ai_act_manifests() -> list[str]:
         else:
             print(f"  OK {m.name}")
     if not errors:
-        print(f"All {len(manifests)} EU AI Act Lula manifests passed YAML structure check.")
+        print(
+            f"All {len(manifests)} EU AI Act Lula manifests passed YAML structure check."
+        )
     return errors
 
 
@@ -85,7 +89,9 @@ def check_dora_logging() -> None:
     """Check DORA Art. 10 audit logging in eu-dev.tfvars (warning only)."""
     tfvars_path = pathlib.Path("infra/targets/gcp-gke/eu-dev.tfvars")
     if not tfvars_path.exists():
-        print("WARNING: infra/targets/gcp-gke/eu-dev.tfvars not found — skipping DORA check")
+        print(
+            "WARNING: infra/targets/gcp-gke/eu-dev.tfvars not found — skipping DORA check"
+        )
         return
     content = tfvars_path.read_text()
     if "enable_eu_ecb_compliance" not in content:


### PR DESCRIPTION
Applies ruff formatting to scripts/check_apac_mas_posture.py and scripts/check_eu_ecb_posture.py to pass the ruff format CI check.