### PR TITLE
fix(compliance-bridge): bind node metadata into evidence chain record_hash

### DIFF
--- a/src/compliance_bridge/context_accumulator.py
+++ b/src/compliance_bridge/context_accumulator.py
@@ -25,7 +25,9 @@ Architecture:
   forming a blockchain-style linked list. The genesis entry's ``prev_hash`` is seeded from
   the ``audit_id`` SHA-256, deterministically tying the chain to its audit run.
 
-  Hash function: SHA-256(prev_hash_hex || json.dumps(content, sort_keys=True))
+  Hash function: SHA-256(prev_hash_hex || canonical_header || json.dumps(content,
+  sort_keys=True)), where canonical_header binds the node's schema, index,
+  audit_id, control_id and event_type into the link.
 
   This matches the existing production pattern established in examples/telemetry.py
   (``PlaygroundTelemetry``) and validated by governance_demo.py ACT 3, now promoted to
@@ -40,7 +42,7 @@ Wire format (NDJSON, one JSON object per line):
     "event_type":    "OSCAL_FINDING" | "AUDIT_START" | "CHAIN_SEALED",
     "content_hash":  "<sha256 of content JSON>",
     "prev_hash":     "<sha256 of preceding entry>",
-    "record_hash":   "<sha256(prev_hash + content_json)>",
+    "record_hash":   "<sha256(prev_hash + header_json + content_json)>",
     "timestamp_utc": "<ISO-8601>",
     "payload":       { ... }   // OscalFinding fields
   }
@@ -80,6 +82,36 @@ def _sha256(data: str) -> str:
     return hashlib.sha256(data.encode("utf-8")).hexdigest()
 
 
