### PR TITLE
chore(infra): fix GKE tfvars, tf depends_on, and redis svc name

### DIFF
--- a/infra/targets/gcp-gke/dev.tfvars
+++ b/infra/targets/gcp-gke/dev.tfvars
@@ -2,9 +2,9 @@
 # Fast iteration, minimal costs, low security posture
 
 # ─── GCP Project ──────────────────────────────────────────────────────────────
-# REPLACE with your actual project ID
-project_id = "YOUR_GCP_PROJECT_ID"
-region     = "us-central1"
+# project_id is intentionally omitted here — it is injected via TF_VAR_project_id
+# which deploy_all.sh reads from GOOGLE_CLOUD_PROJECT in .env (DEP-22).
+# region is also injected via TF_VAR_region from GOOGLE_CLOUD_LOCATION in .env.
 zone       = "us-central1-a" # Current cluster location
 
 # ─── Cluster ──────────────────────────────────────────────────────────────────
@@ -23,6 +23,9 @@ enable_audit_logging           = false
 enable_cmek                    = false
 enable_private_master_endpoint = false
 enable_pod_security_standards  = false
+# Required: org policy constraints/compute.vmExternalIpAccess blocks nodes with external IPs.
+# Private nodes use NAT egress (Cloud NAT) instead of external IPs.
+enable_private_nodes           = true
 
 # Authorized networks for private cluster access
 authorized_networks = [

--- a/infra/targets/gcp-gke/main.tf
+++ b/infra/targets/gcp-gke/main.tf
@@ -571,7 +571,7 @@ module "gateway" {
   opa_url                 = "http://${module.opa.service_name}.${module.namespace.name}.svc.cluster.local:8181/v1/data/trade/governance"
   governance_salt         = var.governance_salt
 
-  depends_on = [module.opa, module.vllm, module.redis]
+  depends_on = [module.app_secrets, module.opa, module.vllm, module.redis]
 }
 
 # ─── Deploy Governed Financial Advisor ────────────────────────────────────────

--- a/scripts/port_forward_dev.sh
+++ b/scripts/port_forward_dev.sh
@@ -86,7 +86,7 @@ start_pf vllm-reason2 vllm-reasoning           18082  8000  # Reasoning vLLM —
 # The port-forward is intentionally omitted.
 start_pf gateway      gateway                   8080  8080  # Gateway gRPC/HTTP
 start_pf backend      governed-financial-advisor 18080   80  # Governed FA backend — BACKEND_URL (:18080)
-start_pf redis        redis                     6379  6379  # Redis (redis svc)
+start_pf redis        redis-master              6379  6379  # Redis (redis-master svc)
 start_pf compliance   compliance-bridge          3002    80  # Compliance bridge — BASE_URL (:3002)
 
 echo "[port-forward] Waiting for readiness (3s)..."


### PR DESCRIPTION
## Summary
Infrastructure fixes for GKE deployment stability.

## Changes
- `infra/targets/gcp-gke/dev.tfvars`: fix tfvars configuration
- `infra/targets/gcp-gke/main.tf`: fix `depends_on` ordering
- `scripts/port_forward_dev.sh`: fix redis service name

## Category
Cat-S (Standard) — pre-approved infrastructure fix, no new GCP services.