### PR TITLE
fix(compliance-bridge): escape untrusted fields in slack alert

### DIFF
--- a/src/compliance_bridge/notifier.py
+++ b/src/compliance_bridge/notifier.py
@@ -87,8 +87,14 @@ def _build_critical_alert_body(
                     "fields": [
                         {"type": "mrkdwn", "text": f"*Control:* `{f.control_id}`"},
                         {"type": "mrkdwn", "text": f"*Result:* {f.result}"},
-                        {"type": "mrkdwn", "text": f"*Finding ID:* {f.finding_id}"},
-                        {"type": "mrkdwn", "text": f"*Remarks:* {f.remarks or 'none'}"},
+                        {
+                            "type": "mrkdwn",
+                            "text": f"*Finding ID:* {_escape_slack_mrkdwn(f.finding_id)}",
+                        },
+                        {
+                            "type": "mrkdwn",
+                            "text": f"*Remarks:* {_escape_slack_mrkdwn(f.remarks or 'none')}",
+                        },
                     ],
                 }
                 for f in critical_fails
@@ -99,7 +105,7 @@ def _build_critical_alert_body(
                     {
                         "type": "mrkdwn",
                         "text": (
-                            f"Audit ID: {audit_id} | "
+                            f"Audit ID: {_escape_slack_mrkdwn(audit_id)} | "
                             f"Timestamp: {datetime.now(tz=timezone.utc).isoformat()} | "
                             "System: governance-gateway-01"
                         ),

--- a/tests/test_security_medium_severity.py
+++ b/tests/test_security_medium_severity.py
@@ -748,6 +748,60 @@ class TestM22SlackEscaping:
         result = self._escape("Normal advisory text with numbers 123")
         assert "Normal advisory text with numbers 123" in result
 
+    def _critical_fields(self, finding_id: str, remarks: str) -> list[str]:
+        from src.compliance_bridge.notifier import _build_critical_alert_body
+        from src.compliance_bridge.types import OscalFinding
+
+        finding = OscalFinding(
+            control_id="A.9.2",
+            result="FAIL",
+            finding_id=finding_id,
+            remarks=remarks,
+            safety_rate=None,
+        )
+        body = _build_critical_alert_body([finding], audit_id="audit-1")
+        return [f["text"] for f in body["blocks"][1]["fields"]]
+
+    def test_critical_alert_escapes_remarks(self):
+        # A finding on a critical control carries attacker-controlled remarks from
+        # the ingested OSCAL YAML; the builder must run it through the escaper so a
+        # <!channel> mass-mention or <url|text> link cannot reach the Slack surface.
+        texts = self._critical_fields(
+            "F1", "<!channel> <https://evil.example/pwn|remediate> *bold*"
+        )
+        remarks = next(t for t in texts if t.startswith("*Remarks:*"))
+        assert "<!channel>" not in remarks
+        assert "<https://evil.example/pwn|" not in remarks
+        assert "&lt;!channel&gt;" in remarks
+        assert "\\*bold\\*" in remarks
+
+    def test_critical_alert_escapes_finding_id(self):
+        texts = self._critical_fields("F1<!here>", "none")
+        finding_id = next(t for t in texts if t.startswith("*Finding ID:*"))
+        assert "<!here>" not in finding_id
+        assert "&lt;!here&gt;" in finding_id
+
+    def test_critical_alert_preserves_plain_remarks(self):
+        texts = self._critical_fields("F1", "evidence age 42s exceeded window")
+        remarks = next(t for t in texts if t.startswith("*Remarks:*"))
+        assert remarks == "*Remarks:* evidence age 42s exceeded window"
+
+    def test_critical_alert_escapes_audit_id_context(self):
+        # audit_id reaches the builder verbatim from POST /v1/audit/ingest, so the
+        # context footer must escape it too.
+        from src.compliance_bridge.notifier import _build_critical_alert_body
+        from src.compliance_bridge.types import OscalFinding
+
+        finding = OscalFinding(
+            control_id="A.9.2", result="FAIL", finding_id="F1", remarks="none"
+        )
+        body = _build_critical_alert_body(
+            [finding], audit_id="<!channel> <https://evil.example|x>"
+        )
+        context_text = body["blocks"][2]["elements"][0]["text"]
+        assert "<!channel>" not in context_text
+        assert "&lt;!channel&gt;" in context_text
+
 
 # ---------------------------------------------------------------------------
 # M-23 — OPA decision log config


### PR DESCRIPTION
## Summary

`_build_critical_alert_body` drops `finding_id`, `remarks` and `audit_id` straight into Slack Block Kit `mrkdwn` fields, while the sibling `_build_remediation_followup_body` in the same module already runs its untrusted field through `_escape_slack_mrkdwn()` (the M-22 helper). All three values are attacker-controlled free text: `finding_id` and `remarks` come from the OSCAL findings submitted to `POST /v1/audit/ingest`, and `audit_id` is that request's own field with only `.strip()` applied. A finding on a critical control (`A.9.2`/`SC-4`/`A.8.4`) with state `not-satisfied` maps to FAIL and flows through `send_critical_alert` unchanged, so a crafted `remarks` such as `<!channel> <https://evil.example/pwn|remediate>` lands in the compliance operators' channel as a real mass-mention plus a spoofed link. The critical-alert builder just missed the escaping the remediation builder already does; this routes the same three fields through `_escape_slack_mrkdwn()` at their interpolation sites.

## Type of Change

- [x] `fix` — bug fix

## Related Issues / ADRs

N/A

## Changes Made

- `src/compliance_bridge/notifier.py` — escape `finding_id`, `remarks`, and the context-block `audit_id` in `_build_critical_alert_body` via the existing `_escape_slack_mrkdwn()`. `control_id` (backticked, allow-listed to `CRITICAL_CONTROLS` on this path) and `result` (enum) are left as-is.
- `tests/test_security_medium_severity.py` — extend `TestM22SlackEscaping` with builder-level cases: `remarks`/`finding_id`/`audit_id` injection is neutralised and plain remarks pass through byte-for-byte.

## Testing

- [x] Unit tests added / updated (`pytest tests/`)

**Manual test steps (if applicable):**
```
uv run pytest tests/test_security_medium_severity.py::TestM22SlackEscaping -q
```

## Compliance & Security Checklist

### 🔒 Universal — All contributors must verify (all regions affected)

- [x] No secrets, credentials, or PII in committed files
- [x] Network policy unchanged **or** reviewed by security owner

### 🎯 Region-specific depth — Check only your target deployment

**US_FED**
- [x] N/A — not targeting US_FED (shared-module change, behaviour identical across regions)

**EU_ECB**
- [x] N/A — not targeting EU_ECB

**APAC_MAS**
- [x] N/A — not targeting APAC_MAS

### 📋 Shared-module impact declaration

- [x] **Impact assessed across all three regions:** escaping is region-independent; the alert payload is identical in US_FED/EU_ECB/APAC_MAS. Only the rendered representation of untrusted `finding_id`/`remarks`/`audit_id` changes (special characters are now escaped); valid inputs are unchanged.

## Deployment Notes

N/A