+def _link_hash(
+    prev_hash: str,
+    node_index: int,
+    audit_id: str,
+    control_id: str,
+    event_type: str,
+    content_json: str,
+) -> str:
+    """Compute a node's ``record_hash`` over its identifying header + payload.
+
+    The header carries the metadata that ``to_dict()`` persists alongside the
+    payload, so re-labelling a node's control or event type, moving it to a
+    different position, or re-attributing it to another audit changes the link
+    and breaks the chain.  ``timestamp_utc`` is deliberately excluded to keep
+    ``record_hash`` a deterministic function of the node's content.
+    """
+    header = json.dumps(
+        {
+            "schema": _SCHEMA,
+            "node_index": node_index,
+            "audit_id": audit_id,
+            "control_id": control_id,
+            "event_type": event_type,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return _sha256(prev_hash + header + content_json)
+
+
 def _content_hash(payload: dict) -> str:
     """Return the SHA-256 hash of a JSON-serialised payload (deterministic key ordering)."""
     return _sha256(json.dumps(payload, sort_keys=True, default=str))
@@ -104,7 +136,9 @@ class ContextAccumulatorEntry:
         content_hash  — SHA-256 of ``json.dumps(payload, sort_keys=True)``.
         prev_hash     — SHA-256 of the *preceding* entry's ``record_hash``
                         (genesis constant for the first node).
-        record_hash   — SHA-256(prev_hash + json.dumps(payload, sort_keys=True)).
+        record_hash   — SHA-256(prev_hash + canonical header + json.dumps(
+                        payload, sort_keys=True)), where the header covers
+                        schema, node_index, audit_id, control_id and event_type.
         timestamp_utc — ISO-8601 UTC wall-clock at append time.
         kms_signature — Cloud KMS asymmetric signature of this record (hex-encoded).
                         Empty string when per-record KMS signing is disabled.
@@ -250,10 +284,11 @@ class ContextAccumulator:
                                    first node whose computed hash does not match
                                    its stored ``record_hash``.
 
-        The verification recomputes expected = SHA-256(prev_hash + content_json)
-        for every node, comparing against the stored ``record_hash``.  Any
-        mutation to any field in any node will cause the check to fail at that
-        node *and* every subsequent node (because prev_hash forward-propagates).
+        The verification recomputes the link over ``prev_hash``, the node's
+        committed header fields and ``content_json`` for every node, comparing
+        against the stored ``record_hash`` and ``content_hash``.  Any mutation
+        to any field in any node will cause the check to fail at that node
+        *and* every subsequent node (because prev_hash forward-propagates).
         """
         if not self._entries:
             return True, 0
@@ -262,9 +297,20 @@ class ContextAccumulator:
 
         for i, entry in enumerate(self._entries):
             content_json = json.dumps(entry.payload, sort_keys=True, default=str)
-            expected_hash = _sha256(expected_prev + content_json)
+            expected_hash = _link_hash(
+                prev_hash=expected_prev,
+                node_index=entry.node_index,
+                audit_id=entry.audit_id,
+                control_id=entry.control_id,
+                event_type=entry.event_type,
+                content_json=content_json,
+            )
 
-            if entry.prev_hash != expected_prev or entry.record_hash != expected_hash:
+            if (
+                entry.prev_hash != expected_prev
+                or entry.record_hash != expected_hash
+                or entry.content_hash != _sha256(content_json)
+            ):
                 logger.warning(
                     "[context_accumulator] Chain integrity FAILED at node %d "
                     "(audit_id=%s). Expected prev=%s… got %s…; "
@@ -334,11 +380,19 @@ class ContextAccumulator:
         now_utc = datetime.now(tz=timezone.utc).isoformat()
         content_json = json.dumps(payload, sort_keys=True, default=str)
         chash = _sha256(content_json)
-        record_hash = _sha256(self._prev_hash + content_json)
+        node_index = len(self._entries)
+        record_hash = _link_hash(
+            prev_hash=self._prev_hash,
+            node_index=node_index,
+            audit_id=self._audit_id,
+            control_id=control_id,
+            event_type=event_type,
+            content_json=content_json,
+        )
 
         entry = ContextAccumulatorEntry(
             schema=_SCHEMA,
-            node_index=len(self._entries),
+            node_index=node_index,
             audit_id=self._audit_id,
             control_id=control_id,
             event_type=event_type,

--- a/src/compliance_bridge/evidence_stream.py
+++ b/src/compliance_bridge/evidence_stream.py
@@ -128,6 +128,32 @@ def _sha256(data: str) -> str:
     return hashlib.sha256(data.encode("utf-8")).hexdigest()
 
 
+def _link_hash(
+    prev_hash: str,
+    sequence: int,
+    event_type: str,
+    control_id: str,
+    payload_json: str,
+) -> str:
+    """Compute a stream entry's ``record_hash`` over its header + payload.
+
+    The header carries the identifying metadata stored beside the payload in
+    the Redis Stream entry, so re-ordering or re-labelling a record changes
+    the link and breaks the chain.
+    """
+    header = json.dumps(
+        {
+            "schema": _SCHEMA,
+            "sequence": sequence,
+            "event_type": event_type,
+            "control_id": control_id,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return _sha256(prev_hash + header + payload_json)
+
+
 # ---------------------------------------------------------------------------
 # EvidenceStreamSink — the core streaming sink
 # ---------------------------------------------------------------------------
@@ -250,14 +276,23 @@ class EvidenceStreamSink:
         # Hash-chain the event — lock guards all reads/writes of _prev_hash and _sequence
         payload_json = json.dumps(event, sort_keys=True, default=str)
 
+        event_type = event.get("type", "UNKNOWN")
+        control_id = event.get("controlId", "")
+
         async with self._chain_lock:
-            record_hash = _sha256(self._prev_hash + payload_json)
+            record_hash = _link_hash(
+                prev_hash=self._prev_hash,
+                sequence=self._sequence,
+                event_type=event_type,
+                control_id=control_id,
+                payload_json=payload_json,
+            )
 
             entry = {
                 "schema": _SCHEMA,
                 "sequence": str(self._sequence),
-                "event_type": event.get("type", "UNKNOWN"),
-                "control_id": event.get("controlId", ""),
+                "event_type": event_type,
+                "control_id": control_id,
                 "prev_hash": self._prev_hash,
                 "record_hash": record_hash,
                 "payload_json": payload_json,

--- a/tests/test_context_accumulator.py
+++ b/tests/test_context_accumulator.py
@@ -35,6 +35,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from src.compliance_bridge.context_accumulator import (
     ContextAccumulator,
     _sha256,
@@ -235,6 +237,33 @@ def test_tamper_middle_node_detected_at_correct_index():
     valid, fail_at = acc.verify_integrity()
     assert valid is False
     assert fail_at == 2
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("control_id", "A.9.9"),
+        ("event_type", "CHAIN_SEALED"),
+        ("node_index", 99),
+        ("audit_id", "some-other-audit"),
+        ("content_hash", "0" * 64),
+    ],
+)
+def test_tamper_node_metadata_detected(field, value):
+    """Mutating a committed metadata field is detected, not just the payload.
+
+    Every field here is serialised by to_dict() into the persisted NDJSON, so
+    each one must be bound into record_hash for the chain to be tamper-evident.
+    """
+    acc = ContextAccumulator(audit_id="tamper-meta-001")
+    acc.append_finding(_finding("A.5.3", "PASS"))
+    acc.append_finding(_finding("SC-4", "PASS"))
+
+    setattr(acc._entries[0], field, value)
+
+    valid, fail_at = acc.verify_integrity()
+    assert valid is False, f"Mutating {field} must invalidate the chain"
+    assert fail_at == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`ContextAccumulator._append_node` and `EvidenceStreamSink.ingest` link each node with `SHA-256(prev_hash + content_json)`, where `content_json` is the payload alone. Everything else the record commits to — `control_id`, `event_type`, `node_index`/`sequence`, `audit_id` — is serialised beside the payload by `to_dict()` into the NDJSON artifact and into the Redis Stream entry, but sits outside the hash. `verify_integrity()` recomputes the same payload-only link, so a node can be re-attributed to a different ISO control, relabelled `CHAIN_SEALED`, moved to another position, or reassigned to another audit run and the chain still validates. That contradicts the method's own contract ("Any mutation to any field in any node will cause the check to fail at that node") and the AARM claim in `aarm_mapper.py:118` that poisoning is detected by `verify_integrity()`. `provenance_chain.chain_hash()` and `examples/telemetry.py` already hash the full record; these two sinks are the outliers, so this brings them to the same shape rather than inventing a new one.

`timestamp_utc` is deliberately left out of the header: `record_hash` is asserted to be a deterministic function of node content (`test_single_node_record_hash_is_deterministic`), and folding wall-clock time in would break that. Happy to bind it too if you'd rather have re-dating covered and drop the determinism property.

## Type of Change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no feature/fix, code restructuring
- [ ] `perf` — performance improvement
- [ ] `test` — test additions or corrections
- [ ] `chore` — build, deps, tooling
- [ ] `ci` — CI/CD pipeline
- [x] `BREAKING CHANGE` — existing behaviour changes

## Related Issues / ADRs

N/A

## Changes Made

- `src/compliance_bridge/context_accumulator.py` — added `_link_hash()`, which folds a canonical header (`schema`, `node_index`, `audit_id`, `control_id`, `event_type`) into the link; used it in `_append_node()` and `verify_integrity()`. `verify_integrity()` also re-derives `content_hash`, which was likewise stored but never checked.
- `src/compliance_bridge/evidence_stream.py` — same header binding for the Redis Stream chain (`schema`, `sequence`, `event_type`, `control_id`).
- `tests/test_context_accumulator.py` — parametrised regression over the five metadata fields; each case fails on the unpatched tree.

## Testing

- [x] Unit tests added / updated (`pytest tests/`)
- [ ] Integration tests pass (`make test-integration`)
- [x] Manual smoke test performed (describe below)
- [ ] No tests needed (docs/config only — explain why)

**Manual test steps (if applicable):**
```
# Before: seal a 3-node chain, rewrite node 0's metadata, chain still verifies.
#   acc.seal(); e = acc._entries[0]
#   e.control_id = "A.9.9"; e.event_type = "CHAIN_SEALED"
#   e.node_index = 99; e.audit_id = "some-other-audit"
#   e.content_hash = "0" * 64
#   acc.verify_integrity()  ->  (True, 3)      # tampered record accepted
# After:
#   acc.verify_integrity()  ->  (False, 0)     # detected at the mutated node

pytest tests/test_context_accumulator.py tests/test_provenance_chain.py -q   # 66 passed
ruff check . && ruff format --check .
mypy src/compliance_bridge/context_accumulator.py src/compliance_bridge/evidence_stream.py
```

## Compliance & Security Checklist

### 🔒 Universal — All contributors must verify (all regions affected)

- [x] No secrets, credentials, or PII in committed files
- [x] Network policy unchanged **or** reviewed by security owner
- [x] OPA policy changes reviewed for correctness (`src/governed_financial_advisor/graph/governance/trade_policy.rego`) — no OPA change in this PR
- [x] **Data residency:** Any new storage path, GCS write, Langfuse sink, or telemetry export is guarded by `CAGE_DEPLOYMENT_REGION` — no new data path; the NDJSON and Redis Stream wire formats are unchanged, only the value of `record_hash`
- [x] **ISO 42001 / CSA AARM:** Lula assertions unaffected — no control mapping or evidence path changed; A.5.3 tamper-evidence is strengthened, not remapped
- [x] **No region-specific behaviour introduced without a `cage_deployment_region` guard** — the header binding is region-agnostic

### 🎯 Region-specific depth — Check only your target deployment

**US_FED**
- [x] N/A — not targeting US_FED

**EU_ECB**
- [x] N/A — not targeting EU_ECB

**APAC_MAS**
- [x] N/A — not targeting APAC_MAS

### 📋 Shared-module impact declaration

- [ ] Not applicable — PR does not touch shared compliance modules
- [x] **Impact assessed across all three regions:** Describe below how this change affects US_FED, EU_ECB, and APAC_MAS posture

**Cross-region impact summary (if applicable):**
```
US_FED impact: AU-12 / SC-4 audit-trail integrity improves — evidence nodes can no
  longer be re-attributed to a different control or audit run without detection.
  No control mapping or coverage % change.
EU_ECB impact: DORA Art. 10 audit logging unchanged in scope; the same records are
  written to the same europe-west1 paths. Tamper-evidence of those records improves.
APAC_MAS impact: MAS Notice 655 audit logging unchanged in scope; same asia-southeast1
  paths. Tamper-evidence improves.
```

## Deployment Notes

`record_hash` values change, so chains sealed by the current code will not re-verify
under this build. The chains are per-audit-run and verified in-process immediately
before persistence (`audit_workflow.py:797`), so this only matters if you re-verify
previously archived NDJSON artifacts with the new code. If that matters for the WORM
archive, a schema bump (`cage-context-accumulator/1.1`) with version-dispatched
verification would keep old artifacts verifiable — happy to add that here.
