### PR TITLE
fix(compliance-bridge): sanitize audit_id in export filename header

### DIFF
--- a/src/compliance_bridge/main.py
+++ b/src/compliance_bridge/main.py
@@ -33,6 +33,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import time
 from collections import OrderedDict
 from contextlib import asynccontextmanager
@@ -88,6 +89,17 @@ _AUDIT_STATUS_MAXSIZE = 256
 _audit_status: OrderedDict[str, dict] = OrderedDict()
 
 AuditPhase = Literal["pending", "running", "done", "error"]
+
+# Characters permitted inside a quoted Content-Disposition filename. Anything
+# outside this set (notably `"`, `;` and `\`) can terminate the quoted-string
+# and start a new disposition parameter, so it is folded to `_` first.
+_UNSAFE_FILENAME_CHARS = re.compile(r"[^A-Za-z0-9._-]")
+_FILENAME_TOKEN_MAXLEN = 128
+
+
+def _filename_token(audit_id: str) -> str:
+    """Reduce an audit ID to a token that is safe to embed in a filename."""
+    return _UNSAFE_FILENAME_CHARS.sub("_", audit_id)[:_FILENAME_TOKEN_MAXLEN]
 
 
 def _set_audit_status(audit_id: str, payload: dict) -> None:
@@ -671,7 +683,7 @@ async def export_oscal_assessment_results(
             return JSONResponse(
                 content={"yaml": content, "audit_id": _audit_id},
                 headers={
-                    "Content-Disposition": f'attachment; filename="assessment-results-{_audit_id}.yaml"'
+                    "Content-Disposition": f'attachment; filename="assessment-results-{_filename_token(_audit_id)}.yaml"'
                 },
             )
         except ImportError:
@@ -680,7 +692,7 @@ async def export_oscal_assessment_results(
     return JSONResponse(
         content={"document": doc, "audit_id": _audit_id},
         headers={
-            "Content-Disposition": f'attachment; filename="assessment-results-{_audit_id}.json"'
+            "Content-Disposition": f'attachment; filename="assessment-results-{_filename_token(_audit_id)}.json"'
         },
     )
 
@@ -1020,7 +1032,7 @@ async def get_aarm_conformance_report(
             return JSONResponse(
                 content={"yaml": content, "audit_id": _audit_id},
                 headers={
-                    "Content-Disposition": f'attachment; filename="aarm-conformance-{_audit_id}.yaml"'
+                    "Content-Disposition": f'attachment; filename="aarm-conformance-{_filename_token(_audit_id)}.yaml"'
                 },
             )
         except ImportError:
@@ -1029,7 +1041,7 @@ async def get_aarm_conformance_report(
     return JSONResponse(
         content={"report": report_dict, "audit_id": _audit_id},
         headers={
-            "Content-Disposition": f'attachment; filename="aarm-conformance-{_audit_id}.json"'
+            "Content-Disposition": f'attachment; filename="aarm-conformance-{_filename_token(_audit_id)}.json"'
         },
     )
 

--- a/tests/test_compliance_bridge_tier2b.py
+++ b/tests/test_compliance_bridge_tier2b.py
@@ -307,6 +307,44 @@ class TestOscalExporterEndpoint:
         resp = client.get("/v1/oscal/assessment-results?format=xml")
         assert resp.status_code == 422
 
+    def test_audit_id_cannot_break_out_of_content_disposition(self, client):
+        payload = "a\"; filename*=UTF-8''evil.html"
+        with patch(
+            "src.compliance_bridge.main.get_compliance_metrics",
+            new=AsyncMock(side_effect=self._mock_metrics_side_effect),
+        ):
+            resp = client.get(
+                "/v1/oscal/assessment-results", params={"audit_id": payload}
+            )
+        disposition = resp.headers["content-disposition"]
+        assert disposition == (
+            'attachment; filename="assessment-results-'
+            'a___filename__UTF-8__evil.html.json"'
+        )
+        # The unsanitised ID is still echoed in the body for correlation.
+        assert resp.json()["audit_id"] == payload
+
+    def test_aarm_audit_id_cannot_break_out_of_content_disposition(self, client):
+        payload = "b\"; filename*=UTF-8''evil.html"
+        with patch(
+            "src.compliance_bridge.main.get_compliance_metrics",
+            new=AsyncMock(side_effect=self._mock_metrics_side_effect),
+        ):
+            resp = client.get(
+                "/v1/aarm/conformance-report", params={"audit_id": payload}
+            )
+        disposition = resp.headers["content-disposition"]
+        assert disposition == (
+            'attachment; filename="aarm-conformance-'
+            'b___filename__UTF-8__evil.html.json"'
+        )
+
+    def test_filename_token_preserves_generated_ids(self):
+        from src.compliance_bridge.main import _filename_token
+
+        assert _filename_token("cage-export-1750000000") == "cage-export-1750000000"
+        assert _filename_token("aarm-ondemand-1750000000") == "aarm-ondemand-1750000000"
+
 
 # ---------------------------------------------------------------------------
 # 2.4 — PagerDutyNotifier


### PR DESCRIPTION
## Summary

`GET /v1/oscal/assessment-results` and `GET /v1/aarm/conformance-report` interpolate the caller-supplied `audit_id` query parameter directly into a quoted `Content-Disposition` filename. A `"` in `audit_id` closes the quoted-string early and lets the caller append arbitrary disposition parameters, including `filename*=UTF-8''…`, which browsers prefer over `filename` per RFC 6266 §4.3. Both routes are unauthenticated, so a crafted link makes the JSON export save under a name and extension the attacker chose. The token is now reduced to the safe filename character set before it reaches the header.

## Type of Change

- [x] `fix` — bug fix

## Related Issues / ADRs

N/A

## Changes Made

- `src/compliance_bridge/main.py` — added `_filename_token()` and applied it at the four `Content-Disposition` sites (JSON and YAML paths of both exports). `audit_id` is still echoed verbatim in the response body, so correlation is unchanged; only the header token is normalised.
- `tests/test_compliance_bridge_tier2b.py` — regression coverage for both endpoints plus a check that the auto-generated `cage-export-…` / `aarm-ondemand-…` IDs pass through untouched.

## Testing

- [x] Unit tests added / updated (`pytest tests/`)

**Manual test steps (if applicable):**
```
# Before the patch the quote breaks out of the header:
curl -sD- 'http://localhost:3001/v1/oscal/assessment-results?audit_id=a%22;%20filename*=UTF-8%27%27evil.html' | grep -i content-disposition
# -> attachment; filename="assessment-results-a"; filename*=UTF-8''evil.html.json"

pytest tests/test_compliance_bridge_tier2b.py -q   # 35 passed
ruff check . && ruff format --check .
```

## Compliance & Security Checklist

### 🔒 Universal — All contributors must verify (all regions affected)

- [x] No secrets, credentials, or PII in committed files
- [x] Network policy unchanged **or** reviewed by security owner
- [x] OPA policy changes reviewed for correctness (`src/governed_financial_advisor/graph/governance/trade_policy.rego`) — no policy files touched
- [x] **Data residency:** Any new storage path, GCS write, Langfuse sink, or telemetry export is guarded by `CAGE_DEPLOYMENT_REGION` — no new storage or telemetry path introduced
- [ ] **ISO 42001 / CSA AARM:** Lula assertions unaffected — I could not run `lula validate` locally. The change alters only an HTTP response header token; the OSCAL and AARM documents themselves are byte-identical, so the assertions should be unaffected, but a CI confirmation would be welcome.
- [x] **No region-specific behaviour introduced without a `cage_deployment_region` guard** — the fix is region-agnostic and applies identically to all three postures

### 🎯 Region-specific depth — Check only your target deployment

**US_FED**
- [x] N/A — not targeting US_FED

**EU_ECB**
- [x] N/A — not targeting EU_ECB

**APAC_MAS**
- [x] N/A — not targeting APAC_MAS

### 📋 Shared-module impact declaration

- [x] **Impact assessed across all three regions:** Describe below how this change affects US_FED, EU_ECB, and APAC_MAS posture

**Cross-region impact summary (if applicable):**
```
US_FED impact:   none — header-only normalisation, document payload unchanged
EU_ECB impact:   none — header-only normalisation, document payload unchanged
APAC_MAS impact: none — header-only normalisation, document payload unchanged
```

## Deployment Notes

N/A
