### PR TITLE
bound email PII regex quantifiers to stop quadratic backtracking

### DIFF
--- a/src/gateway/governance/pii_sanitizer.py
+++ b/src/gateway/governance/pii_sanitizer.py
@@ -131,9 +131,12 @@ _PII_PATTERNS: list[tuple[re.Pattern[str], str]] = [
         re.compile(r"\b[A-Z]{4}[A-Z]{2}[A-Z0-9]{2}(?:[A-Z0-9]{3})?\b"),
         "[REDACTED_SWIFT]",
     ),
-    # Email address: RFC 5321 simplified.
+    # Email address: RFC 5321 simplified.  Local part and domain are
+    # length-bounded (RFC 5321: local ≤64, domain ≤255) — the unbounded ``+``
+    # form let a crafted no-TLD string ("a@a.a.a.…!") drive O(n²) backtracking
+    # in re.sub, which stalls the sanitizer on attacker-supplied text.
     (
-        re.compile(r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b"),
+        re.compile(r"\b[A-Za-z0-9._%+\-]{1,64}@[A-Za-z0-9.\-]{1,255}\.[A-Za-z]{2,}\b"),
         "[REDACTED_EMAIL]",
     ),
     # Phone: US/international formats with optional country code (+1 or 1).

--- a/src/governed_financial_advisor/utils/privacy.py
+++ b/src/governed_financial_advisor/utils/privacy.py
@@ -33,7 +33,11 @@ logger = logging.getLogger("GoverningFinancialAdvisor.Utils.Privacy")
 # Deterministic patterns for Zero-Trust Redaction (Defense-in-Depth)
 PII_PATTERNS = {
     "SSN": r"\b\d{3}[- ]?\d{2}[- ]?\d{4}\b",
-    "EMAIL": r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
+    # Local part and domain are length-bounded (RFC 5321: local ≤64, domain
+    # ≤255). The unbounded ``+`` form let a crafted no-TLD string like
+    # "a@a.a.a.…!" force O(n²) backtracking in re.sub, stalling the event loop
+    # (scrub_pii runs inline on unauthenticated /v1/chat/completions input).
+    "EMAIL": r"\b[A-Za-z0-9._%+-]{1,64}@[A-Za-z0-9.-]{1,255}\.[A-Z|a-z]{2,}\b",
     "CREDIT_CARD": r"\b(?:\d[ -]*?){13,16}\b",
     "PHONE": r"\b(?:\+?1[-. ]?)?\(?([0-9]{3})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})\b",
 }

--- a/tests/test_pii_sanitizer.py
+++ b/tests/test_pii_sanitizer.py
@@ -82,3 +82,27 @@ def test_singleton_returns_same_instance():
     a = _get_pii_sanitizer()
     b = _get_pii_sanitizer()
     assert a is b
+
+
+@pytest.mark.local
+def test_email_pattern_no_quadratic_backtracking(sanitizer):
+    # A crafted "no valid TLD" string used to force O(n^2) backtracking in the
+    # unbounded email regex. With the length-bounded quantifiers it stays
+    # linear, so a large adversarial input completes near-instantly.
+    import time
+
+    payload = "a@" + "a." * 60_000 + "!"
+    start = time.perf_counter()
+    result = sanitizer.sanitize(payload)
+    elapsed = time.perf_counter() - start
+    assert elapsed < 1.0, f"sanitize took {elapsed:.2f}s — regex backtracking regressed"
+    assert result == payload  # no email present, so nothing is redacted
+
+
+@pytest.mark.local
+def test_long_domain_email_still_redacted(sanitizer):
+    # A legitimate multi-label address must still be redacted after bounding.
+    assert (
+        sanitizer.sanitize("first.last+tag@mail.sub.example.co.uk")
+        == "[REDACTED_EMAIL]"
+    )

--- a/tests/test_privacy_scrub_pii.py
+++ b/tests/test_privacy_scrub_pii.py
@@ -1,0 +1,55 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Marker: @pytest.mark.local — CI-gated, no external dependencies.
+# Run: uv run pytest tests/test_privacy_scrub_pii.py -m local -v
+
+import time
+
+import pytest
+
+from src.governed_financial_advisor.utils.privacy import scrub_pii
+
+
+@pytest.mark.local
+def test_email_redacted():
+    assert "[REDACTED-EMAIL-UCA-3]" in scrub_pii("reach me at user@example.com")
+
+
+@pytest.mark.local
+def test_multi_label_email_redacted():
+    assert "[REDACTED-EMAIL-UCA-3]" in scrub_pii(
+        "first.last+tag@mail.sub.example.co.uk"
+    )
+
+
+@pytest.mark.local
+def test_clean_text_unchanged():
+    assert scrub_pii("no pii in this line") == "no pii in this line"
+
+
+@pytest.mark.local
+def test_email_pattern_no_quadratic_backtracking():
+    # "a@a.a.a.…!" has no valid TLD and used to trigger O(n^2) backtracking in
+    # the unbounded email regex. scrub_pii runs inline on unauthenticated
+    # /v1/chat/completions message content, so this is a pre-auth stall vector.
+    # With length-bounded quantifiers the scan is linear.
+    payload = "a@" + "a." * 60_000 + "!"
+    start = time.perf_counter()
+    result = scrub_pii(payload)
+    elapsed = time.perf_counter() - start
+    assert elapsed < 1.0, (
+        f"scrub_pii took {elapsed:.2f}s — regex backtracking regressed"
+    )
+    assert result == payload  # no email present, nothing redacted


### PR DESCRIPTION
## Summary

The email PII pattern in `scrub_pii` (`utils/privacy.py`) and `PIISanitizer` (`gateway/governance/pii_sanitizer.py`) uses an unbounded `[...]+@[...]+\.[a-z]{2,}` form. The domain character class contains `.`, which also serves as the required separator before the TLD, so a no-TLD input like `a@a.a.a.…!` forces the domain repeat to backtrack quadratically. `scrub_pii` runs inline on message content in the unauthenticated `POST /v1/chat/completions` handler (`gateway/server/inference_proxy.py`) and on NeMo rails input, so a single crafted body of a few tens of KB stalls the async event loop for seconds. Bounding the local part and domain to their RFC 5321 maximum lengths makes the scan linear while keeping matching behaviour identical for every valid address.

## Type of Change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no feature/fix, code restructuring
- [ ] `perf` — performance improvement
- [ ] `test` — test additions or corrections
- [ ] `chore` — build, deps, tooling
- [ ] `ci` — CI/CD pipeline
- [ ] `BREAKING CHANGE` — existing behaviour changes

## Related Issues / ADRs

N/A

## Changes Made

- `src/governed_financial_advisor/utils/privacy.py` — bound the `EMAIL` pattern's local part to `{1,64}` and domain to `{1,255}`.
- `src/gateway/governance/pii_sanitizer.py` — same bound on the sibling email pattern.
- `tests/test_privacy_scrub_pii.py`, `tests/test_pii_sanitizer.py` — regression tests asserting a 120 KB adversarial no-TLD string is scrubbed in under a second and that valid multi-label addresses still redact.

## Testing

- [x] Unit tests added / updated (`pytest tests/`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Manual smoke test performed (describe below)
- [ ] No tests needed (docs/config only — explain why)

**Manual test steps (if applicable):**
```
# Quadratic before, linear after (payload = "a@" + "a."*n + "!")
# before: n=64000 (128 KB) -> ~10.3 s in re.sub
# after:  n=64000 (128 KB) -> ~0.013 s
uv run pytest tests/test_privacy_scrub_pii.py tests/test_pii_sanitizer.py -m local -v

# Matching parity: 4000 randomly generated valid addresses plus edge cases
# produce byte-identical scrub output before and after the change.
```

## Compliance & Security Checklist

### 🔒 Universal — All contributors must verify (all regions affected)

- [x] No secrets, credentials, or PII in committed files
- [x] Network policy unchanged **or** reviewed by security owner
- [x] OPA policy changes reviewed for correctness (`src/governed_financial_advisor/graph/governance/trade_policy.rego`) — no OPA change in this PR
- [x] **Data residency:** Any new storage path, GCS write, Langfuse sink, or telemetry export is guarded by `CAGE_DEPLOYMENT_REGION` — no new data path added; the change is a regex bound
- [x] **ISO 42001 / CSA AARM:** Lula assertions unaffected — no control mapping or evidence path changed
- [x] **No region-specific behaviour introduced without a `cage_deployment_region` guard** — the bound is region-agnostic and matching output is unchanged

### 🎯 Region-specific depth — Check only your target deployment

**US_FED**
- [x] N/A — not targeting US_FED

**EU_ECB**
- [x] N/A — not targeting EU_ECB

**APAC_MAS**
- [x] N/A — not targeting APAC_MAS

### 📋 Shared-module impact declaration

- [ ] Not applicable — PR does not touch shared compliance modules
- [x] **Impact assessed across all three regions:** Describe below how this change affects US_FED, EU_ECB, and APAC_MAS posture

**Cross-region impact summary (if applicable):**
```
US_FED impact: none — email redaction output is byte-identical; only the worst-case match time changes.
EU_ECB impact: none — same PII redaction behaviour; GDPR Art. 17 scrubbing coverage unchanged.
APAC_MAS impact: none — same PII redaction behaviour; MAS Notice 655 scrubbing coverage unchanged.
```

## Deployment Notes

N/A
