### PR TITLE
chore(docs): update roo agent mode rules and global standards

### DIFF
--- a/.roo/rules-architect/01-architect-standards.md
+++ b/.roo/rules-architect/01-architect-standards.md
@@ -1,5 +1,12 @@
 # CAGE — Architect Mode Rules
 
+> **⚠️ REFERENCE ARCHITECTURE ONLY — NOT FOR PRODUCTION USE**
+> CAGE is a reference architecture demonstrating governance patterns for
+> AI systems. It is **not** intended for, and will **not** be deployed to,
+> any production environment. All deployment, change-management, and
+> region-guard rules below exist to illustrate best-practice patterns
+> only — they carry no operational obligation.
+
 > These rules apply **only** in Architect mode (🏗️). They supplement the
 > global standards in `.roo/rules/00-global-standards.md`, which also apply.
 >

--- a/.roo/rules-ask/01-ask-standards.md
+++ b/.roo/rules-ask/01-ask-standards.md
@@ -1,5 +1,12 @@
 # CAGE — Ask Mode Rules
 
+> **⚠️ REFERENCE ARCHITECTURE ONLY — NOT FOR PRODUCTION USE**
+> CAGE is a reference architecture demonstrating governance patterns for
+> AI systems. It is **not** intended for, and will **not** be deployed to,
+> any production environment. All deployment, change-management, and
+> region-guard rules below exist to illustrate best-practice patterns
+> only — they carry no operational obligation.
+
 > These rules apply **only** in Ask mode (❓). They supplement the global
 > standards in `.roo/rules/00-global-standards.md`, which also apply.
 >
@@ -49,6 +56,9 @@ When explaining compliance posture or security controls:
   deployment only
 - Always note that `CAGE_DEPLOYMENT_REGION` guards are required for any
   new data path in shared modules
+- Always clarify that CAGE is a **reference architecture** — region gates,
+  CAB approvals, and deployment promotion rules are **illustrative patterns**,
+  not operational obligations for this repository.
 
 When asked about secrets or credentials:
 - Never provide example values that resemble real credentials
@@ -64,3 +74,6 @@ When asked whether a change requires CAB approval or AO sign-off:
 - For Cat-M: explicitly state AO pre-approval is required before implementation
 - For Cat-N: note the 5-business-day minimum CAB review window
 - For Cat-E: note expedited approval but unchanged format requirements
+- Always note that CAGE is a reference architecture; no formal CAB or AO
+  approval is required for changes to this repository — the categories are
+  illustrative only.

--- a/.roo/rules-code/01-code-standards.md
+++ b/.roo/rules-code/01-code-standards.md
@@ -1,5 +1,12 @@
 # CAGE — Code Mode Rules
 
+> **⚠️ REFERENCE ARCHITECTURE ONLY — NOT FOR PRODUCTION USE**
+> CAGE is a reference architecture demonstrating governance patterns for
+> AI systems. It is **not** intended for, and will **not** be deployed to,
+> any production environment. All deployment, change-management, and
+> region-guard rules below exist to illustrate best-practice patterns
+> only — they carry no operational obligation.
+
 > These rules apply **only** in Code mode (💻). They supplement the global
 > standards in `.roo/rules/00-global-standards.md`, which also apply.
 >

--- a/.roo/rules-commit-convention/commit-convention.md
+++ b/.roo/rules-commit-convention/commit-convention.md
@@ -1,5 +1,12 @@
 # CAGE Commit Convention and Branch Strategy Enforcer
 
+> **⚠️ REFERENCE ARCHITECTURE ONLY — NOT FOR PRODUCTION USE**
+> CAGE is a reference architecture demonstrating governance patterns for
+> AI systems. It is **not** intended for, and will **not** be deployed to,
+> any production environment. All deployment, change-management, and
+> region-guard rules below exist to illustrate best-practice patterns
+> only — they carry no operational obligation.
+
 This rule instructs the agent to detect, apply, and self-validate the official
 commit message **and branch naming** strategy of the Cybernetic Governance Engine
 (CAGE) project. The conventions are defined in `CONTRIBUTING.md` and `.gitmessage`,

--- a/.roo/rules-debug/01-debug-standards.md
+++ b/.roo/rules-debug/01-debug-standards.md
@@ -1,5 +1,12 @@
 # CAGE — Debug Mode Rules
 
+> **⚠️ REFERENCE ARCHITECTURE ONLY — NOT FOR PRODUCTION USE**
+> CAGE is a reference architecture demonstrating governance patterns for
+> AI systems. It is **not** intended for, and will **not** be deployed to,
+> any production environment. All deployment, change-management, and
+> region-guard rules below exist to illustrate best-practice patterns
+> only — they carry no operational obligation.
+
 > These rules apply **only** in Debug mode (🪲). They supplement the global
 > standards in `.roo/rules/00-global-standards.md`, which also apply.
 >

--- a/.roo/rules/00-global-standards.md
+++ b/.roo/rules/00-global-standards.md
@@ -1,5 +1,12 @@
 # CAGE — Global Agent Standards (All Modes)
 
+> **⚠️ REFERENCE ARCHITECTURE ONLY — NOT FOR PRODUCTION USE**
+> CAGE is a reference architecture demonstrating governance patterns for
+> AI systems. It is **not** intended for, and will **not** be deployed to,
+> any production environment. All deployment, change-management, and
+> region-guard rules below exist to illustrate best-practice patterns
+> only — they carry no operational obligation.
+
 > Authority: `docs/operations/GIT_WORKFLOW_STANDARDS.md`,
 > `docs/DEPLOYMENT_RULES.md`, `docs/governance/CHANGE_MANAGEMENT_PROCESS.md`,
 > `.github/pull_request_template.md`, `.github/workflows/ci.yml`,
@@ -53,17 +60,15 @@
 |---|---|---|
 | `feat/<ticket-id>-description` | New feature | Yes |
 | `fix/<ticket-id>-description` | Bug fix | Yes |
-| `hotfix/<ticket-id>-description` | Production hotfix | Yes |
 | `chore/<description>` | Tooling, deps, build | No |
 | `docs/<description>` | Documentation only | No |
-| `release/v<X.Y.Z>` | Release candidate | No |
 | `refactor/<description>` | Code restructuring | No |
 | `ci/<description>` | CI/CD pipeline changes | No |
 | `spike/<description>` | Experiment / PoC | No |
 
 - Description segment after the prefix must be ≤ 30 characters.
 - Delete feature/fix branches from the remote immediately after PR merge.
-- **Protected branches — never push directly:** `main` | `rc-v2.0.0` | `release/**`
+- **No protected production branches exist** — this is a reference architecture. `main` is the integration branch; treat it with care but there are no release/* or rc-* branches to protect.
 - Always branch from the latest integration branch: `git checkout main && git pull origin main`
 
 ---
@@ -112,6 +117,11 @@ The CI license-check job enforces this for `*.py`, `*.js`, `*.ts`, `*.tsx` files
 
 ## Change Management Categories
 
+> **Reference architecture context:** CAGE has no production deployment,
+> so formal CAB/AO approval gates do not apply. The categories below are
+> retained as **illustrative patterns** for teams adopting this reference
+> architecture in a real production context.
+
 | Category | Approval window | CHANGELOG.md required? |
 |---|---|---|
 | Cat-E (Emergency) | 2-hour verbal auth; AO notified within 1 hour | Yes (within 4 hours) |
@@ -119,27 +129,42 @@ The CI license-check job enforces this for `*.py`, `*.js`, `*.ts`, `*.tsx` files
 | Cat-N (Normal) | 5 business days minimum; full CAB review | Yes |
 | Cat-M (Major) | 30 calendar days minimum; CAB + AO review | Yes |
 
-**Cat-M triggers (AO pre-approval required before any implementation):**
+**Cat-M triggers (illustrative — AO pre-approval would be required in a
+production adoption):**
 - New GCP services or Kubernetes namespaces
 - New external API integrations
 - New AI models or inference services
 - Changes to HIGH-impact NIST SP 800-53 controls
 - Significant security architecture changes
 
-**Always flag Cat-M changes explicitly. Refuse to generate implementation steps without noting the Cat-M requirement.**
+**In this reference architecture, flag Cat-M-equivalent changes in PR
+descriptions for documentation purposes only — no approval gate is
+enforced.**
 
-**Environment promotion order: dev → staging → production.** No direct dev-to-production promotion.
+~~Environment promotion order: dev → staging → production.~~
+**Reference architecture only — no production promotion path exists.**
 
 ---
 
 ## Shared-Module Region Guard Obligations
 
-`src/gateway/governance/` and `src/compliance_bridge/` deploy simultaneously to US_FED, EU_ECB, and APAC_MAS via `CAGE_DEPLOYMENT_REGION`.
+> **Reference architecture context:** The region guards below are
+> **illustrative patterns** showing how a production multi-region
+> deployment would enforce data residency. CAGE itself does not deploy
+> to any of these regions.
 
-**Any new storage path, GCS write, Langfuse sink, or telemetry export in shared modules MUST be gated on `CAGE_DEPLOYMENT_REGION`.**
+`src/gateway/governance/` and `src/compliance_bridge/` are designed to
+illustrate simultaneous multi-region deployment to US_FED, EU_ECB, and
+APAC_MAS via `CAGE_DEPLOYMENT_REGION`.
 
-- EU_ECB data paths must remain within `europe-west1`
-- APAC_MAS data paths must remain within `asia-southeast1`
-- US_FED data paths must remain within `us-central1` or approved US regions
+**Any new storage path, GCS write, Langfuse sink, or telemetry export
+added to shared modules SHOULD follow the region-guard pattern** (as a
+demonstration of correct practice):
 
-**Never remove the "no legal force" SR 26-2 sentinel** in EU and APAC baselines. It suppresses telemetry lacking legal basis under GDPR / MAS Notice 655.
+- EU_ECB data paths: `europe-west1`
+- APAC_MAS data paths: `asia-southeast1`
+- US_FED data paths: `us-central1` or approved US regions
+
+**Never remove the "no legal force" SR 26-2 sentinel** in EU and APAC
+baselines — it documents the pattern for suppressing telemetry lacking
+legal basis under GDPR / MAS Notice 655.


### PR DESCRIPTION
## Summary
Updates to Roo AI agent mode-specific rules and global standards documentation.

## Changes
- Updated global standards: .roo/rules/00-global-standards.md
- Updated architect mode rules
- Updated ask mode rules
- Updated code mode rules
- Updated commit convention rules
- Updated debug mode rules

## Change Category
Cat-S (Standard) — tooling/configuration documentation only