### PR TITLE
chore(compliance): refresh lula assessment results and readme

### DIFF
--- a/compliance/lula/README.md
+++ b/compliance/lula/README.md
@@ -67,11 +67,23 @@ The active/stub split is **intentional and aligned with the posture architecture
 - **1 Active (US_FED scope):** SC-4 fiscal limits — production-ready for US Federal deployments
 - **1 Stub (ALL scope):** CSA AARM vectors — universal but requires cluster configuration. **Note:** This validation is listed as `Status: 🔶 Stub` and counted as 1 stub (ALL scope). It is NOT counted as an active validation for release gate purposes until real assertions replace the stub. See CA-05 remediation note below.
 - **10 Stub (US_FED scope):** NIST SP 800-53 controls — US Federal only; require cluster-specific namespace/resource configuration before activation
-- **5 Stub (US_FED scope):** NIST AI 600-1 controls — added in Phase 0 of the AI 600-1 implementation plan (branch `feat/CAGE-AI600-ai600-1-implementation`, 2026-06-15); require Langfuse metric availability and cluster-specific configuration before activation
+- **5 Stub (US_FED scope):** NIST AI 600-1 controls — phases 0–3 implemented in v2.1.0 (runtime enforcement active); Lula manifests are stub-ready and require Langfuse metric availability and cluster-specific configuration before activation
 
 The 10 US_FED NIST SP 800-53 stubs represent an **implementation gap** tracked as an open POAM item: activating all 10 would raise NIST SP 800-53 Lula coverage from 1/11 to 11/11 controls, directly supporting the US_FED release gate requirement (F-01 in `docs/PRODUCTION_READINESS_REPORT.md`). The CSA AARM stub (1 manifest, ALL scope) is a separate gap affecting all regions.
 
-The 5 US_FED NIST AI 600-1 stubs are **scaffolding stubs** created as part of Phase 0 of [`docs/AI_600_1_IMPLEMENTATION_PLAN.md`](../../docs/AI_600_1_IMPLEMENTATION_PLAN.md). They will be hardened to full assertions in Phase 3 §7.5 (Weeks 16–52). The CBRN stub (`lula-validation-ai600-cbrn.yaml`) is a **Cat-M change** requiring AO pre-approval before cluster activation per [`docs/CHANGE_MANAGEMENT_PROCESS.md`](../../docs/governance/CHANGE_MANAGEMENT_PROCESS.md) §8.4.
+The 5 US_FED NIST AI 600-1 stubs correspond to **phases 0–3 of the AI 600-1 implementation** (v2.1.0). Runtime enforcement is active for all phases via `confabulation_scorer.py`, `pii_sanitizer.py`, `prompt_injection_detector.py`, `hitl_escalator.py`, and `text_filter.py`. The Lula manifests are scaffolding-ready and will be hardened to full live-cluster assertions once Langfuse metric endpoints are configured. The CBRN stub (`lula-validation-ai600-cbrn.yaml`) remains a **Cat-M change** requiring AO pre-approval before cluster activation per [`docs/CHANGE_MANAGEMENT_PROCESS.md`](../../docs/governance/CHANGE_MANAGEMENT_PROCESS.md) §8.4.
+
+### Three-Region OSCAL SSPs
+
+Each deployment region has a dedicated OSCAL System Security Plan:
+
+| Region | SSP File | Frameworks |
+|--------|----------|------------|
+| **US_FED** | [`compliance/oscal/system-security-plan.yaml`](../oscal/system-security-plan.yaml) | NIST SP 800-53 Rev 5 HIGH + NIST AI 600-1 |
+| **EU_ECB** | [`compliance/oscal/system-security-plan-eu-ecb.yaml`](../oscal/system-security-plan-eu-ecb.yaml) | EU AI Act / GDPR Art. 22 / DORA |
+| **APAC_MAS** | [`compliance/oscal/system-security-plan-apac-mas.yaml`](../oscal/system-security-plan-apac-mas.yaml) | MAS FEAT / MAS Notice 655 / MAS TRM §6.3 |
+
+Region selection is controlled exclusively by `CAGE_DEPLOYMENT_REGION`. The Lula CronJob (`deployment/k8s/lula-cron.yaml`) reads this variable to determine which jurisdiction-specific manifests to include in each run.
 
 ---
 

--- a/compliance/lula/assessment-results.yaml
+++ b/compliance/lula/assessment-results.yaml
@@ -1,28 +1,7166 @@
-# Copyright 2026 Google LLC
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     https://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 assessment-results:
   import-ap:
     href: ""
   metadata:
-    last-modified: 2026-07-01T10:08:48.633345-04:00
+    last-modified: 2026-07-27T09:38:56.362355-04:00
     oscal-version: 1.1.3
     published: 2026-07-01T09:19:14.704178-04:00
     remarks: Assessment Results generated from Lula
     title: '[System Name] Security Assessment Results (SAR)'
     version: 0.0.1
   results:
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 350c54ef-a57a-5117-b4e1-03c257885b21 / Implemented Requirement: 241d9a37-67b7-5deb-914b-5f83e8ed68d8
+            Automated lula validation for MAS FEAT.
+          related-observations:
+            - observation-uuid: 50252527-3d61-433a-a7e1-8f30e654811f
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: mas-feat
+            type: objective-id
+          title: 'Validation Result - Control: mas-feat'
+          uuid: 776a80a9-48b5-4b61-a082-18601bacb413
+      observations:
+        - collected: 2026-07-27T09:38:56.292-04:00
+          description: |
+            [TEST]: 44249863-3ab1-5cb0-9b6f-3a17700a71b2 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #44249863-3ab1-5cb0-9b6f-3a17700a71b2: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 50252527-3d61-433a-a7e1-8f30e654811f
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.mas.gov.sg/regulation/guidelines/technology-risk-management-guidelines
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: mas-feat
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-27T09:38:56.292111-04:00
+      title: Lula Validation Result
+      uuid: 44a989dd-6cb8-4a2f-ac3d-2200fec3a765
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: a3697688-6e46-5205-910e-22c7b44f6bdd / Implemented Requirement: 6915c619-071a-51ea-a57f-60232a68751d
+            Automated lula validation for AARM VECTORS.
+          related-observations:
+            - observation-uuid: a0b38454-754e-41b9-8628-a936eac0e874
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: aarm-vectors
+            type: objective-id
+          title: 'Validation Result - Control: aarm-vectors'
+          uuid: 0ddd95a4-c487-44b2-b764-6e4c79681885
+      observations:
+        - collected: 2026-07-27T09:38:56.039391-04:00
+          description: |
+            [TEST]: ec32ba67-e5a7-50b4-8ff5-eca8aac8da66 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #ec32ba67-e5a7-50b4-8ff5-eca8aac8da66: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: a0b38454-754e-41b9-8628-a936eac0e874
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://cloudsecurityalliance.org/research/working-groups/artificial-intelligence
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: aarm-vectors
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-27T09:38:56.039526-04:00
+      title: Lula Validation Result
+      uuid: c24d84e9-641b-468c-8391-85dbbc4d616a
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 11a88f5e-1f94-5774-94b9-617f7870e62a / Implemented Requirement: 4332a913-0441-5d14-8df5-ba79df3749d5
+            Automated lula validation for A92.
+          related-observations:
+            - observation-uuid: 1cf360d8-f2a3-4800-8b30-b5fdc64eb2ef
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a92
+            type: objective-id
+          title: 'Validation Result - Control: a92'
+          uuid: 8dbd68d6-7f81-42cf-a892-c8e5a3af149c
+      observations:
+        - collected: 2026-07-27T09:38:55.792817-04:00
+          description: |
+            [TEST]: 189e411a-b3fb-5db2-b787-349693054e29 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #189e411a-b3fb-5db2-b787-349693054e29: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 1cf360d8-f2a3-4800-8b30-b5fdc64eb2ef
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a92
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-27T09:38:55.792928-04:00
+      title: Lula Validation Result
+      uuid: b383def8-f167-4694-b523-6e68c9495d06
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 1ece732e-9180-52e4-a04d-bb92f5e01929 / Implemented Requirement: 76dea904-7d5c-53b3-b5d8-2c31702ff8ca
+            Automated lula validation for A53.
+          related-observations:
+            - observation-uuid: f688f432-030e-43de-8b20-39db9dc8e949
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a53
+            type: objective-id
+          title: 'Validation Result - Control: a53'
+          uuid: b30737c6-2544-436b-821f-6df6e4f748f9
+      observations:
+        - collected: 2026-07-27T09:38:55.547097-04:00
+          description: |
+            [TEST]: eb760977-813f-5999-af3f-dcd76b48c7aa - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #eb760977-813f-5999-af3f-dcd76b48c7aa: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: f688f432-030e-43de-8b20-39db9dc8e949
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a53
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-27T09:38:55.547203-04:00
+      title: Lula Validation Result
+      uuid: 2340d4c8-c344-4cb1-aa4e-3e47e28b03c1
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: aa0f365e-7e2d-538a-95d1-c994b78ff302 / Implemented Requirement: 6a8eb074-850a-57b0-8198-0b7a929b92b1
+            Automated lula validation for A52.
+          related-observations:
+            - observation-uuid: 0aec31e0-068c-4cc8-ba42-9a35bffb8525
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a52
+            type: objective-id
+          title: 'Validation Result - Control: a52'
+          uuid: 1becf7d5-b26a-400e-a4fa-ec753c7c8d20
+      observations:
+        - collected: 2026-07-27T09:38:55.298606-04:00
+          description: |
+            [TEST]: 40037dad-ee78-523f-97dc-1f73fabf7d41 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #40037dad-ee78-523f-97dc-1f73fabf7d41: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 0aec31e0-068c-4cc8-ba42-9a35bffb8525
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a52
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-27T09:38:55.299697-04:00
+      title: Lula Validation Result
+      uuid: 9829c313-ddb7-44d8-9c3a-11c5e2a1d6cd
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: a3697688-6e46-5205-910e-22c7b44f6bdd / Implemented Requirement: 6915c619-071a-51ea-a57f-60232a68751d
+            Automated lula validation for AARM VECTORS.
+          related-observations:
+            - observation-uuid: 8e68f470-e66a-4ea3-8532-7c62fa326314
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: aarm-vectors
+            type: objective-id
+          title: 'Validation Result - Control: aarm-vectors'
+          uuid: 9bb59534-c4c3-43e1-a18e-c2252a82399a
+      observations:
+        - collected: 2026-07-27T09:38:36.529514-04:00
+          description: |
+            [TEST]: ec32ba67-e5a7-50b4-8ff5-eca8aac8da66 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #ec32ba67-e5a7-50b4-8ff5-eca8aac8da66: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 8e68f470-e66a-4ea3-8532-7c62fa326314
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://cloudsecurityalliance.org/research/working-groups/artificial-intelligence
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: aarm-vectors
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-27T09:38:36.529624-04:00
+      title: Lula Validation Result
+      uuid: 93e6ce4b-3046-4bf5-a87e-5203c220e665
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 11a88f5e-1f94-5774-94b9-617f7870e62a / Implemented Requirement: 4332a913-0441-5d14-8df5-ba79df3749d5
+            Automated lula validation for A92.
+          related-observations:
+            - observation-uuid: 910e87fa-2a88-4a8e-98fc-9466914829de
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a92
+            type: objective-id
+          title: 'Validation Result - Control: a92'
+          uuid: ffe12a7d-1a94-4ce5-a27c-0a84b0b472eb
+      observations:
+        - collected: 2026-07-27T09:38:36.282685-04:00
+          description: |
+            [TEST]: 189e411a-b3fb-5db2-b787-349693054e29 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #189e411a-b3fb-5db2-b787-349693054e29: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 910e87fa-2a88-4a8e-98fc-9466914829de
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a92
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-27T09:38:36.282821-04:00
+      title: Lula Validation Result
+      uuid: d2c4c69f-827d-4265-b1a2-d2a60943d40c
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 1ece732e-9180-52e4-a04d-bb92f5e01929 / Implemented Requirement: 76dea904-7d5c-53b3-b5d8-2c31702ff8ca
+            Automated lula validation for A53.
+          related-observations:
+            - observation-uuid: 4a57a917-6ebf-4900-bba3-c9d8b37be382
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a53
+            type: objective-id
+          title: 'Validation Result - Control: a53'
+          uuid: c2639236-9762-4607-a223-21eaf9107b57
+      observations:
+        - collected: 2026-07-27T09:38:36.037057-04:00
+          description: |
+            [TEST]: eb760977-813f-5999-af3f-dcd76b48c7aa - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #eb760977-813f-5999-af3f-dcd76b48c7aa: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 4a57a917-6ebf-4900-bba3-c9d8b37be382
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a53
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-27T09:38:36.037164-04:00
+      title: Lula Validation Result
+      uuid: 7a2ddde6-d1c7-480a-a6bd-5792eddad586
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: aa0f365e-7e2d-538a-95d1-c994b78ff302 / Implemented Requirement: 6a8eb074-850a-57b0-8198-0b7a929b92b1
+            Automated lula validation for A52.
+          related-observations:
+            - observation-uuid: 63a834bc-787c-4da6-8e49-f5d4238ab5fe
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a52
+            type: objective-id
+          title: 'Validation Result - Control: a52'
+          uuid: 0e67227a-3823-4d47-8427-410ee4547ebd
+      observations:
+        - collected: 2026-07-27T09:38:35.790603-04:00
+          description: |
+            [TEST]: 40037dad-ee78-523f-97dc-1f73fabf7d41 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #40037dad-ee78-523f-97dc-1f73fabf7d41: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 63a834bc-787c-4da6-8e49-f5d4238ab5fe
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a52
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-27T09:38:35.791648-04:00
+      title: Lula Validation Result
+      uuid: 67871474-7e3c-4478-b858-49a3d232984a
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: a3697688-6e46-5205-910e-22c7b44f6bdd / Implemented Requirement: 6915c619-071a-51ea-a57f-60232a68751d
+            Automated lula validation for AARM VECTORS.
+          related-observations:
+            - observation-uuid: 430433e3-1bdf-4626-9984-e562b73fbecc
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: aarm-vectors
+            type: objective-id
+          title: 'Validation Result - Control: aarm-vectors'
+          uuid: c42baa78-13ca-4923-a0d0-1c47576bc080
+      observations:
+        - collected: 2026-07-27T09:38:14.470728-04:00
+          description: |
+            [TEST]: ec32ba67-e5a7-50b4-8ff5-eca8aac8da66 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #ec32ba67-e5a7-50b4-8ff5-eca8aac8da66: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 430433e3-1bdf-4626-9984-e562b73fbecc
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://cloudsecurityalliance.org/research/working-groups/artificial-intelligence
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: aarm-vectors
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-27T09:38:14.470851-04:00
+      title: Lula Validation Result
+      uuid: acefb7f3-171f-4e33-ab5f-a4729e06edf6
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 11a88f5e-1f94-5774-94b9-617f7870e62a / Implemented Requirement: 4332a913-0441-5d14-8df5-ba79df3749d5
+            Automated lula validation for A92.
+          related-observations:
+            - observation-uuid: 82fcc664-916f-4b08-a889-153fb4c88d6b
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a92
+            type: objective-id
+          title: 'Validation Result - Control: a92'
+          uuid: a5a5b05a-4f7b-4173-b5fc-b5d818073b54
+      observations:
+        - collected: 2026-07-27T09:38:14.220645-04:00
+          description: |
+            [TEST]: 189e411a-b3fb-5db2-b787-349693054e29 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #189e411a-b3fb-5db2-b787-349693054e29: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 82fcc664-916f-4b08-a889-153fb4c88d6b
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a92
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-27T09:38:14.220793-04:00
+      title: Lula Validation Result
+      uuid: 704dd26a-5028-479d-a4da-baad8666e3da
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 1ece732e-9180-52e4-a04d-bb92f5e01929 / Implemented Requirement: 76dea904-7d5c-53b3-b5d8-2c31702ff8ca
+            Automated lula validation for A53.
+          related-observations:
+            - observation-uuid: dd0fd677-67fb-44d0-bd3d-1b32936e2851
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a53
+            type: objective-id
+          title: 'Validation Result - Control: a53'
+          uuid: 4fc5e929-0c76-4322-8f32-0692f0fe315b
+      observations:
+        - collected: 2026-07-27T09:38:13.968817-04:00
+          description: |
+            [TEST]: eb760977-813f-5999-af3f-dcd76b48c7aa - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #eb760977-813f-5999-af3f-dcd76b48c7aa: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: dd0fd677-67fb-44d0-bd3d-1b32936e2851
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a53
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-27T09:38:13.968936-04:00
+      title: Lula Validation Result
+      uuid: b3dbcc23-2888-40d8-891e-59f1d78ea3dc
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: aa0f365e-7e2d-538a-95d1-c994b78ff302 / Implemented Requirement: 6a8eb074-850a-57b0-8198-0b7a929b92b1
+            Automated lula validation for A52.
+          related-observations:
+            - observation-uuid: ab76b02f-26ed-4bb6-95ff-0cbf908b746b
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a52
+            type: objective-id
+          title: 'Validation Result - Control: a52'
+          uuid: f75ac5f6-e4c1-4068-95f8-da473dc8e2d8
+      observations:
+        - collected: 2026-07-27T09:38:13.724639-04:00
+          description: |
+            [TEST]: 40037dad-ee78-523f-97dc-1f73fabf7d41 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #40037dad-ee78-523f-97dc-1f73fabf7d41: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: ab76b02f-26ed-4bb6-95ff-0cbf908b746b
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a52
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-27T09:38:13.725804-04:00
+      title: Lula Validation Result
+      uuid: d4c8d16f-b676-4644-8433-8e968ce49da8
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: a3697688-6e46-5205-910e-22c7b44f6bdd / Implemented Requirement: 6915c619-071a-51ea-a57f-60232a68751d
+            Automated lula validation for AARM VECTORS.
+          related-observations:
+            - observation-uuid: 103247de-af96-471a-b899-0b6f0f4f3b22
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: aarm-vectors
+            type: objective-id
+          title: 'Validation Result - Control: aarm-vectors'
+          uuid: 2a1de72e-9c8b-4dc6-8dbf-052b99abe2a8
+      observations:
+        - collected: 2026-07-26T22:08:36.320981-04:00
+          description: |
+            [TEST]: ec32ba67-e5a7-50b4-8ff5-eca8aac8da66 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #ec32ba67-e5a7-50b4-8ff5-eca8aac8da66: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 103247de-af96-471a-b899-0b6f0f4f3b22
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://cloudsecurityalliance.org/research/working-groups/artificial-intelligence
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: aarm-vectors
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:08:36.321103-04:00
+      title: Lula Validation Result
+      uuid: b68332a5-472c-4f02-9735-9c407645a7e2
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 11a88f5e-1f94-5774-94b9-617f7870e62a / Implemented Requirement: 4332a913-0441-5d14-8df5-ba79df3749d5
+            Automated lula validation for A92.
+          related-observations:
+            - observation-uuid: 2d751f69-037d-4a87-8a0c-fef5c9ffceaa
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a92
+            type: objective-id
+          title: 'Validation Result - Control: a92'
+          uuid: 890337fa-cc87-4b58-b1bc-2cb4dcfb353a
+      observations:
+        - collected: 2026-07-26T22:08:36.069041-04:00
+          description: |
+            [TEST]: 189e411a-b3fb-5db2-b787-349693054e29 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #189e411a-b3fb-5db2-b787-349693054e29: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 2d751f69-037d-4a87-8a0c-fef5c9ffceaa
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a92
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:08:36.069151-04:00
+      title: Lula Validation Result
+      uuid: 0f15d9ea-5f06-4413-b3ea-c2c344f70f47
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 1ece732e-9180-52e4-a04d-bb92f5e01929 / Implemented Requirement: 76dea904-7d5c-53b3-b5d8-2c31702ff8ca
+            Automated lula validation for A53.
+          related-observations:
+            - observation-uuid: d6e421d5-9c6e-43f0-954e-8c89cf90e870
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a53
+            type: objective-id
+          title: 'Validation Result - Control: a53'
+          uuid: b837180f-7fbc-4c35-b29c-742ce4ab3a96
+      observations:
+        - collected: 2026-07-26T22:08:35.81806-04:00
+          description: |
+            [TEST]: eb760977-813f-5999-af3f-dcd76b48c7aa - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #eb760977-813f-5999-af3f-dcd76b48c7aa: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: d6e421d5-9c6e-43f0-954e-8c89cf90e870
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a53
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:08:35.818172-04:00
+      title: Lula Validation Result
+      uuid: 0fc144e9-40df-455a-bdb7-13e005f07737
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: aa0f365e-7e2d-538a-95d1-c994b78ff302 / Implemented Requirement: 6a8eb074-850a-57b0-8198-0b7a929b92b1
+            Automated lula validation for A52.
+          related-observations:
+            - observation-uuid: 01d9488f-8cf9-4c7f-a7d0-f92870b291b9
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a52
+            type: objective-id
+          title: 'Validation Result - Control: a52'
+          uuid: c0d0fe15-1af1-4918-8704-7c1fd1455648
+      observations:
+        - collected: 2026-07-26T22:08:35.557243-04:00
+          description: |
+            [TEST]: 40037dad-ee78-523f-97dc-1f73fabf7d41 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #40037dad-ee78-523f-97dc-1f73fabf7d41: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 01d9488f-8cf9-4c7f-a7d0-f92870b291b9
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a52
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:08:35.558325-04:00
+      title: Lula Validation Result
+      uuid: 5be10e7d-f8f3-47bb-bda8-3cfeeece58a9
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: fa3a2446-e669-51fb-89d0-809f86be5882 / Implemented Requirement: 14246452-86b5-58f7-abc8-9ef7f2a9e9f1
+            Automated lula validation for TQP007 (CTRL_TQP_007).
+          related-observations:
+            - observation-uuid: 26b17332-9d4c-4b88-aa39-a7d715973a46
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: A.8.4
+            type: objective-id
+          title: 'Validation Result - Control: A.8.4'
+          uuid: ea58149a-6f16-4152-8d02-cc72edf65720
+      observations:
+        - collected: 2026-07-26T22:07:53.884257-04:00
+          description: |
+            [TEST]: 7ce8309c-ecfc-5208-ba63-f6d01d8335b0 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #7ce8309c-ecfc-5208-ba63-f6d01d8335b0: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>}]
+          uuid: 26b17332-9d4c-4b88-aa39-a7d715973a46
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: A.8.4
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:53.884374-04:00
+      title: Lula Validation Result
+      uuid: ef425a17-a8dd-45bb-a49f-2666a157ff6e
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 265c3e24-6a08-5306-8c7e-e2c1d830495f / Implemented Requirement: 41943d9b-5ead-5c8e-ace2-b07b769526ac
+            Automated lula validation for SI2.
+          related-observations:
+            - observation-uuid: 1f71fd35-81e6-4944-a2e2-5f04554f06c8
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: si2
+            type: objective-id
+          title: 'Validation Result - Control: si2'
+          uuid: f6bf10dc-ffd9-4b88-abdd-e4f093330fa1
+      observations:
+        - collected: 2026-07-26T22:07:53.629463-04:00
+          description: |
+            [TEST]: daff725b-aea0-5a5c-981e-df1a30306f2e - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #daff725b-aea0-5a5c-981e-df1a30306f2e: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>}]
+          uuid: 1f71fd35-81e6-4944-a2e2-5f04554f06c8
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: si2
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:53.629569-04:00
+      title: Lula Validation Result
+      uuid: cf483cca-5471-4e19-bc08-b4b9bbcfd194
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 2ddc6d0d-c35e-583b-b5bb-12a5a69cbca8 / Implemented Requirement: 50796b20-07f7-5904-acae-cf0e2f117f15
+            Automated lula validation for SC8.
+          related-observations:
+            - observation-uuid: ff6b52f4-eefa-4661-96a5-888ee13442f3
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: sc8
+            type: objective-id
+          title: 'Validation Result - Control: sc8'
+          uuid: 76b93dfd-0fb1-4134-acb0-33d50af1f9a6
+      observations:
+        - collected: 2026-07-26T22:07:53.371787-04:00
+          description: |
+            [TEST]: a4ff5a9e-3621-52c6-9c1f-157e6e432b5e - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #a4ff5a9e-3621-52c6-9c1f-157e6e432b5e: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/2 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/3 "missing property 'resource-rule'" <nil>}]
+          uuid: ff6b52f4-eefa-4661-96a5-888ee13442f3
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: sc8
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:53.371897-04:00
+      title: Lula Validation Result
+      uuid: 3c96fd9e-c252-4752-81c5-63009ba3fed1
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 71af40e7-a7a8-570a-a320-3c4154bea03a / Implemented Requirement: 57b3f09d-e367-5c5c-9876-82f5d837d78b
+            Automated lula validation for SC4.
+          related-observations:
+            - observation-uuid: 3740cce6-f085-4872-9686-7fc99485bdd7
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: sc4
+            type: objective-id
+          title: 'Validation Result - Control: sc4'
+          uuid: b025ceb6-2e20-450e-ad3c-f0ea8efeca90
+      observations:
+        - collected: 2026-07-26T22:07:53.115437-04:00
+          description: |
+            [TEST]: 9b6f9b2e-f19d-54a8-bd5f-47f1fbed0a22 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #9b6f9b2e-f19d-54a8-bd5f-47f1fbed0a22: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>}]
+          uuid: 3740cce6-f085-4872-9686-7fc99485bdd7
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: sc4
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:53.115543-04:00
+      title: Lula Validation Result
+      uuid: 29ce9703-9268-4646-87dd-d64d10a580cb
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 6957afe5-394b-5641-b059-4d210795dc00 / Implemented Requirement: 4647ae49-b402-5fcd-919b-8a39244aa7f6
+            Automated lula validation for RA5.
+          related-observations:
+            - observation-uuid: 1bbf3421-b08d-4bc5-8a05-e4d7729e26ee
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ra5
+            type: objective-id
+          title: 'Validation Result - Control: ra5'
+          uuid: afe70061-b924-4b3e-8ce1-63eea37f55b9
+      observations:
+        - collected: 2026-07-26T22:07:52.861451-04:00
+          description: |
+            [TEST]: 7a32a7bb-2f37-54ce-a16f-1435d2607512 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #7a32a7bb-2f37-54ce-a16f-1435d2607512: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>}]
+          uuid: 1bbf3421-b08d-4bc5-8a05-e4d7729e26ee
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ra5
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:52.861564-04:00
+      title: Lula Validation Result
+      uuid: 18e0e958-3c84-41df-8e08-34153f7243ae
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 130746b5-8e06-5793-96f5-cbb9ed0cb09e / Implemented Requirement: 41638730-fd45-5c96-a029-f3753269b01c
+            Automated lula validation for MAS TRM S6.
+          related-observations:
+            - observation-uuid: df8fdce8-6bac-45c0-b0f3-e348fc39d3e3
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: mas-trm-s6
+            type: objective-id
+          title: 'Validation Result - Control: mas-trm-s6'
+          uuid: 62971926-cdb1-4f88-a6db-ef5e691f5076
+      observations:
+        - collected: 2026-07-26T22:07:52.556409-04:00
+          description: |
+            [TEST]: 1cd75fa9-7175-5f07-a975-4eed29074d88 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #1cd75fa9-7175-5f07-a975-4eed29074d88: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: df8fdce8-6bac-45c0-b0f3-e348fc39d3e3
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.mas.gov.sg/regulation/guidelines/technology-risk-management-guidelines
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: mas-trm-s6
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:52.556527-04:00
+      title: Lula Validation Result
+      uuid: 39aa149f-49ac-4be6-9a5d-0812961c07cd
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 27475017-b615-5f28-bc86-137cebf13a3a / Implemented Requirement: 564d9d85-b2a5-5494-83d2-d06334ec06b7
+            Automated lula validation for MAS NOTICE655.
+          related-observations:
+            - observation-uuid: 2e1b158f-ffc6-4046-bdae-c72bba8f1658
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: mas-notice655
+            type: objective-id
+          title: 'Validation Result - Control: mas-notice655'
+          uuid: 34bbbfa0-3417-45ae-a22d-bc29f302be20
+      observations:
+        - collected: 2026-07-26T22:07:52.307484-04:00
+          description: |
+            [TEST]: 31845ca7-3729-5a11-8faa-028892829144 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #31845ca7-3729-5a11-8faa-028892829144: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 2e1b158f-ffc6-4046-bdae-c72bba8f1658
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://lula.dev
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: mas-notice655
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:52.307596-04:00
+      title: Lula Validation Result
+      uuid: 03e82f65-ba9f-4752-aec2-bca01006ddb9
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 350c54ef-a57a-5117-b4e1-03c257885b21 / Implemented Requirement: 241d9a37-67b7-5deb-914b-5f83e8ed68d8
+            Automated lula validation for MAS FEAT.
+          related-observations:
+            - observation-uuid: 273fd758-e210-4962-b82c-8239f9b2bee9
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: mas-feat
+            type: objective-id
+          title: 'Validation Result - Control: mas-feat'
+          uuid: 9760e3e1-4d64-4a40-af27-ed4af62581b1
+      observations:
+        - collected: 2026-07-26T22:07:52.060416-04:00
+          description: |
+            [TEST]: 44249863-3ab1-5cb0-9b6f-3a17700a71b2 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #44249863-3ab1-5cb0-9b6f-3a17700a71b2: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 273fd758-e210-4962-b82c-8239f9b2bee9
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.mas.gov.sg/regulation/guidelines/technology-risk-management-guidelines
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: mas-feat
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:52.060531-04:00
+      title: Lula Validation Result
+      uuid: 5dc90c72-486e-4f9b-af91-d9b41d72d243
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 3f2c9f85-c105-5d35-898d-e7fde67638ef / Implemented Requirement: b73bcc6c-d919-5368-bbd3-77f142eb54dd
+            Automated lula validation for ISO001 TOKEN QUOTA (ISO-001).
+          related-observations:
+            - observation-uuid: b319e9e8-eb5e-4bca-93f2-db06ae686ea0
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: A.4
+            type: objective-id
+          title: 'Validation Result - Control: A.4'
+          uuid: ef82a769-8cc5-4e4e-82a7-718c19ec3802
+      observations:
+        - collected: 2026-07-26T22:07:51.535852-04:00
+          description: |
+            [TEST]: 9c4c3db2-8fc7-5959-ba63-38e6ffd6ecc9 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #9c4c3db2-8fc7-5959-ba63-38e6ffd6ecc9: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>}]
+          uuid: b319e9e8-eb5e-4bca-93f2-db06ae686ea0
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: A.4
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:51.535987-04:00
+      title: Lula Validation Result
+      uuid: 45ed6e13-026c-49f5-812c-afce2be58cbb
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 92301774-6531-538c-ac3f-5509744b1aa0 / Implemented Requirement: 3fdd491f-1d9e-523a-a46d-07abfedf72f1
+            Automated lula validation for IR6.
+          related-observations:
+            - observation-uuid: fd81d7d2-d27f-452b-9d71-6acd43b38571
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ir6
+            type: objective-id
+          title: 'Validation Result - Control: ir6'
+          uuid: 3e0c5ef7-3e83-48d2-939f-75484059ce7b
+      observations:
+        - collected: 2026-07-26T22:07:51.288859-04:00
+          description: |
+            [TEST]: 07d356e8-2cf4-5aa3-8523-cd3e868d4367 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #07d356e8-2cf4-5aa3-8523-cd3e868d4367: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>}]
+          uuid: fd81d7d2-d27f-452b-9d71-6acd43b38571
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ir6
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:51.288968-04:00
+      title: Lula Validation Result
+      uuid: de1a7c65-0c05-44ed-9073-1ef2b0626d37
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 8ca3b5e5-0d39-5d8f-a452-020ca7259254 / Implemented Requirement: cce1fd52-f0f5-5788-9a91-ca652f102324
+            Automated lula validation for IA5.
+          related-observations:
+            - observation-uuid: ced2942e-2162-4101-ab4d-edd32207e05c
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ia5
+            type: objective-id
+          title: 'Validation Result - Control: ia5'
+          uuid: 77bf8d84-08d6-4a79-ac73-ef0190bc85dc
+      observations:
+        - collected: 2026-07-26T22:07:51.039234-04:00
+          description: |
+            [TEST]: b322b5e6-d8bd-51ab-bbf0-246a45d87b8f - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #b322b5e6-d8bd-51ab-bbf0-246a45d87b8f: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>}]
+          uuid: ced2942e-2162-4101-ab4d-edd32207e05c
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ia5
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:51.03936-04:00
+      title: Lula Validation Result
+      uuid: 41aa43ce-86ea-4aed-a92b-cec09e16d697
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: b0982882-d418-5f5f-b01c-c473cbb86fba / Implemented Requirement: a92a8532-0edd-5c5f-800e-a112ff570d38
+            Automated lula validation for IA3.
+          related-observations:
+            - observation-uuid: d0f1cec0-98ef-49c9-9543-1cf2e7188376
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ia3
+            type: objective-id
+          title: 'Validation Result - Control: ia3'
+          uuid: 9aabb6c6-974e-48dd-aa4e-f339e9e876af
+      observations:
+        - collected: 2026-07-26T22:07:50.794732-04:00
+          description: |
+            [TEST]: 976c6d03-26a0-5071-86ec-98978bdc5a7e - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #976c6d03-26a0-5071-86ec-98978bdc5a7e: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/2 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/3 "missing property 'resource-rule'" <nil>}]
+          uuid: d0f1cec0-98ef-49c9-9543-1cf2e7188376
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ia3
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:50.794844-04:00
+      title: Lula Validation Result
+      uuid: 9ca77128-6c97-49dc-99ef-bdc1e9e3fb82
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 64186a87-ffc0-514c-877e-41832df17e5c / Implemented Requirement: c7b6e46e-eac7-5499-80aa-af4dba8e104d
+            Automated lula validation for GDPR ART22.
+          related-observations:
+            - observation-uuid: 73bac68b-afb7-4e9d-9468-737bd9e9d276
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: gdpr-art22
+            type: objective-id
+          title: 'Validation Result - Control: gdpr-art22'
+          uuid: 515cbe23-a7eb-42d1-8f82-fe0c31d7ba9d
+      observations:
+        - collected: 2026-07-26T22:07:50.542738-04:00
+          description: |
+            [TEST]: 877aaff1-86c0-5e6d-a9b9-2756af2e6889 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #877aaff1-86c0-5e6d-a9b9-2756af2e6889: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 73bac68b-afb7-4e9d-9468-737bd9e9d276
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32016R0679
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: gdpr-art22
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:50.542855-04:00
+      title: Lula Validation Result
+      uuid: fcb06916-3473-4963-9c66-b21c392445c0
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 3e5c5cbb-a661-56be-9742-ed8e86fe38f9 / Implemented Requirement: e30d88ac-5dd8-5a04-b6f3-5eaf024e508e
+            Automated lula validation for EU FRIA (EU-001).
+          related-observations:
+            - observation-uuid: 7710ef64-c1c7-4d2b-90d1-2756df2f9abb
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: EU_AI_ACT_ART29A
+            type: objective-id
+          title: 'Validation Result - Control: EU_AI_ACT_ART29A'
+          uuid: c77c2c01-7e67-4031-8ee3-db047459ca86
+      observations:
+        - collected: 2026-07-26T22:07:50.29606-04:00
+          description: |
+            [TEST]: 3b422f73-7da4-5147-8c46-8abe44f82892 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #3b422f73-7da4-5147-8c46-8abe44f82892: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>}]
+          uuid: 7710ef64-c1c7-4d2b-90d1-2756df2f9abb
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://lula.dev
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: EU_AI_ACT_ART29A
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:50.296238-04:00
+      title: Lula Validation Result
+      uuid: 9e24f1e8-9273-433a-acb6-f42c21c1f088
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 58d1a2f5-47d9-594b-805f-3316a2fdc129 / Implemented Requirement: 5f274328-f25a-5a19-8d0a-4a103d341baf
+            Automated lula validation for EU AI ACT ART9.
+          related-observations:
+            - observation-uuid: 85f3a382-a0ac-4150-b87f-39abb5223048
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: eu-ai-act-art9
+            type: objective-id
+          title: 'Validation Result - Control: eu-ai-act-art9'
+          uuid: b2a8f084-7bd3-426e-b28e-e207782f715a
+      observations:
+        - collected: 2026-07-26T22:07:50.056584-04:00
+          description: |
+            [TEST]: bf519130-9b51-584d-b88c-d2357f5ab16f - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #bf519130-9b51-584d-b88c-d2357f5ab16f: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 85f3a382-a0ac-4150-b87f-39abb5223048
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32024R1689
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: eu-ai-act-art9
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:50.056702-04:00
+      title: Lula Validation Result
+      uuid: d0a13378-b58e-4a2f-b526-a3d9dd1528e2
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: b10dffbc-e2ac-5479-8b54-599f18925b3a / Implemented Requirement: d71fd848-246a-5665-9fd1-ad67cd2bc703
+            Automated lula validation for DORA ART10.
+          related-observations:
+            - observation-uuid: 61e17c92-90f5-4936-aef2-36f7a5aa3d8a
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: dora-art10
+            type: objective-id
+          title: 'Validation Result - Control: dora-art10'
+          uuid: c00670c0-6150-4b03-ab9d-5b5d3b990269
+      observations:
+        - collected: 2026-07-26T22:07:49.818897-04:00
+          description: |
+            [TEST]: eaacb9e8-bb4f-5c67-a1f2-4adb59b47eaa - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #eaacb9e8-bb4f-5c67-a1f2-4adb59b47eaa: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 61e17c92-90f5-4936-aef2-36f7a5aa3d8a
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32022R2554
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: dora-art10
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:49.81901-04:00
+      title: Lula Validation Result
+      uuid: 42d28c51-a1c0-4522-98b0-30fea482570e
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 9dec443c-138b-578d-9255-d6f67fc95c5b / Implemented Requirement: 7054ff11-50ab-5798-80b5-7f28c918da9a
+            Automated lula validation for CM6.
+          related-observations:
+            - observation-uuid: 38f4a4ec-2086-46ae-8852-f2f07b9c1fb0
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: cm6
+            type: objective-id
+          title: 'Validation Result - Control: cm6'
+          uuid: 2465d9c7-dcb5-43f3-b1da-3bf1769ff1cb
+      observations:
+        - collected: 2026-07-26T22:07:49.581513-04:00
+          description: |
+            [TEST]: d3a42dd5-3cf9-5ee5-baae-5b72ebd497ab - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #d3a42dd5-3cf9-5ee5-baae-5b72ebd497ab: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>}]
+          uuid: 38f4a4ec-2086-46ae-8852-f2f07b9c1fb0
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: cm6
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:49.581619-04:00
+      title: Lula Validation Result
+      uuid: f40f39ee-e92b-4dc1-89a7-a1ccef0c39d5
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 257ab77e-1020-5595-a07b-a8ae59511c0d / Implemented Requirement: 4405db85-a4ec-513f-bc34-161e9935bf04
+            Automated lula validation for AU12.
+          related-observations:
+            - observation-uuid: 88ec3eeb-ad3b-43b6-84f9-c20dee5dba22
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: au12
+            type: objective-id
+          title: 'Validation Result - Control: au12'
+          uuid: 783e0cf0-758c-4641-81e6-3efee5603142
+      observations:
+        - collected: 2026-07-26T22:07:49.347901-04:00
+          description: |
+            [TEST]: 610ee241-76a3-5f1f-b41d-613019559b15 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #610ee241-76a3-5f1f-b41d-613019559b15: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>}]
+          uuid: 88ec3eeb-ad3b-43b6-84f9-c20dee5dba22
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: au12
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:49.348008-04:00
+      title: Lula Validation Result
+      uuid: a6433666-9d2d-4b6f-be34-f3bbc8028ffb
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 119840ef-2fa9-4bed-8cac-7a5e6a5d81dd / Implemented Requirement: 3ec272e8-651b-4ece-9d16-3a2b5f0c2425
+            Phase-0 stub for AI 600-1 §2.3 prompt injection / data poisoning controls.
+          related-observations:
+            - observation-uuid: 8c6fa6c4-cd0e-466b-a41c-8f9382fc5db9
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ai600-prompt-injection
+            type: objective-id
+          title: 'Validation Result - Control: ai600-prompt-injection'
+          uuid: 6b4fb8b0-7447-4b33-8ee5-b8654f84c1de
+      observations:
+        - collected: 2026-07-26T22:07:49.110475-04:00
+          description: |
+            [TEST]: 8dfec2ec-e9b1-41fe-9b84-91f851874621 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #8dfec2ec-e9b1-41fe-9b84-91f851874621: schema is invalid: [{/properties/domain/$ref/allOf/1/then/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/domain/allOf/1/then/required /domain "missing property 'kubernetes-spec'" <nil>}]
+          uuid: 8c6fa6c4-cd0e-466b-a41c-8f9382fc5db9
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://airc.nist.gov/Docs/1
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ai600-prompt-injection
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:49.110603-04:00
+      title: Lula Validation Result
+      uuid: b87e0e03-1ac9-4bca-b5fd-69a60f352184
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 312cc965-a1d8-4703-8d23-be38546aa60f / Implemented Requirement: 06a58dcc-ca7b-46ac-8a3a-175eac3cb336
+            Phase-0 stub for AI 600-1 §2.5 human-AI configuration controls.
+          related-observations:
+            - observation-uuid: 9bfc9f1e-16c2-4847-80a7-fb410706532c
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ai600-human-ai-config
+            type: objective-id
+          title: 'Validation Result - Control: ai600-human-ai-config'
+          uuid: 02b76cd9-1dab-4281-8031-1794aeb2c96f
+      observations:
+        - collected: 2026-07-26T22:07:48.86466-04:00
+          description: |
+            [TEST]: f64407ae-70e5-462c-9cea-4c065667c31f - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #f64407ae-70e5-462c-9cea-4c065667c31f: schema is invalid: [{/properties/domain/$ref/allOf/1/then/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/domain/allOf/1/then/required /domain "missing property 'kubernetes-spec'" <nil>}]
+          uuid: 9bfc9f1e-16c2-4847-80a7-fb410706532c
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://airc.nist.gov/Docs/1
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ai600-human-ai-config
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:48.864784-04:00
+      title: Lula Validation Result
+      uuid: 8e89fe2b-42e2-4232-be30-bcf87fd260a5
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 36e6e16a-a854-4ced-87a9-2b017580b199 / Implemented Requirement: 2c91e53d-5ec2-4223-99d3-be7dfce07fbc
+            Phase-0 stub for AI 600-1 §2.2 data privacy controls.
+          related-observations:
+            - observation-uuid: 53b928d8-7568-43b6-8497-f89c99ee6dbf
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ai600-data-privacy
+            type: objective-id
+          title: 'Validation Result - Control: ai600-data-privacy'
+          uuid: 4cdfb5b0-2b59-4e87-b482-e25a625681a9
+      observations:
+        - collected: 2026-07-26T22:07:48.608219-04:00
+          description: |
+            [TEST]: d6734f08-028c-4170-a796-6a63a2beb311 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #d6734f08-028c-4170-a796-6a63a2beb311: schema is invalid: [{/properties/domain/$ref/allOf/1/then/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/domain/allOf/1/then/required /domain "missing property 'kubernetes-spec'" <nil>}]
+          uuid: 53b928d8-7568-43b6-8497-f89c99ee6dbf
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://airc.nist.gov/Docs/1
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ai600-data-privacy
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:48.609064-04:00
+      title: Lula Validation Result
+      uuid: 7e717de1-da43-456c-9393-dc37aecd3a3b
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 5e579bed-cae9-486d-a40c-e9bb88328405 / Implemented Requirement: 28838c8d-8386-4bb7-8d75-98ace7480441
+            Phase-0 stub for AI 600-1 §2.1 confabulation controls.
+          related-observations:
+            - observation-uuid: a1366af7-b201-4829-a4f0-cdbea7b353ce
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ai600-confabulation
+            type: objective-id
+          title: 'Validation Result - Control: ai600-confabulation'
+          uuid: 6e562ebf-0cea-499e-a0f8-c6bc45f519f2
+      observations:
+        - collected: 2026-07-26T22:07:48.359524-04:00
+          description: |
+            [TEST]: fedddcdb-2789-4575-9b7e-dbaca5ccb90f - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #fedddcdb-2789-4575-9b7e-dbaca5ccb90f: schema is invalid: [{/properties/domain/$ref/allOf/1/then/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/domain/allOf/1/then/required /domain "missing property 'kubernetes-spec'" <nil>}]
+          uuid: a1366af7-b201-4829-a4f0-cdbea7b353ce
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://airc.nist.gov/Docs/1
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ai600-confabulation
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:48.35965-04:00
+      title: Lula Validation Result
+      uuid: 5768a19d-f90c-442e-8825-19cd3b88182b
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 4e1574ab-8b13-4b48-b8bc-20daeb93e0ad / Implemented Requirement: fd641f71-329b-41db-83ce-9d2dc1e57c04
+            Phase-0 stub for AI 600-1 §2.6 CBRN harmful content controls.
+          related-observations:
+            - observation-uuid: 19f66c5f-947b-4435-b48b-6b5aec053f02
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ai600-cbrn
+            type: objective-id
+          title: 'Validation Result - Control: ai600-cbrn'
+          uuid: 345f0609-79d2-4e0b-997c-d35bb74b3f53
+      observations:
+        - collected: 2026-07-26T22:07:48.126945-04:00
+          description: |
+            [TEST]: ab3e9842-b66a-4e1e-b518-2d47937ee8e8 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #ab3e9842-b66a-4e1e-b518-2d47937ee8e8: schema is invalid: [{/properties/domain/$ref/allOf/1/then/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/domain/allOf/1/then/required /domain "missing property 'kubernetes-spec'" <nil>}]
+          uuid: 19f66c5f-947b-4435-b48b-6b5aec053f02
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://airc.nist.gov/Docs/1
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ai600-cbrn
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:48.127062-04:00
+      title: Lula Validation Result
+      uuid: a927e773-9c88-40ec-819e-9df8002c570f
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: b8efdf73-2801-5ce0-a588-b486e87bd490 / Implemented Requirement: dc9af4f2-aeef-55ae-ac99-95eeed7f3521
+            Automated lula validation for AC3.
+          related-observations:
+            - observation-uuid: 57fe78c2-3366-4a21-a257-f6aef2531937
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ac3
+            type: objective-id
+          title: 'Validation Result - Control: ac3'
+          uuid: 8a900ef8-05a2-4fab-a3af-e77b987b6989
+      observations:
+        - collected: 2026-07-26T22:07:47.891904-04:00
+          description: |
+            [TEST]: 73f98590-b9c9-52da-bfac-27cf03ae46af - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #73f98590-b9c9-52da-bfac-27cf03ae46af: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>}]
+          uuid: 57fe78c2-3366-4a21-a257-f6aef2531937
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ac3
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:47.892013-04:00
+      title: Lula Validation Result
+      uuid: 8fca6f84-5be6-4d82-adc8-4e41b2e019a1
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 22ce9e77-15c9-5ba5-9d91-a0b0191ebb44 / Implemented Requirement: 18e5a104-64e5-58d5-b8c4-dcd91b3878ce
+            Automated lula validation for AC2.
+          related-observations:
+            - observation-uuid: 3cc720ca-7f97-484f-8fc9-4a8a76a60c0a
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ac2
+            type: objective-id
+          title: 'Validation Result - Control: ac2'
+          uuid: 25aa9f5f-2eef-4bbd-ab4b-f7c473990abf
+      observations:
+        - collected: 2026-07-26T22:07:47.641642-04:00
+          description: |
+            [TEST]: 1fcd8ff2-3d20-5d34-a450-0f78901b8039 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #1fcd8ff2-3d20-5d34-a450-0f78901b8039: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>}]
+          uuid: 3cc720ca-7f97-484f-8fc9-4a8a76a60c0a
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ac2
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:47.641752-04:00
+      title: Lula Validation Result
+      uuid: 9398cd7c-9917-4a8e-a56c-2c5f84157131
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: a3697688-6e46-5205-910e-22c7b44f6bdd / Implemented Requirement: 6915c619-071a-51ea-a57f-60232a68751d
+            Automated lula validation for AARM VECTORS.
+          related-observations:
+            - observation-uuid: ed27b05f-8894-4579-b8f6-c0f054226421
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: aarm-vectors
+            type: objective-id
+          title: 'Validation Result - Control: aarm-vectors'
+          uuid: 138a6786-d4cc-4787-9ab9-a9a80bcc8dc8
+      observations:
+        - collected: 2026-07-26T22:07:47.40688-04:00
+          description: |
+            [TEST]: ec32ba67-e5a7-50b4-8ff5-eca8aac8da66 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #ec32ba67-e5a7-50b4-8ff5-eca8aac8da66: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: ed27b05f-8894-4579-b8f6-c0f054226421
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://cloudsecurityalliance.org/research/working-groups/artificial-intelligence
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: aarm-vectors
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:47.406997-04:00
+      title: Lula Validation Result
+      uuid: 2fe687c8-5bf2-44f7-aaf3-becfba72a786
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 11a88f5e-1f94-5774-94b9-617f7870e62a / Implemented Requirement: 4332a913-0441-5d14-8df5-ba79df3749d5
+            Automated lula validation for A92.
+          related-observations:
+            - observation-uuid: ab091485-c58d-46ae-a8ee-e299a17b770b
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a92
+            type: objective-id
+          title: 'Validation Result - Control: a92'
+          uuid: 4369929d-9f6f-45fe-bbce-030a59998a4d
+      observations:
+        - collected: 2026-07-26T22:07:47.178844-04:00
+          description: |
+            [TEST]: 189e411a-b3fb-5db2-b787-349693054e29 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #189e411a-b3fb-5db2-b787-349693054e29: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: ab091485-c58d-46ae-a8ee-e299a17b770b
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a92
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:47.178949-04:00
+      title: Lula Validation Result
+      uuid: f6e8c0c3-5c6f-4fc0-8e66-8a99b5e2f04b
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 1ece732e-9180-52e4-a04d-bb92f5e01929 / Implemented Requirement: 76dea904-7d5c-53b3-b5d8-2c31702ff8ca
+            Automated lula validation for A53.
+          related-observations:
+            - observation-uuid: c565d1f6-e7d4-4ffb-924e-75e599161e13
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a53
+            type: objective-id
+          title: 'Validation Result - Control: a53'
+          uuid: 7b1cb474-2465-4000-92be-598bf0285da9
+      observations:
+        - collected: 2026-07-26T22:07:46.948399-04:00
+          description: |
+            [TEST]: eb760977-813f-5999-af3f-dcd76b48c7aa - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #eb760977-813f-5999-af3f-dcd76b48c7aa: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: c565d1f6-e7d4-4ffb-924e-75e599161e13
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a53
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:46.948508-04:00
+      title: Lula Validation Result
+      uuid: daf8dd2b-2d53-4005-aac8-585e90e1eb40
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: aa0f365e-7e2d-538a-95d1-c994b78ff302 / Implemented Requirement: 6a8eb074-850a-57b0-8198-0b7a929b92b1
+            Automated lula validation for A52.
+          related-observations:
+            - observation-uuid: 577731d4-7a5b-45d0-b88a-52e854feeaad
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a52
+            type: objective-id
+          title: 'Validation Result - Control: a52'
+          uuid: a7e08afa-143b-4905-ba1f-81862292814e
+      observations:
+        - collected: 2026-07-26T22:07:46.705854-04:00
+          description: |
+            [TEST]: 40037dad-ee78-523f-97dc-1f73fabf7d41 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #40037dad-ee78-523f-97dc-1f73fabf7d41: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 577731d4-7a5b-45d0-b88a-52e854feeaad
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a52
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T22:07:46.707036-04:00
+      title: Lula Validation Result
+      uuid: ccdcc3da-20ba-426f-9006-dcd1387d9a7a
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 350c54ef-a57a-5117-b4e1-03c257885b21 / Implemented Requirement: 241d9a37-67b7-5deb-914b-5f83e8ed68d8
+            Automated lula validation for MAS FEAT.
+          related-observations:
+            - observation-uuid: e83877c3-c7e7-4aba-b527-f9522daee985
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: mas-feat
+            type: objective-id
+          title: 'Validation Result - Control: mas-feat'
+          uuid: 1878ae18-a414-41f1-92b5-15f6b8393c34
+      observations:
+        - collected: 2026-07-26T21:52:56.376031-04:00
+          description: |
+            [TEST]: 44249863-3ab1-5cb0-9b6f-3a17700a71b2 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #44249863-3ab1-5cb0-9b6f-3a17700a71b2: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: e83877c3-c7e7-4aba-b527-f9522daee985
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.mas.gov.sg/regulation/guidelines/technology-risk-management-guidelines
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: mas-feat
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:52:56.376138-04:00
+      title: Lula Validation Result
+      uuid: 9f2cd416-fdbc-4709-bb5c-58332b808d76
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: a3697688-6e46-5205-910e-22c7b44f6bdd / Implemented Requirement: 6915c619-071a-51ea-a57f-60232a68751d
+            Automated lula validation for AARM VECTORS.
+          related-observations:
+            - observation-uuid: 1119cc60-8b37-4ac6-b270-53deee224eb7
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: aarm-vectors
+            type: objective-id
+          title: 'Validation Result - Control: aarm-vectors'
+          uuid: 9c4e1ee9-9966-4ddc-8c9f-b37794f02453
+      observations:
+        - collected: 2026-07-26T21:52:56.152263-04:00
+          description: |
+            [TEST]: ec32ba67-e5a7-50b4-8ff5-eca8aac8da66 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #ec32ba67-e5a7-50b4-8ff5-eca8aac8da66: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 1119cc60-8b37-4ac6-b270-53deee224eb7
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://cloudsecurityalliance.org/research/working-groups/artificial-intelligence
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: aarm-vectors
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:52:56.152381-04:00
+      title: Lula Validation Result
+      uuid: e34dfefc-c4d3-4e87-a839-b10bc3e8bbd7
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 11a88f5e-1f94-5774-94b9-617f7870e62a / Implemented Requirement: 4332a913-0441-5d14-8df5-ba79df3749d5
+            Automated lula validation for A92.
+          related-observations:
+            - observation-uuid: e7a63826-206e-410d-a9ef-8b49ca547798
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a92
+            type: objective-id
+          title: 'Validation Result - Control: a92'
+          uuid: 406c77b4-fc8c-4086-b6de-44d50a93de3e
+      observations:
+        - collected: 2026-07-26T21:52:55.926596-04:00
+          description: |
+            [TEST]: 189e411a-b3fb-5db2-b787-349693054e29 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #189e411a-b3fb-5db2-b787-349693054e29: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: e7a63826-206e-410d-a9ef-8b49ca547798
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a92
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:52:55.926759-04:00
+      title: Lula Validation Result
+      uuid: 300373b2-2879-4048-8735-a8cf45050dbe
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 1ece732e-9180-52e4-a04d-bb92f5e01929 / Implemented Requirement: 76dea904-7d5c-53b3-b5d8-2c31702ff8ca
+            Automated lula validation for A53.
+          related-observations:
+            - observation-uuid: 1943593e-2ee8-43c7-a3da-4e79739313b7
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a53
+            type: objective-id
+          title: 'Validation Result - Control: a53'
+          uuid: a96091a0-1eec-4b8a-82cc-c6cd33a9e03c
+      observations:
+        - collected: 2026-07-26T21:52:55.703798-04:00
+          description: |
+            [TEST]: eb760977-813f-5999-af3f-dcd76b48c7aa - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #eb760977-813f-5999-af3f-dcd76b48c7aa: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 1943593e-2ee8-43c7-a3da-4e79739313b7
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a53
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:52:55.703909-04:00
+      title: Lula Validation Result
+      uuid: 551f6e34-8415-4ef4-a35a-9a1f35902f8f
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: aa0f365e-7e2d-538a-95d1-c994b78ff302 / Implemented Requirement: 6a8eb074-850a-57b0-8198-0b7a929b92b1
+            Automated lula validation for A52.
+          related-observations:
+            - observation-uuid: 483a4fe8-b78b-43c2-959a-7fa441e4435c
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a52
+            type: objective-id
+          title: 'Validation Result - Control: a52'
+          uuid: 66c2d2dc-d9ec-43e4-bc5c-5c606ae53407
+      observations:
+        - collected: 2026-07-26T21:52:55.474413-04:00
+          description: |
+            [TEST]: 40037dad-ee78-523f-97dc-1f73fabf7d41 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #40037dad-ee78-523f-97dc-1f73fabf7d41: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 483a4fe8-b78b-43c2-959a-7fa441e4435c
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a52
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:52:55.475464-04:00
+      title: Lula Validation Result
+      uuid: 29695b98-744e-42aa-98ef-ce37da15f78e
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: a3697688-6e46-5205-910e-22c7b44f6bdd / Implemented Requirement: 6915c619-071a-51ea-a57f-60232a68751d
+            Automated lula validation for AARM VECTORS.
+          related-observations:
+            - observation-uuid: 6fb5a0d5-d10b-49c8-b3a7-5ada84f9714d
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: aarm-vectors
+            type: objective-id
+          title: 'Validation Result - Control: aarm-vectors'
+          uuid: 02229576-5e45-4f55-8e08-46f5c39f96ee
+      observations:
+        - collected: 2026-07-26T21:52:06.409984-04:00
+          description: |
+            [TEST]: ec32ba67-e5a7-50b4-8ff5-eca8aac8da66 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #ec32ba67-e5a7-50b4-8ff5-eca8aac8da66: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 6fb5a0d5-d10b-49c8-b3a7-5ada84f9714d
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://cloudsecurityalliance.org/research/working-groups/artificial-intelligence
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: aarm-vectors
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:52:06.410197-04:00
+      title: Lula Validation Result
+      uuid: 76c8f9fa-e386-4de4-b414-e88971efb54e
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 11a88f5e-1f94-5774-94b9-617f7870e62a / Implemented Requirement: 4332a913-0441-5d14-8df5-ba79df3749d5
+            Automated lula validation for A92.
+          related-observations:
+            - observation-uuid: 25939bef-411c-4191-8cc6-933f0b7338da
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a92
+            type: objective-id
+          title: 'Validation Result - Control: a92'
+          uuid: 38497f42-261f-4043-98c0-0a445825a7e8
+      observations:
+        - collected: 2026-07-26T21:52:06.190464-04:00
+          description: |
+            [TEST]: 189e411a-b3fb-5db2-b787-349693054e29 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #189e411a-b3fb-5db2-b787-349693054e29: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 25939bef-411c-4191-8cc6-933f0b7338da
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a92
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:52:06.190571-04:00
+      title: Lula Validation Result
+      uuid: a959a0d1-099b-4c33-abb6-694b5ed52ba4
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 1ece732e-9180-52e4-a04d-bb92f5e01929 / Implemented Requirement: 76dea904-7d5c-53b3-b5d8-2c31702ff8ca
+            Automated lula validation for A53.
+          related-observations:
+            - observation-uuid: 452d63b9-a0bd-44dc-bc58-f75697b046f4
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a53
+            type: objective-id
+          title: 'Validation Result - Control: a53'
+          uuid: b5645f15-eefe-4227-9172-b58ca1844f2e
+      observations:
+        - collected: 2026-07-26T21:52:05.972096-04:00
+          description: |
+            [TEST]: eb760977-813f-5999-af3f-dcd76b48c7aa - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #eb760977-813f-5999-af3f-dcd76b48c7aa: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 452d63b9-a0bd-44dc-bc58-f75697b046f4
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a53
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:52:05.972208-04:00
+      title: Lula Validation Result
+      uuid: b0775d67-90e3-46bd-bf0c-fedddf0ebf64
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: aa0f365e-7e2d-538a-95d1-c994b78ff302 / Implemented Requirement: 6a8eb074-850a-57b0-8198-0b7a929b92b1
+            Automated lula validation for A52.
+          related-observations:
+            - observation-uuid: 5bd6dbe5-f36c-43a7-968c-ba62b9f72209
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a52
+            type: objective-id
+          title: 'Validation Result - Control: a52'
+          uuid: 71b8c4a9-f579-46e6-9a49-a480994e00fd
+      observations:
+        - collected: 2026-07-26T21:52:05.750088-04:00
+          description: |
+            [TEST]: 40037dad-ee78-523f-97dc-1f73fabf7d41 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #40037dad-ee78-523f-97dc-1f73fabf7d41: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 5bd6dbe5-f36c-43a7-968c-ba62b9f72209
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a52
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:52:05.751156-04:00
+      title: Lula Validation Result
+      uuid: 80577e06-87c3-4e94-98f0-c32f5032d5cf
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: a3697688-6e46-5205-910e-22c7b44f6bdd / Implemented Requirement: 6915c619-071a-51ea-a57f-60232a68751d
+            Automated lula validation for AARM VECTORS.
+          related-observations:
+            - observation-uuid: 738b477e-6774-41aa-b2ae-bfa827062de7
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: aarm-vectors
+            type: objective-id
+          title: 'Validation Result - Control: aarm-vectors'
+          uuid: 52e32877-7dfc-4dec-83fb-9d5bf05a4397
+      observations:
+        - collected: 2026-07-26T21:51:12.144979-04:00
+          description: |
+            [TEST]: ec32ba67-e5a7-50b4-8ff5-eca8aac8da66 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #ec32ba67-e5a7-50b4-8ff5-eca8aac8da66: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 738b477e-6774-41aa-b2ae-bfa827062de7
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://cloudsecurityalliance.org/research/working-groups/artificial-intelligence
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: aarm-vectors
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:51:12.145102-04:00
+      title: Lula Validation Result
+      uuid: 79574f40-c441-4de8-95c9-57acf79a6ee8
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 11a88f5e-1f94-5774-94b9-617f7870e62a / Implemented Requirement: 4332a913-0441-5d14-8df5-ba79df3749d5
+            Automated lula validation for A92.
+          related-observations:
+            - observation-uuid: f227b750-b58d-48ba-afde-f112bee6cab0
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a92
+            type: objective-id
+          title: 'Validation Result - Control: a92'
+          uuid: 38b53637-cb9c-4f4a-9bc5-e6d6a6eb9062
+      observations:
+        - collected: 2026-07-26T21:51:11.930212-04:00
+          description: |
+            [TEST]: 189e411a-b3fb-5db2-b787-349693054e29 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #189e411a-b3fb-5db2-b787-349693054e29: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: f227b750-b58d-48ba-afde-f112bee6cab0
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a92
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:51:11.930323-04:00
+      title: Lula Validation Result
+      uuid: 8c4cad21-c4c9-4be3-9318-09db9f283cf5
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 1ece732e-9180-52e4-a04d-bb92f5e01929 / Implemented Requirement: 76dea904-7d5c-53b3-b5d8-2c31702ff8ca
+            Automated lula validation for A53.
+          related-observations:
+            - observation-uuid: 1980ffeb-b53c-4801-9069-f5dea81f79e6
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a53
+            type: objective-id
+          title: 'Validation Result - Control: a53'
+          uuid: e929a8e0-a57d-4cb1-b06d-e015dfe4c94b
+      observations:
+        - collected: 2026-07-26T21:51:11.716197-04:00
+          description: |
+            [TEST]: eb760977-813f-5999-af3f-dcd76b48c7aa - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #eb760977-813f-5999-af3f-dcd76b48c7aa: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 1980ffeb-b53c-4801-9069-f5dea81f79e6
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a53
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:51:11.716303-04:00
+      title: Lula Validation Result
+      uuid: 116738eb-94cf-4f98-ba44-92a8a45cd1f8
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: aa0f365e-7e2d-538a-95d1-c994b78ff302 / Implemented Requirement: 6a8eb074-850a-57b0-8198-0b7a929b92b1
+            Automated lula validation for A52.
+          related-observations:
+            - observation-uuid: 76481c18-1f6a-41a4-84f7-5fde210c5bb8
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a52
+            type: objective-id
+          title: 'Validation Result - Control: a52'
+          uuid: 02aff830-11c4-4397-b20f-36f0d8da241a
+      observations:
+        - collected: 2026-07-26T21:51:11.500332-04:00
+          description: |
+            [TEST]: 40037dad-ee78-523f-97dc-1f73fabf7d41 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #40037dad-ee78-523f-97dc-1f73fabf7d41: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 76481c18-1f6a-41a4-84f7-5fde210c5bb8
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a52
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:51:11.501413-04:00
+      title: Lula Validation Result
+      uuid: 4f612617-86fb-46c2-92e9-50bb7363fc03
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: a3697688-6e46-5205-910e-22c7b44f6bdd / Implemented Requirement: 6915c619-071a-51ea-a57f-60232a68751d
+            Automated lula validation for AARM VECTORS.
+          related-observations:
+            - observation-uuid: 5357da5f-6a17-42a8-9ea4-3109225110e8
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: aarm-vectors
+            type: objective-id
+          title: 'Validation Result - Control: aarm-vectors'
+          uuid: 72b64f4c-1995-4c72-87e1-c1fb6d8410b3
+      observations:
+        - collected: 2026-07-26T21:49:48.689752-04:00
+          description: |
+            [TEST]: ec32ba67-e5a7-50b4-8ff5-eca8aac8da66 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #ec32ba67-e5a7-50b4-8ff5-eca8aac8da66: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 5357da5f-6a17-42a8-9ea4-3109225110e8
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://cloudsecurityalliance.org/research/working-groups/artificial-intelligence
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: aarm-vectors
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:49:48.689865-04:00
+      title: Lula Validation Result
+      uuid: 692db171-f421-426a-a13f-f634d03f07fc
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 11a88f5e-1f94-5774-94b9-617f7870e62a / Implemented Requirement: 4332a913-0441-5d14-8df5-ba79df3749d5
+            Automated lula validation for A92.
+          related-observations:
+            - observation-uuid: 338f82e5-808d-4eb7-bf77-6e76cc3044b0
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a92
+            type: objective-id
+          title: 'Validation Result - Control: a92'
+          uuid: a5d21df6-30ac-4e7f-9d66-bf63a858eab1
+      observations:
+        - collected: 2026-07-26T21:49:48.474412-04:00
+          description: |
+            [TEST]: 189e411a-b3fb-5db2-b787-349693054e29 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #189e411a-b3fb-5db2-b787-349693054e29: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 338f82e5-808d-4eb7-bf77-6e76cc3044b0
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a92
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:49:48.474529-04:00
+      title: Lula Validation Result
+      uuid: 56593656-78a1-43d8-a108-5bfe5f900969
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 1ece732e-9180-52e4-a04d-bb92f5e01929 / Implemented Requirement: 76dea904-7d5c-53b3-b5d8-2c31702ff8ca
+            Automated lula validation for A53.
+          related-observations:
+            - observation-uuid: 6925a3eb-46ab-4675-ab41-bb2f19246d35
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a53
+            type: objective-id
+          title: 'Validation Result - Control: a53'
+          uuid: cd275026-e10b-4498-a2f9-55fb923b0ac6
+      observations:
+        - collected: 2026-07-26T21:49:48.262686-04:00
+          description: |
+            [TEST]: eb760977-813f-5999-af3f-dcd76b48c7aa - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #eb760977-813f-5999-af3f-dcd76b48c7aa: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 6925a3eb-46ab-4675-ab41-bb2f19246d35
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a53
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:49:48.262803-04:00
+      title: Lula Validation Result
+      uuid: bff86414-4d1c-4cc0-996d-0cb971f49b8b
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: aa0f365e-7e2d-538a-95d1-c994b78ff302 / Implemented Requirement: 6a8eb074-850a-57b0-8198-0b7a929b92b1
+            Automated lula validation for A52.
+          related-observations:
+            - observation-uuid: d48f0acd-351f-4a6d-9ff5-b57a83072823
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a52
+            type: objective-id
+          title: 'Validation Result - Control: a52'
+          uuid: b9c1bc33-6f6a-4094-8ff1-cd9c17506482
+      observations:
+        - collected: 2026-07-26T21:49:48.045578-04:00
+          description: |
+            [TEST]: 40037dad-ee78-523f-97dc-1f73fabf7d41 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #40037dad-ee78-523f-97dc-1f73fabf7d41: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: d48f0acd-351f-4a6d-9ff5-b57a83072823
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a52
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:49:48.046669-04:00
+      title: Lula Validation Result
+      uuid: 89de87fa-ec61-4bf1-a53a-2bcaa5faefd1
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 350c54ef-a57a-5117-b4e1-03c257885b21 / Implemented Requirement: 241d9a37-67b7-5deb-914b-5f83e8ed68d8
+            Automated lula validation for MAS FEAT.
+          related-observations:
+            - observation-uuid: 7d55345d-da7b-4b52-af44-75f359a32433
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: mas-feat
+            type: objective-id
+          title: 'Validation Result - Control: mas-feat'
+          uuid: e614125e-c816-4b88-b6ac-0ee73d16e5b9
+      observations:
+        - collected: 2026-07-26T21:39:36.991241-04:00
+          description: |
+            [TEST]: 44249863-3ab1-5cb0-9b6f-3a17700a71b2 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #44249863-3ab1-5cb0-9b6f-3a17700a71b2: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 7d55345d-da7b-4b52-af44-75f359a32433
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.mas.gov.sg/regulation/guidelines/technology-risk-management-guidelines
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: mas-feat
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:39:36.991349-04:00
+      title: Lula Validation Result
+      uuid: dc5b709d-6a48-4905-b458-efc3a1d7c4a9
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: a3697688-6e46-5205-910e-22c7b44f6bdd / Implemented Requirement: 6915c619-071a-51ea-a57f-60232a68751d
+            Automated lula validation for AARM VECTORS.
+          related-observations:
+            - observation-uuid: 7d33df84-ed3c-4ac1-8d62-12a66ec4efe4
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: aarm-vectors
+            type: objective-id
+          title: 'Validation Result - Control: aarm-vectors'
+          uuid: c3146175-0178-4325-9204-8d5698ecc978
+      observations:
+        - collected: 2026-07-26T21:39:36.756294-04:00
+          description: |
+            [TEST]: ec32ba67-e5a7-50b4-8ff5-eca8aac8da66 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #ec32ba67-e5a7-50b4-8ff5-eca8aac8da66: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 7d33df84-ed3c-4ac1-8d62-12a66ec4efe4
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://cloudsecurityalliance.org/research/working-groups/artificial-intelligence
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: aarm-vectors
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:39:36.756412-04:00
+      title: Lula Validation Result
+      uuid: ad7ed074-b9df-4fc2-851b-ba75ebf6c5fb
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 11a88f5e-1f94-5774-94b9-617f7870e62a / Implemented Requirement: 4332a913-0441-5d14-8df5-ba79df3749d5
+            Automated lula validation for A92.
+          related-observations:
+            - observation-uuid: f7a2d576-299e-4ea1-b053-d308a07ba1bc
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a92
+            type: objective-id
+          title: 'Validation Result - Control: a92'
+          uuid: e29949c4-401c-4f36-80dc-8a9b909d856d
+      observations:
+        - collected: 2026-07-26T21:39:36.532165-04:00
+          description: |
+            [TEST]: 189e411a-b3fb-5db2-b787-349693054e29 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #189e411a-b3fb-5db2-b787-349693054e29: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: f7a2d576-299e-4ea1-b053-d308a07ba1bc
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a92
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:39:36.532278-04:00
+      title: Lula Validation Result
+      uuid: a870021d-565f-4129-80cf-862774ca2602
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 1ece732e-9180-52e4-a04d-bb92f5e01929 / Implemented Requirement: 76dea904-7d5c-53b3-b5d8-2c31702ff8ca
+            Automated lula validation for A53.
+          related-observations:
+            - observation-uuid: e6655e27-b7f8-454c-9a9a-3a54a0f1e5a8
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a53
+            type: objective-id
+          title: 'Validation Result - Control: a53'
+          uuid: bd76fcd2-b484-42dd-bcc2-a598fa96c8dc
+      observations:
+        - collected: 2026-07-26T21:39:36.319693-04:00
+          description: |
+            [TEST]: eb760977-813f-5999-af3f-dcd76b48c7aa - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #eb760977-813f-5999-af3f-dcd76b48c7aa: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: e6655e27-b7f8-454c-9a9a-3a54a0f1e5a8
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a53
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:39:36.319801-04:00
+      title: Lula Validation Result
+      uuid: d9abda67-9164-442c-8c4d-e9389429da0d
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: aa0f365e-7e2d-538a-95d1-c994b78ff302 / Implemented Requirement: 6a8eb074-850a-57b0-8198-0b7a929b92b1
+            Automated lula validation for A52.
+          related-observations:
+            - observation-uuid: d1de39e0-ba8e-46e1-958f-a21aeb06c3e8
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a52
+            type: objective-id
+          title: 'Validation Result - Control: a52'
+          uuid: 26da305f-6e60-4687-acb0-38a6b6ccd145
+      observations:
+        - collected: 2026-07-26T21:39:36.101353-04:00
+          description: |
+            [TEST]: 40037dad-ee78-523f-97dc-1f73fabf7d41 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #40037dad-ee78-523f-97dc-1f73fabf7d41: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: d1de39e0-ba8e-46e1-958f-a21aeb06c3e8
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a52
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:39:36.102322-04:00
+      title: Lula Validation Result
+      uuid: ea68c869-252b-4bcf-a284-f01deb25a843
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: a3697688-6e46-5205-910e-22c7b44f6bdd / Implemented Requirement: 6915c619-071a-51ea-a57f-60232a68751d
+            Automated lula validation for AARM VECTORS.
+          related-observations:
+            - observation-uuid: 83506e92-4cf6-4828-95c3-e14f6db63079
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: aarm-vectors
+            type: objective-id
+          title: 'Validation Result - Control: aarm-vectors'
+          uuid: 118a7651-7c96-4900-8a01-bfb2215f63c1
+      observations:
+        - collected: 2026-07-26T21:38:48.402856-04:00
+          description: |
+            [TEST]: ec32ba67-e5a7-50b4-8ff5-eca8aac8da66 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #ec32ba67-e5a7-50b4-8ff5-eca8aac8da66: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 83506e92-4cf6-4828-95c3-e14f6db63079
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://cloudsecurityalliance.org/research/working-groups/artificial-intelligence
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: aarm-vectors
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:38:48.402973-04:00
+      title: Lula Validation Result
+      uuid: b16d51a6-246a-4ebd-bf00-5ee7f8739f6c
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 11a88f5e-1f94-5774-94b9-617f7870e62a / Implemented Requirement: 4332a913-0441-5d14-8df5-ba79df3749d5
+            Automated lula validation for A92.
+          related-observations:
+            - observation-uuid: 306d1a87-f41e-40ee-a0dd-22826e719bff
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a92
+            type: objective-id
+          title: 'Validation Result - Control: a92'
+          uuid: 12cf6d04-9ef9-479c-940b-897f95ee9661
+      observations:
+        - collected: 2026-07-26T21:38:48.179243-04:00
+          description: |
+            [TEST]: 189e411a-b3fb-5db2-b787-349693054e29 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #189e411a-b3fb-5db2-b787-349693054e29: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 306d1a87-f41e-40ee-a0dd-22826e719bff
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a92
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:38:48.179358-04:00
+      title: Lula Validation Result
+      uuid: 0e8926c5-d0b4-4433-9204-85d0491c3994
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 1ece732e-9180-52e4-a04d-bb92f5e01929 / Implemented Requirement: 76dea904-7d5c-53b3-b5d8-2c31702ff8ca
+            Automated lula validation for A53.
+          related-observations:
+            - observation-uuid: f51d151a-305a-4b74-92be-66fb9cda9336
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a53
+            type: objective-id
+          title: 'Validation Result - Control: a53'
+          uuid: 32e93ca7-2423-47b4-979a-06d1e4453c9e
+      observations:
+        - collected: 2026-07-26T21:38:47.963645-04:00
+          description: |
+            [TEST]: eb760977-813f-5999-af3f-dcd76b48c7aa - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #eb760977-813f-5999-af3f-dcd76b48c7aa: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: f51d151a-305a-4b74-92be-66fb9cda9336
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a53
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:38:47.963752-04:00
+      title: Lula Validation Result
+      uuid: de194921-8a85-45a5-b6f1-340c60f5ffcc
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: aa0f365e-7e2d-538a-95d1-c994b78ff302 / Implemented Requirement: 6a8eb074-850a-57b0-8198-0b7a929b92b1
+            Automated lula validation for A52.
+          related-observations:
+            - observation-uuid: 8a2d8193-13da-4593-8720-87b87bf85b25
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a52
+            type: objective-id
+          title: 'Validation Result - Control: a52'
+          uuid: 1ccbba7a-aa76-47f7-908c-a99275e7dfc7
+      observations:
+        - collected: 2026-07-26T21:38:47.746581-04:00
+          description: |
+            [TEST]: 40037dad-ee78-523f-97dc-1f73fabf7d41 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #40037dad-ee78-523f-97dc-1f73fabf7d41: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 8a2d8193-13da-4593-8720-87b87bf85b25
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a52
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:38:47.747795-04:00
+      title: Lula Validation Result
+      uuid: 86bb2e46-a9e6-4528-850d-16c4920965a3
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: a3697688-6e46-5205-910e-22c7b44f6bdd / Implemented Requirement: 6915c619-071a-51ea-a57f-60232a68751d
+            Automated lula validation for AARM VECTORS.
+          related-observations:
+            - observation-uuid: 021b9a6f-b8dd-4a99-9e3b-28347ef67194
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: aarm-vectors
+            type: objective-id
+          title: 'Validation Result - Control: aarm-vectors'
+          uuid: a7584b0a-52e2-4272-b879-e41e47df6857
+      observations:
+        - collected: 2026-07-26T21:37:12.783937-04:00
+          description: |
+            [TEST]: ec32ba67-e5a7-50b4-8ff5-eca8aac8da66 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #ec32ba67-e5a7-50b4-8ff5-eca8aac8da66: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 021b9a6f-b8dd-4a99-9e3b-28347ef67194
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://cloudsecurityalliance.org/research/working-groups/artificial-intelligence
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: aarm-vectors
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:37:12.784051-04:00
+      title: Lula Validation Result
+      uuid: 885768ab-404c-4e14-bff2-cd3b2a2230ec
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 11a88f5e-1f94-5774-94b9-617f7870e62a / Implemented Requirement: 4332a913-0441-5d14-8df5-ba79df3749d5
+            Automated lula validation for A92.
+          related-observations:
+            - observation-uuid: c7cd0c41-cfc7-4039-8a1d-7f240b6315df
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a92
+            type: objective-id
+          title: 'Validation Result - Control: a92'
+          uuid: 86c551f3-9cf1-419d-9678-0e4daac0675b
+      observations:
+        - collected: 2026-07-26T21:37:12.566661-04:00
+          description: |
+            [TEST]: 189e411a-b3fb-5db2-b787-349693054e29 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #189e411a-b3fb-5db2-b787-349693054e29: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: c7cd0c41-cfc7-4039-8a1d-7f240b6315df
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a92
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:37:12.566767-04:00
+      title: Lula Validation Result
+      uuid: e0790d08-ea56-4eea-b622-1117ef5e1985
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 1ece732e-9180-52e4-a04d-bb92f5e01929 / Implemented Requirement: 76dea904-7d5c-53b3-b5d8-2c31702ff8ca
+            Automated lula validation for A53.
+          related-observations:
+            - observation-uuid: 26d9434a-cfb1-4286-80cf-483c1eef9a7a
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a53
+            type: objective-id
+          title: 'Validation Result - Control: a53'
+          uuid: a0a036e3-58ce-4313-86ae-f51e9dc70870
+      observations:
+        - collected: 2026-07-26T21:37:12.355365-04:00
+          description: |
+            [TEST]: eb760977-813f-5999-af3f-dcd76b48c7aa - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #eb760977-813f-5999-af3f-dcd76b48c7aa: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 26d9434a-cfb1-4286-80cf-483c1eef9a7a
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a53
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:37:12.355477-04:00
+      title: Lula Validation Result
+      uuid: 4a32e700-eabd-4e29-9928-ac7e690257ef
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: aa0f365e-7e2d-538a-95d1-c994b78ff302 / Implemented Requirement: 6a8eb074-850a-57b0-8198-0b7a929b92b1
+            Automated lula validation for A52.
+          related-observations:
+            - observation-uuid: 4d39351b-30fd-48e4-a0b0-6b0ebc142778
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a52
+            type: objective-id
+          title: 'Validation Result - Control: a52'
+          uuid: b0735950-5600-4505-a44b-f88c131221f2
+      observations:
+        - collected: 2026-07-26T21:37:12.138778-04:00
+          description: |
+            [TEST]: 40037dad-ee78-523f-97dc-1f73fabf7d41 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #40037dad-ee78-523f-97dc-1f73fabf7d41: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 4d39351b-30fd-48e4-a0b0-6b0ebc142778
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a52
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:37:12.140297-04:00
+      title: Lula Validation Result
+      uuid: aa408b55-dda6-4515-a91b-9acdea79a052
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: a3697688-6e46-5205-910e-22c7b44f6bdd / Implemented Requirement: 6915c619-071a-51ea-a57f-60232a68751d
+            Automated lula validation for AARM VECTORS.
+          related-observations:
+            - observation-uuid: 5cd79cb4-bea0-489b-b284-bedc24ece768
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: aarm-vectors
+            type: objective-id
+          title: 'Validation Result - Control: aarm-vectors'
+          uuid: 99081078-6842-48be-84bf-bf8bb0b4aeed
+      observations:
+        - collected: 2026-07-26T21:35:45.824557-04:00
+          description: |
+            [TEST]: ec32ba67-e5a7-50b4-8ff5-eca8aac8da66 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #ec32ba67-e5a7-50b4-8ff5-eca8aac8da66: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 5cd79cb4-bea0-489b-b284-bedc24ece768
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://cloudsecurityalliance.org/research/working-groups/artificial-intelligence
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: aarm-vectors
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:35:45.824697-04:00
+      title: Lula Validation Result
+      uuid: 0b673b67-4b48-41a5-819b-5c60d0f431ac
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 11a88f5e-1f94-5774-94b9-617f7870e62a / Implemented Requirement: 4332a913-0441-5d14-8df5-ba79df3749d5
+            Automated lula validation for A92.
+          related-observations:
+            - observation-uuid: e1931995-2b69-4a57-b0d3-f70cb1e31336
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a92
+            type: objective-id
+          title: 'Validation Result - Control: a92'
+          uuid: 2f225ca7-9f3b-4ba9-baf6-dcc16288ef5a
+      observations:
+        - collected: 2026-07-26T21:35:45.608785-04:00
+          description: |
+            [TEST]: 189e411a-b3fb-5db2-b787-349693054e29 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #189e411a-b3fb-5db2-b787-349693054e29: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: e1931995-2b69-4a57-b0d3-f70cb1e31336
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a92
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:35:45.608896-04:00
+      title: Lula Validation Result
+      uuid: 64c1e6c0-b49d-4bf2-b6ab-f3417fd76a1e
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 1ece732e-9180-52e4-a04d-bb92f5e01929 / Implemented Requirement: 76dea904-7d5c-53b3-b5d8-2c31702ff8ca
+            Automated lula validation for A53.
+          related-observations:
+            - observation-uuid: d3d66db9-d157-49b2-9e19-f163a739f79d
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a53
+            type: objective-id
+          title: 'Validation Result - Control: a53'
+          uuid: 4f126dc5-047d-463e-8c78-1661e34aa964
+      observations:
+        - collected: 2026-07-26T21:35:45.398304-04:00
+          description: |
+            [TEST]: eb760977-813f-5999-af3f-dcd76b48c7aa - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #eb760977-813f-5999-af3f-dcd76b48c7aa: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: d3d66db9-d157-49b2-9e19-f163a739f79d
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a53
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:35:45.398415-04:00
+      title: Lula Validation Result
+      uuid: 5731705f-9c65-42d2-8f79-7014d6da5329
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: aa0f365e-7e2d-538a-95d1-c994b78ff302 / Implemented Requirement: 6a8eb074-850a-57b0-8198-0b7a929b92b1
+            Automated lula validation for A52.
+          related-observations:
+            - observation-uuid: b1136990-819c-4329-b19f-63267657ec93
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a52
+            type: objective-id
+          title: 'Validation Result - Control: a52'
+          uuid: d9bf4f9e-adad-4247-841e-c3eaf67a2ec5
+      observations:
+        - collected: 2026-07-26T21:35:45.178426-04:00
+          description: |
+            [TEST]: 40037dad-ee78-523f-97dc-1f73fabf7d41 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #40037dad-ee78-523f-97dc-1f73fabf7d41: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: b1136990-819c-4329-b19f-63267657ec93
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a52
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:35:45.179499-04:00
+      title: Lula Validation Result
+      uuid: cb8a56de-a10f-4bab-8aa1-572e3935e953
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: fa3a2446-e669-51fb-89d0-809f86be5882 / Implemented Requirement: 14246452-86b5-58f7-abc8-9ef7f2a9e9f1
+            Automated lula validation for TQP007 (CTRL_TQP_007).
+          related-observations:
+            - observation-uuid: 16dfb072-d889-408c-87ce-dd8d06d039dd
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: A.8.4
+            type: objective-id
+          title: 'Validation Result - Control: A.8.4'
+          uuid: 05f31e99-4d29-49e9-b254-af3c37ef9fd5
+      observations:
+        - collected: 2026-07-26T21:33:17.29227-04:00
+          description: |
+            [TEST]: 7ce8309c-ecfc-5208-ba63-f6d01d8335b0 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #7ce8309c-ecfc-5208-ba63-f6d01d8335b0: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>}]
+          uuid: 16dfb072-d889-408c-87ce-dd8d06d039dd
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: A.8.4
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:17.292539-04:00
+      title: Lula Validation Result
+      uuid: c95c03ce-bfb8-4ac8-9d30-4a9b83d505b8
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 265c3e24-6a08-5306-8c7e-e2c1d830495f / Implemented Requirement: 41943d9b-5ead-5c8e-ace2-b07b769526ac
+            Automated lula validation for SI2.
+          related-observations:
+            - observation-uuid: 6cd92faf-9d64-4591-b269-0613c2dc7ca2
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: si2
+            type: objective-id
+          title: 'Validation Result - Control: si2'
+          uuid: d1275353-1641-4473-a5fc-64364dacb123
+      observations:
+        - collected: 2026-07-26T21:33:17.065661-04:00
+          description: |
+            [TEST]: daff725b-aea0-5a5c-981e-df1a30306f2e - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #daff725b-aea0-5a5c-981e-df1a30306f2e: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>}]
+          uuid: 6cd92faf-9d64-4591-b269-0613c2dc7ca2
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: si2
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:17.065771-04:00
+      title: Lula Validation Result
+      uuid: fae1ae52-0875-4e54-b113-183c455f6c6c
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 2ddc6d0d-c35e-583b-b5bb-12a5a69cbca8 / Implemented Requirement: 50796b20-07f7-5904-acae-cf0e2f117f15
+            Automated lula validation for SC8.
+          related-observations:
+            - observation-uuid: a13531d4-e21f-4189-acd1-051effdd2ddf
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: sc8
+            type: objective-id
+          title: 'Validation Result - Control: sc8'
+          uuid: 9d59f2aa-b760-4d2c-8f69-ee3c0db8bc41
+      observations:
+        - collected: 2026-07-26T21:33:16.848696-04:00
+          description: |
+            [TEST]: a4ff5a9e-3621-52c6-9c1f-157e6e432b5e - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #a4ff5a9e-3621-52c6-9c1f-157e6e432b5e: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/2 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/3 "missing property 'resource-rule'" <nil>}]
+          uuid: a13531d4-e21f-4189-acd1-051effdd2ddf
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: sc8
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:16.848802-04:00
+      title: Lula Validation Result
+      uuid: 882fe13e-8704-42cf-981d-b38f5d49d3b4
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 71af40e7-a7a8-570a-a320-3c4154bea03a / Implemented Requirement: 57b3f09d-e367-5c5c-9876-82f5d837d78b
+            Automated lula validation for SC4.
+          related-observations:
+            - observation-uuid: 8135b788-6e6b-4622-967c-5153b9dff69c
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: sc4
+            type: objective-id
+          title: 'Validation Result - Control: sc4'
+          uuid: e509478f-b2c2-412d-a212-bde32980a95f
+      observations:
+        - collected: 2026-07-26T21:33:16.627555-04:00
+          description: |
+            [TEST]: 9b6f9b2e-f19d-54a8-bd5f-47f1fbed0a22 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #9b6f9b2e-f19d-54a8-bd5f-47f1fbed0a22: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>}]
+          uuid: 8135b788-6e6b-4622-967c-5153b9dff69c
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: sc4
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:16.62767-04:00
+      title: Lula Validation Result
+      uuid: bf780c5e-370e-403d-8969-2f6ecf699e10
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 6957afe5-394b-5641-b059-4d210795dc00 / Implemented Requirement: 4647ae49-b402-5fcd-919b-8a39244aa7f6
+            Automated lula validation for RA5.
+          related-observations:
+            - observation-uuid: 98f1cc41-ab58-44ab-831f-53d5d75221d5
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ra5
+            type: objective-id
+          title: 'Validation Result - Control: ra5'
+          uuid: 3f11183c-b5d8-49b7-a718-0d40a98420f3
+      observations:
+        - collected: 2026-07-26T21:33:16.416707-04:00
+          description: |
+            [TEST]: 7a32a7bb-2f37-54ce-a16f-1435d2607512 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #7a32a7bb-2f37-54ce-a16f-1435d2607512: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>}]
+          uuid: 98f1cc41-ab58-44ab-831f-53d5d75221d5
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ra5
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:16.416818-04:00
+      title: Lula Validation Result
+      uuid: 84790b0f-9199-4a3a-a5f0-38a576dfe127
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 130746b5-8e06-5793-96f5-cbb9ed0cb09e / Implemented Requirement: 41638730-fd45-5c96-a029-f3753269b01c
+            Automated lula validation for MAS TRM S6.
+          related-observations:
+            - observation-uuid: 8a4111fc-e4fa-467f-90be-bed34cc813c8
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: mas-trm-s6
+            type: objective-id
+          title: 'Validation Result - Control: mas-trm-s6'
+          uuid: 8bfd98cf-ecfb-433e-b6bc-6db6de27e413
+      observations:
+        - collected: 2026-07-26T21:33:16.199912-04:00
+          description: |
+            [TEST]: 1cd75fa9-7175-5f07-a975-4eed29074d88 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #1cd75fa9-7175-5f07-a975-4eed29074d88: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 8a4111fc-e4fa-467f-90be-bed34cc813c8
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.mas.gov.sg/regulation/guidelines/technology-risk-management-guidelines
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: mas-trm-s6
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:16.200032-04:00
+      title: Lula Validation Result
+      uuid: af7b4958-4c02-4d0e-87b2-09402fc3204b
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 27475017-b615-5f28-bc86-137cebf13a3a / Implemented Requirement: 564d9d85-b2a5-5494-83d2-d06334ec06b7
+            Automated lula validation for MAS NOTICE655.
+          related-observations:
+            - observation-uuid: ddb0f956-34c4-4e3d-b8a5-23654c0946db
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: mas-notice655
+            type: objective-id
+          title: 'Validation Result - Control: mas-notice655'
+          uuid: 2c48e5c9-6df6-4e25-93a5-abaebbbb9228
+      observations:
+        - collected: 2026-07-26T21:33:15.770269-04:00
+          description: |
+            [TEST]: 31845ca7-3729-5a11-8faa-028892829144 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #31845ca7-3729-5a11-8faa-028892829144: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: ddb0f956-34c4-4e3d-b8a5-23654c0946db
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://lula.dev
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: mas-notice655
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:15.77039-04:00
+      title: Lula Validation Result
+      uuid: 2d109e86-600e-4ebc-a7fd-21991ab94c0d
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 350c54ef-a57a-5117-b4e1-03c257885b21 / Implemented Requirement: 241d9a37-67b7-5deb-914b-5f83e8ed68d8
+            Automated lula validation for MAS FEAT.
+          related-observations:
+            - observation-uuid: e21cb828-9ed5-4ab5-945f-46f399d84610
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: mas-feat
+            type: objective-id
+          title: 'Validation Result - Control: mas-feat'
+          uuid: d3778ebf-6257-4cfd-aab1-dd89b9875125
+      observations:
+        - collected: 2026-07-26T21:33:15.540984-04:00
+          description: |
+            [TEST]: 44249863-3ab1-5cb0-9b6f-3a17700a71b2 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #44249863-3ab1-5cb0-9b6f-3a17700a71b2: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: e21cb828-9ed5-4ab5-945f-46f399d84610
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.mas.gov.sg/regulation/guidelines/technology-risk-management-guidelines
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: mas-feat
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:15.541257-04:00
+      title: Lula Validation Result
+      uuid: 79e1ca78-2175-4b05-8fb8-83d9402c3fb0
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 3f2c9f85-c105-5d35-898d-e7fde67638ef / Implemented Requirement: b73bcc6c-d919-5368-bbd3-77f142eb54dd
+            Automated lula validation for ISO001 TOKEN QUOTA (ISO-001).
+          related-observations:
+            - observation-uuid: 5094ad1f-fb93-49bc-8f27-910a71a704a9
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: A.4
+            type: objective-id
+          title: 'Validation Result - Control: A.4'
+          uuid: 9942c7c5-25da-402c-ae21-24b12bf9c339
+      observations:
+        - collected: 2026-07-26T21:33:15.335252-04:00
+          description: |
+            [TEST]: 9c4c3db2-8fc7-5959-ba63-38e6ffd6ecc9 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #9c4c3db2-8fc7-5959-ba63-38e6ffd6ecc9: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>}]
+          uuid: 5094ad1f-fb93-49bc-8f27-910a71a704a9
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: A.4
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:15.335389-04:00
+      title: Lula Validation Result
+      uuid: 051f3f38-2afb-45d4-8289-73eda44e73b6
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 92301774-6531-538c-ac3f-5509744b1aa0 / Implemented Requirement: 3fdd491f-1d9e-523a-a46d-07abfedf72f1
+            Automated lula validation for IR6.
+          related-observations:
+            - observation-uuid: c8bfef55-5fab-4d74-b05f-1a3e83e14d0e
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ir6
+            type: objective-id
+          title: 'Validation Result - Control: ir6'
+          uuid: e6a499e0-6a43-4ecd-a26c-1012b3258c1f
+      observations:
+        - collected: 2026-07-26T21:33:15.122415-04:00
+          description: |
+            [TEST]: 07d356e8-2cf4-5aa3-8523-cd3e868d4367 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #07d356e8-2cf4-5aa3-8523-cd3e868d4367: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>}]
+          uuid: c8bfef55-5fab-4d74-b05f-1a3e83e14d0e
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ir6
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:15.122823-04:00
+      title: Lula Validation Result
+      uuid: 8b066e2f-63d1-451e-a237-514251dbfc11
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 8ca3b5e5-0d39-5d8f-a452-020ca7259254 / Implemented Requirement: cce1fd52-f0f5-5788-9a91-ca652f102324
+            Automated lula validation for IA5.
+          related-observations:
+            - observation-uuid: 7d0b13c9-b4eb-48ab-aa1b-83a7e15d1366
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ia5
+            type: objective-id
+          title: 'Validation Result - Control: ia5'
+          uuid: 42b480b9-ed77-4e41-a01d-1120cd58750a
+      observations:
+        - collected: 2026-07-26T21:33:14.901008-04:00
+          description: |
+            [TEST]: b322b5e6-d8bd-51ab-bbf0-246a45d87b8f - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #b322b5e6-d8bd-51ab-bbf0-246a45d87b8f: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>}]
+          uuid: 7d0b13c9-b4eb-48ab-aa1b-83a7e15d1366
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ia5
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:14.901121-04:00
+      title: Lula Validation Result
+      uuid: b63ab393-8cfa-475f-a9d5-78f13db9c401
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: b0982882-d418-5f5f-b01c-c473cbb86fba / Implemented Requirement: a92a8532-0edd-5c5f-800e-a112ff570d38
+            Automated lula validation for IA3.
+          related-observations:
+            - observation-uuid: 3825b3d3-f435-4645-b935-14a5d08c27d2
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ia3
+            type: objective-id
+          title: 'Validation Result - Control: ia3'
+          uuid: bb682ce2-034d-4a9d-a695-fc3693fa3c40
+      observations:
+        - collected: 2026-07-26T21:33:14.689429-04:00
+          description: |
+            [TEST]: 976c6d03-26a0-5071-86ec-98978bdc5a7e - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #976c6d03-26a0-5071-86ec-98978bdc5a7e: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/2 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/3 "missing property 'resource-rule'" <nil>}]
+          uuid: 3825b3d3-f435-4645-b935-14a5d08c27d2
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ia3
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:14.692371-04:00
+      title: Lula Validation Result
+      uuid: d5effc78-dea9-4272-92d4-5a2d134088a4
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 64186a87-ffc0-514c-877e-41832df17e5c / Implemented Requirement: c7b6e46e-eac7-5499-80aa-af4dba8e104d
+            Automated lula validation for GDPR ART22.
+          related-observations:
+            - observation-uuid: 7345dc1f-c7d4-472a-864e-a025c0b86814
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: gdpr-art22
+            type: objective-id
+          title: 'Validation Result - Control: gdpr-art22'
+          uuid: 85507c75-e056-4906-a8a2-bc2c92472b0b
+      observations:
+        - collected: 2026-07-26T21:33:14.479852-04:00
+          description: |
+            [TEST]: 877aaff1-86c0-5e6d-a9b9-2756af2e6889 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #877aaff1-86c0-5e6d-a9b9-2756af2e6889: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 7345dc1f-c7d4-472a-864e-a025c0b86814
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32016R0679
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: gdpr-art22
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:14.47997-04:00
+      title: Lula Validation Result
+      uuid: 3d29983d-7b55-4e10-91d6-d8d3ef770b07
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 3e5c5cbb-a661-56be-9742-ed8e86fe38f9 / Implemented Requirement: e30d88ac-5dd8-5a04-b6f3-5eaf024e508e
+            Automated lula validation for EU FRIA (EU-001).
+          related-observations:
+            - observation-uuid: c6314287-310f-4ec9-b203-59ff4093779f
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: EU_AI_ACT_ART29A
+            type: objective-id
+          title: 'Validation Result - Control: EU_AI_ACT_ART29A'
+          uuid: 8447cfee-9d8b-4e05-a1c9-fe641b931147
+      observations:
+        - collected: 2026-07-26T21:33:14.267765-04:00
+          description: |
+            [TEST]: 3b422f73-7da4-5147-8c46-8abe44f82892 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #3b422f73-7da4-5147-8c46-8abe44f82892: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>}]
+          uuid: c6314287-310f-4ec9-b203-59ff4093779f
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://lula.dev
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: EU_AI_ACT_ART29A
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:14.267894-04:00
+      title: Lula Validation Result
+      uuid: 3a206e84-a83e-4acd-b06b-a433ca4e669b
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 58d1a2f5-47d9-594b-805f-3316a2fdc129 / Implemented Requirement: 5f274328-f25a-5a19-8d0a-4a103d341baf
+            Automated lula validation for EU AI ACT ART9.
+          related-observations:
+            - observation-uuid: 6489c860-1b1f-4fb5-bff2-ff7b9bacb4b6
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: eu-ai-act-art9
+            type: objective-id
+          title: 'Validation Result - Control: eu-ai-act-art9'
+          uuid: ee2b4049-8f3c-4865-8110-37e49b8ea024
+      observations:
+        - collected: 2026-07-26T21:33:14.054923-04:00
+          description: |
+            [TEST]: bf519130-9b51-584d-b88c-d2357f5ab16f - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #bf519130-9b51-584d-b88c-d2357f5ab16f: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 6489c860-1b1f-4fb5-bff2-ff7b9bacb4b6
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32024R1689
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: eu-ai-act-art9
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:14.05504-04:00
+      title: Lula Validation Result
+      uuid: 12f7be6c-e46f-4d05-b5af-d65fb7870b55
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: b10dffbc-e2ac-5479-8b54-599f18925b3a / Implemented Requirement: d71fd848-246a-5665-9fd1-ad67cd2bc703
+            Automated lula validation for DORA ART10.
+          related-observations:
+            - observation-uuid: 3fafed40-f107-48e2-b746-61f21aae0649
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: dora-art10
+            type: objective-id
+          title: 'Validation Result - Control: dora-art10'
+          uuid: 6263a980-0b8b-48b4-a551-26b7166ab7a6
+      observations:
+        - collected: 2026-07-26T21:33:13.8408-04:00
+          description: |
+            [TEST]: eaacb9e8-bb4f-5c67-a1f2-4adb59b47eaa - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #eaacb9e8-bb4f-5c67-a1f2-4adb59b47eaa: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 3fafed40-f107-48e2-b746-61f21aae0649
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32022R2554
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: dora-art10
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:13.840944-04:00
+      title: Lula Validation Result
+      uuid: 67946fa6-7c73-4685-a278-578564a169d6
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 9dec443c-138b-578d-9255-d6f67fc95c5b / Implemented Requirement: 7054ff11-50ab-5798-80b5-7f28c918da9a
+            Automated lula validation for CM6.
+          related-observations:
+            - observation-uuid: e578a452-e9f8-47a6-a45c-1575b8bc372b
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: cm6
+            type: objective-id
+          title: 'Validation Result - Control: cm6'
+          uuid: b1f27bc9-2abb-4c20-88c4-20b215e1db20
+      observations:
+        - collected: 2026-07-26T21:33:13.594273-04:00
+          description: |
+            [TEST]: d3a42dd5-3cf9-5ee5-baae-5b72ebd497ab - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #d3a42dd5-3cf9-5ee5-baae-5b72ebd497ab: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>}]
+          uuid: e578a452-e9f8-47a6-a45c-1575b8bc372b
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: cm6
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:13.595435-04:00
+      title: Lula Validation Result
+      uuid: 43d904ad-05e6-40bc-938b-6b33e4b09d2b
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 257ab77e-1020-5595-a07b-a8ae59511c0d / Implemented Requirement: 4405db85-a4ec-513f-bc34-161e9935bf04
+            Automated lula validation for AU12.
+          related-observations:
+            - observation-uuid: eb5315f9-8281-4ac9-8be1-a413b78a0d1f
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: au12
+            type: objective-id
+          title: 'Validation Result - Control: au12'
+          uuid: 6e665768-5a85-4abd-9262-fe41e1d56f84
+      observations:
+        - collected: 2026-07-26T21:33:13.144345-04:00
+          description: |
+            [TEST]: 610ee241-76a3-5f1f-b41d-613019559b15 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #610ee241-76a3-5f1f-b41d-613019559b15: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>}]
+          uuid: eb5315f9-8281-4ac9-8be1-a413b78a0d1f
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: au12
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:13.144455-04:00
+      title: Lula Validation Result
+      uuid: d7cf07ef-73b5-417f-a99e-090333fdc393
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 119840ef-2fa9-4bed-8cac-7a5e6a5d81dd / Implemented Requirement: 3ec272e8-651b-4ece-9d16-3a2b5f0c2425
+            Phase-0 stub for AI 600-1 §2.3 prompt injection / data poisoning controls.
+          related-observations:
+            - observation-uuid: cd0fa5a9-f66d-468d-935f-22493e795ada
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ai600-prompt-injection
+            type: objective-id
+          title: 'Validation Result - Control: ai600-prompt-injection'
+          uuid: 33e20ce4-532c-4ae6-b6fc-dfdd7562529d
+      observations:
+        - collected: 2026-07-26T21:33:12.933507-04:00
+          description: |
+            [TEST]: 8dfec2ec-e9b1-41fe-9b84-91f851874621 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #8dfec2ec-e9b1-41fe-9b84-91f851874621: schema is invalid: [{/properties/domain/$ref/allOf/1/then/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/domain/allOf/1/then/required /domain "missing property 'kubernetes-spec'" <nil>}]
+          uuid: cd0fa5a9-f66d-468d-935f-22493e795ada
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://airc.nist.gov/Docs/1
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ai600-prompt-injection
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:12.933641-04:00
+      title: Lula Validation Result
+      uuid: 1b4054f6-9ab3-433a-9770-cfbb25fb8c6e
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 312cc965-a1d8-4703-8d23-be38546aa60f / Implemented Requirement: 06a58dcc-ca7b-46ac-8a3a-175eac3cb336
+            Phase-0 stub for AI 600-1 §2.5 human-AI configuration controls.
+          related-observations:
+            - observation-uuid: 94c3040f-5da0-423a-9170-b26fa468e10d
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ai600-human-ai-config
+            type: objective-id
+          title: 'Validation Result - Control: ai600-human-ai-config'
+          uuid: 46a35b01-14b7-4335-8054-828e0c2f4aa7
+      observations:
+        - collected: 2026-07-26T21:33:12.715903-04:00
+          description: |
+            [TEST]: f64407ae-70e5-462c-9cea-4c065667c31f - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #f64407ae-70e5-462c-9cea-4c065667c31f: schema is invalid: [{/properties/domain/$ref/allOf/1/then/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/domain/allOf/1/then/required /domain "missing property 'kubernetes-spec'" <nil>}]
+          uuid: 94c3040f-5da0-423a-9170-b26fa468e10d
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://airc.nist.gov/Docs/1
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ai600-human-ai-config
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:12.716028-04:00
+      title: Lula Validation Result
+      uuid: 2ad49dc5-00d3-436c-8359-c8694c63833d
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 36e6e16a-a854-4ced-87a9-2b017580b199 / Implemented Requirement: 2c91e53d-5ec2-4223-99d3-be7dfce07fbc
+            Phase-0 stub for AI 600-1 §2.2 data privacy controls.
+          related-observations:
+            - observation-uuid: 26e6bf94-7589-4a83-a495-7e3dbb49d6e2
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ai600-data-privacy
+            type: objective-id
+          title: 'Validation Result - Control: ai600-data-privacy'
+          uuid: e4da0f5c-e627-41be-a251-566bf47c619e
+      observations:
+        - collected: 2026-07-26T21:33:12.513177-04:00
+          description: |
+            [TEST]: d6734f08-028c-4170-a796-6a63a2beb311 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #d6734f08-028c-4170-a796-6a63a2beb311: schema is invalid: [{/properties/domain/$ref/allOf/1/then/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/domain/allOf/1/then/required /domain "missing property 'kubernetes-spec'" <nil>}]
+          uuid: 26e6bf94-7589-4a83-a495-7e3dbb49d6e2
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://airc.nist.gov/Docs/1
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ai600-data-privacy
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:12.513309-04:00
+      title: Lula Validation Result
+      uuid: 89b2248b-bd66-4f0c-97c0-8e3a805168a6
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 5e579bed-cae9-486d-a40c-e9bb88328405 / Implemented Requirement: 28838c8d-8386-4bb7-8d75-98ace7480441
+            Phase-0 stub for AI 600-1 §2.1 confabulation controls.
+          related-observations:
+            - observation-uuid: 4030e536-8e47-4199-9dd3-1152b4347896
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ai600-confabulation
+            type: objective-id
+          title: 'Validation Result - Control: ai600-confabulation'
+          uuid: 273041cc-2f02-46f1-a471-5155ef82c955
+      observations:
+        - collected: 2026-07-26T21:33:12.296286-04:00
+          description: |
+            [TEST]: fedddcdb-2789-4575-9b7e-dbaca5ccb90f - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #fedddcdb-2789-4575-9b7e-dbaca5ccb90f: schema is invalid: [{/properties/domain/$ref/allOf/1/then/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/domain/allOf/1/then/required /domain "missing property 'kubernetes-spec'" <nil>}]
+          uuid: 4030e536-8e47-4199-9dd3-1152b4347896
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://airc.nist.gov/Docs/1
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ai600-confabulation
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:12.296418-04:00
+      title: Lula Validation Result
+      uuid: 940c795b-f2b5-4b20-a4e2-98693d3201ae
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 4e1574ab-8b13-4b48-b8bc-20daeb93e0ad / Implemented Requirement: fd641f71-329b-41db-83ce-9d2dc1e57c04
+            Phase-0 stub for AI 600-1 §2.6 CBRN harmful content controls.
+          related-observations:
+            - observation-uuid: c87d0087-e4f7-450e-a241-c536763ab2da
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ai600-cbrn
+            type: objective-id
+          title: 'Validation Result - Control: ai600-cbrn'
+          uuid: 8d5e65d0-8112-47f2-8de0-78221700fdb7
+      observations:
+        - collected: 2026-07-26T21:33:12.076973-04:00
+          description: |
+            [TEST]: ab3e9842-b66a-4e1e-b518-2d47937ee8e8 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #ab3e9842-b66a-4e1e-b518-2d47937ee8e8: schema is invalid: [{/properties/domain/$ref/allOf/1/then/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/domain/allOf/1/then/required /domain "missing property 'kubernetes-spec'" <nil>}]
+          uuid: c87d0087-e4f7-450e-a241-c536763ab2da
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://airc.nist.gov/Docs/1
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ai600-cbrn
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:12.077137-04:00
+      title: Lula Validation Result
+      uuid: 222c9eb6-f7ec-4b54-b708-73e9e9621c81
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: b8efdf73-2801-5ce0-a588-b486e87bd490 / Implemented Requirement: dc9af4f2-aeef-55ae-ac99-95eeed7f3521
+            Automated lula validation for AC3.
+          related-observations:
+            - observation-uuid: 7daa88de-a960-49da-9861-68dbc4c6d5c8
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ac3
+            type: objective-id
+          title: 'Validation Result - Control: ac3'
+          uuid: 1a52b496-e70d-4ef3-a3cd-0c07d4e84b27
+      observations:
+        - collected: 2026-07-26T21:33:11.879081-04:00
+          description: |
+            [TEST]: 73f98590-b9c9-52da-bfac-27cf03ae46af - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #73f98590-b9c9-52da-bfac-27cf03ae46af: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>}]
+          uuid: 7daa88de-a960-49da-9861-68dbc4c6d5c8
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ac3
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:11.879188-04:00
+      title: Lula Validation Result
+      uuid: 6e117cd1-4f1f-4192-940b-5455f6a6ef8b
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 22ce9e77-15c9-5ba5-9d91-a0b0191ebb44 / Implemented Requirement: 18e5a104-64e5-58d5-b8c4-dcd91b3878ce
+            Automated lula validation for AC2.
+          related-observations:
+            - observation-uuid: ec880548-f461-4530-83ab-ff47b7e469f7
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ac2
+            type: objective-id
+          title: 'Validation Result - Control: ac2'
+          uuid: 5ea3efbe-bcf2-47f9-9444-b5a20ccbbdf4
+      observations:
+        - collected: 2026-07-26T21:33:11.670252-04:00
+          description: |
+            [TEST]: 1fcd8ff2-3d20-5d34-a450-0f78901b8039 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #1fcd8ff2-3d20-5d34-a450-0f78901b8039: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>}]
+          uuid: ec880548-f461-4530-83ab-ff47b7e469f7
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ac2
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:11.67036-04:00
+      title: Lula Validation Result
+      uuid: fdcbb23f-8dd5-40dd-9373-4b8f91702a6d
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: a3697688-6e46-5205-910e-22c7b44f6bdd / Implemented Requirement: 6915c619-071a-51ea-a57f-60232a68751d
+            Automated lula validation for AARM VECTORS.
+          related-observations:
+            - observation-uuid: 99235fd5-8e45-4b64-9fda-365cdfd9c165
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: aarm-vectors
+            type: objective-id
+          title: 'Validation Result - Control: aarm-vectors'
+          uuid: 79d7ca68-1c64-44d3-a360-575195530cce
+      observations:
+        - collected: 2026-07-26T21:33:11.474775-04:00
+          description: |
+            [TEST]: ec32ba67-e5a7-50b4-8ff5-eca8aac8da66 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #ec32ba67-e5a7-50b4-8ff5-eca8aac8da66: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 99235fd5-8e45-4b64-9fda-365cdfd9c165
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://cloudsecurityalliance.org/research/working-groups/artificial-intelligence
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: aarm-vectors
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:11.474892-04:00
+      title: Lula Validation Result
+      uuid: 38892bfb-4207-4aed-abea-9430b5250db9
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 11a88f5e-1f94-5774-94b9-617f7870e62a / Implemented Requirement: 4332a913-0441-5d14-8df5-ba79df3749d5
+            Automated lula validation for A92.
+          related-observations:
+            - observation-uuid: dda5b1bf-7e20-457c-86b5-1ef1dd545eae
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a92
+            type: objective-id
+          title: 'Validation Result - Control: a92'
+          uuid: 84fa6fb6-450d-4ce1-b259-9ffd6c8ab9ef
+      observations:
+        - collected: 2026-07-26T21:33:11.280796-04:00
+          description: |
+            [TEST]: 189e411a-b3fb-5db2-b787-349693054e29 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #189e411a-b3fb-5db2-b787-349693054e29: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: dda5b1bf-7e20-457c-86b5-1ef1dd545eae
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a92
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:11.28091-04:00
+      title: Lula Validation Result
+      uuid: 7fbb318b-a14a-4bec-b960-c4bbe82b0e13
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 1ece732e-9180-52e4-a04d-bb92f5e01929 / Implemented Requirement: 76dea904-7d5c-53b3-b5d8-2c31702ff8ca
+            Automated lula validation for A53.
+          related-observations:
+            - observation-uuid: d2fa3e8f-c999-4f54-ada9-63e3b33b690d
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a53
+            type: objective-id
+          title: 'Validation Result - Control: a53'
+          uuid: b4fbd9e7-8b2f-48e0-af2b-ede2c08b875d
+      observations:
+        - collected: 2026-07-26T21:33:11.079687-04:00
+          description: |
+            [TEST]: eb760977-813f-5999-af3f-dcd76b48c7aa - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #eb760977-813f-5999-af3f-dcd76b48c7aa: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: d2fa3e8f-c999-4f54-ada9-63e3b33b690d
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a53
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:11.079823-04:00
+      title: Lula Validation Result
+      uuid: cedd84ac-3ba7-4b2b-b737-fa97a8e87c6c
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: aa0f365e-7e2d-538a-95d1-c994b78ff302 / Implemented Requirement: 6a8eb074-850a-57b0-8198-0b7a929b92b1
+            Automated lula validation for A52.
+          related-observations:
+            - observation-uuid: a9b5d606-8eef-4543-8787-491e442daa4e
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a52
+            type: objective-id
+          title: 'Validation Result - Control: a52'
+          uuid: 11e39ce1-1725-46e1-af20-104d3a42817f
+      observations:
+        - collected: 2026-07-26T21:33:10.869923-04:00
+          description: |
+            [TEST]: 40037dad-ee78-523f-97dc-1f73fabf7d41 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #40037dad-ee78-523f-97dc-1f73fabf7d41: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: a9b5d606-8eef-4543-8787-491e442daa4e
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a52
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:33:10.874709-04:00
+      title: Lula Validation Result
+      uuid: 4b0735ed-7a33-42f6-82d5-5d9bc3023a8d
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: a3697688-6e46-5205-910e-22c7b44f6bdd / Implemented Requirement: 6915c619-071a-51ea-a57f-60232a68751d
+            Automated lula validation for AARM VECTORS.
+          related-observations:
+            - observation-uuid: 06306ac4-44a8-4008-a0e4-45a4276034eb
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: aarm-vectors
+            type: objective-id
+          title: 'Validation Result - Control: aarm-vectors'
+          uuid: 26853f16-fb3c-4006-af45-ace13f1f6296
+      observations:
+        - collected: 2026-07-26T21:30:38.501316-04:00
+          description: |
+            [TEST]: ec32ba67-e5a7-50b4-8ff5-eca8aac8da66 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #ec32ba67-e5a7-50b4-8ff5-eca8aac8da66: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 06306ac4-44a8-4008-a0e4-45a4276034eb
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://cloudsecurityalliance.org/research/working-groups/artificial-intelligence
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: aarm-vectors
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:30:38.501433-04:00
+      title: Lula Validation Result
+      uuid: aa5b1eba-2c67-4d1d-b17d-ed448d5a5446
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 11a88f5e-1f94-5774-94b9-617f7870e62a / Implemented Requirement: 4332a913-0441-5d14-8df5-ba79df3749d5
+            Automated lula validation for A92.
+          related-observations:
+            - observation-uuid: 47d548c7-cfe8-477b-a0d8-d6090194cce2
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a92
+            type: objective-id
+          title: 'Validation Result - Control: a92'
+          uuid: 18fe20a9-7446-4522-b9ff-5f4194eb167b
+      observations:
+        - collected: 2026-07-26T21:30:38.287381-04:00
+          description: |
+            [TEST]: 189e411a-b3fb-5db2-b787-349693054e29 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #189e411a-b3fb-5db2-b787-349693054e29: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 47d548c7-cfe8-477b-a0d8-d6090194cce2
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a92
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:30:38.287513-04:00
+      title: Lula Validation Result
+      uuid: caa83401-dd0b-418f-a4ba-60ef8cc7607f
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 1ece732e-9180-52e4-a04d-bb92f5e01929 / Implemented Requirement: 76dea904-7d5c-53b3-b5d8-2c31702ff8ca
+            Automated lula validation for A53.
+          related-observations:
+            - observation-uuid: feb33cc1-707b-4fb0-b847-825e26ef8d66
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a53
+            type: objective-id
+          title: 'Validation Result - Control: a53'
+          uuid: 1a0639b6-c023-43fa-9348-f7736e12c040
+      observations:
+        - collected: 2026-07-26T21:30:38.086559-04:00
+          description: |
+            [TEST]: eb760977-813f-5999-af3f-dcd76b48c7aa - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #eb760977-813f-5999-af3f-dcd76b48c7aa: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: feb33cc1-707b-4fb0-b847-825e26ef8d66
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a53
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:30:38.08671-04:00
+      title: Lula Validation Result
+      uuid: 6888b9ed-ab63-4a2c-892a-4052d29461c6
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: aa0f365e-7e2d-538a-95d1-c994b78ff302 / Implemented Requirement: 6a8eb074-850a-57b0-8198-0b7a929b92b1
+            Automated lula validation for A52.
+          related-observations:
+            - observation-uuid: 31973a13-68fd-4828-ae15-ee43626337aa
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a52
+            type: objective-id
+          title: 'Validation Result - Control: a52'
+          uuid: 6122e08d-de58-4cd5-9c25-504b5d5e79c3
+      observations:
+        - collected: 2026-07-26T21:30:37.735264-04:00
+          description: |
+            [TEST]: 40037dad-ee78-523f-97dc-1f73fabf7d41 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #40037dad-ee78-523f-97dc-1f73fabf7d41: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 31973a13-68fd-4828-ae15-ee43626337aa
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a52
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:30:37.736419-04:00
+      title: Lula Validation Result
+      uuid: 7f0ad1dd-b63a-44a9-883c-72166d92701d
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 119840ef-2fa9-4bed-8cac-7a5e6a5d81dd / Implemented Requirement: 3ec272e8-651b-4ece-9d16-3a2b5f0c2425
+            Phase-0 stub for AI 600-1 §2.3 prompt injection / data poisoning controls.
+          related-observations:
+            - observation-uuid: 2c5c1e42-0d16-404b-9d13-13de1d326dc1
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ai600-prompt-injection
+            type: objective-id
+          title: 'Validation Result - Control: ai600-prompt-injection'
+          uuid: 4d3a5b48-b9b1-4ae5-94cc-085e5f100098
+      observations:
+        - collected: 2026-07-26T21:28:35.933131-04:00
+          description: |
+            [TEST]: 8dfec2ec-e9b1-41fe-9b84-91f851874621 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #8dfec2ec-e9b1-41fe-9b84-91f851874621: schema is invalid: [{/properties/domain/$ref/allOf/1/then/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/domain/allOf/1/then/required /domain "missing property 'kubernetes-spec'" <nil>}]
+          uuid: 2c5c1e42-0d16-404b-9d13-13de1d326dc1
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://airc.nist.gov/Docs/1
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ai600-prompt-injection
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:28:35.933265-04:00
+      title: Lula Validation Result
+      uuid: c2908a62-334d-4ef2-a46e-75b53eb2b799
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 312cc965-a1d8-4703-8d23-be38546aa60f / Implemented Requirement: 06a58dcc-ca7b-46ac-8a3a-175eac3cb336
+            Phase-0 stub for AI 600-1 §2.5 human-AI configuration controls.
+          related-observations:
+            - observation-uuid: b31d8145-6673-4f32-b366-7e05ca85a0ac
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ai600-human-ai-config
+            type: objective-id
+          title: 'Validation Result - Control: ai600-human-ai-config'
+          uuid: 6e31c53d-b34d-406c-a349-1c0df0b0bdd0
+      observations:
+        - collected: 2026-07-26T21:28:35.750169-04:00
+          description: |
+            [TEST]: f64407ae-70e5-462c-9cea-4c065667c31f - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #f64407ae-70e5-462c-9cea-4c065667c31f: schema is invalid: [{/properties/domain/$ref/allOf/1/then/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/domain/allOf/1/then/required /domain "missing property 'kubernetes-spec'" <nil>}]
+          uuid: b31d8145-6673-4f32-b366-7e05ca85a0ac
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://airc.nist.gov/Docs/1
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ai600-human-ai-config
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:28:35.750337-04:00
+      title: Lula Validation Result
+      uuid: 0ab407e5-3da1-4d17-a7c1-90f9859007a6
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 36e6e16a-a854-4ced-87a9-2b017580b199 / Implemented Requirement: 2c91e53d-5ec2-4223-99d3-be7dfce07fbc
+            Phase-0 stub for AI 600-1 §2.2 data privacy controls.
+          related-observations:
+            - observation-uuid: 0d0f50f2-ae6f-4375-b0d8-2d4067bbb92e
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ai600-data-privacy
+            type: objective-id
+          title: 'Validation Result - Control: ai600-data-privacy'
+          uuid: 5678e593-7b12-460f-b519-7dba2d028174
+      observations:
+        - collected: 2026-07-26T21:28:35.561817-04:00
+          description: |
+            [TEST]: d6734f08-028c-4170-a796-6a63a2beb311 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #d6734f08-028c-4170-a796-6a63a2beb311: schema is invalid: [{/properties/domain/$ref/allOf/1/then/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/domain/allOf/1/then/required /domain "missing property 'kubernetes-spec'" <nil>}]
+          uuid: 0d0f50f2-ae6f-4375-b0d8-2d4067bbb92e
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://airc.nist.gov/Docs/1
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ai600-data-privacy
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:28:35.56195-04:00
+      title: Lula Validation Result
+      uuid: 2d474193-c0cc-4195-90c0-217335a50940
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 5e579bed-cae9-486d-a40c-e9bb88328405 / Implemented Requirement: 28838c8d-8386-4bb7-8d75-98ace7480441
+            Phase-0 stub for AI 600-1 §2.1 confabulation controls.
+          related-observations:
+            - observation-uuid: 8ac26389-8aa1-49f2-9a9b-6e720a745a7e
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ai600-confabulation
+            type: objective-id
+          title: 'Validation Result - Control: ai600-confabulation'
+          uuid: a873ff2b-6a5d-42c7-b6c1-afacc51dfdb1
+      observations:
+        - collected: 2026-07-26T21:28:35.369009-04:00
+          description: |
+            [TEST]: fedddcdb-2789-4575-9b7e-dbaca5ccb90f - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #fedddcdb-2789-4575-9b7e-dbaca5ccb90f: schema is invalid: [{/properties/domain/$ref/allOf/1/then/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/domain/allOf/1/then/required /domain "missing property 'kubernetes-spec'" <nil>}]
+          uuid: 8ac26389-8aa1-49f2-9a9b-6e720a745a7e
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://airc.nist.gov/Docs/1
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ai600-confabulation
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:28:35.369138-04:00
+      title: Lula Validation Result
+      uuid: cdc1e33b-0cd2-4d46-9756-82831c7c841e
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 4e1574ab-8b13-4b48-b8bc-20daeb93e0ad / Implemented Requirement: fd641f71-329b-41db-83ce-9d2dc1e57c04
+            Phase-0 stub for AI 600-1 §2.6 CBRN harmful content controls.
+          related-observations:
+            - observation-uuid: 2d807f9f-16c1-4eeb-b598-2b23ce26efc3
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ai600-cbrn
+            type: objective-id
+          title: 'Validation Result - Control: ai600-cbrn'
+          uuid: 8a7fb873-c934-4f05-a1f6-39d7e5b5f412
+      observations:
+        - collected: 2026-07-26T21:28:35.178364-04:00
+          description: |
+            [TEST]: ab3e9842-b66a-4e1e-b518-2d47937ee8e8 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #ab3e9842-b66a-4e1e-b518-2d47937ee8e8: schema is invalid: [{/properties/domain/$ref/allOf/1/then/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/domain/allOf/1/then/required /domain "missing property 'kubernetes-spec'" <nil>}]
+          uuid: 2d807f9f-16c1-4eeb-b598-2b23ce26efc3
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://airc.nist.gov/Docs/1
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ai600-cbrn
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:28:35.179499-04:00
+      title: Lula Validation Result
+      uuid: be6ff887-99bb-45f9-9c1b-1f5a1344f654
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 11a88f5e-1f94-5774-94b9-617f7870e62a / Implemented Requirement: 4332a913-0441-5d14-8df5-ba79df3749d5
+            Automated lula validation for A92.
+          related-observations:
+            - observation-uuid: 7781f990-553c-45b6-ad4b-54265433ff77
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a92
+            type: objective-id
+          title: 'Validation Result - Control: a92'
+          uuid: c2cc1731-d7eb-4cf7-9b93-69bc358081f8
+      observations:
+        - collected: 2026-07-26T21:26:04.044188-04:00
+          description: |
+            [TEST]: 189e411a-b3fb-5db2-b787-349693054e29 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #189e411a-b3fb-5db2-b787-349693054e29: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 7781f990-553c-45b6-ad4b-54265433ff77
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a92
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:26:04.044305-04:00
+      title: Lula Validation Result
+      uuid: 6cedb709-b630-4dca-a05f-7d0233621a79
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 1ece732e-9180-52e4-a04d-bb92f5e01929 / Implemented Requirement: 76dea904-7d5c-53b3-b5d8-2c31702ff8ca
+            Automated lula validation for A53.
+          related-observations:
+            - observation-uuid: 27e3a3dd-f1a7-46ab-b52d-998aa04cfc9d
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a53
+            type: objective-id
+          title: 'Validation Result - Control: a53'
+          uuid: 84eeccc4-227c-4de1-8d91-206b59bca38d
+      observations:
+        - collected: 2026-07-26T21:26:03.868895-04:00
+          description: |
+            [TEST]: eb760977-813f-5999-af3f-dcd76b48c7aa - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #eb760977-813f-5999-af3f-dcd76b48c7aa: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 27e3a3dd-f1a7-46ab-b52d-998aa04cfc9d
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a53
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:26:03.869008-04:00
+      title: Lula Validation Result
+      uuid: d8b0124c-1bc9-492d-b4eb-5a3192c4c24d
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: aa0f365e-7e2d-538a-95d1-c994b78ff302 / Implemented Requirement: 6a8eb074-850a-57b0-8198-0b7a929b92b1
+            Automated lula validation for A52.
+          related-observations:
+            - observation-uuid: 921db5eb-b1fe-445c-83da-6d5cd787f41a
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a52
+            type: objective-id
+          title: 'Validation Result - Control: a52'
+          uuid: f1a3f600-a191-48c9-a37a-5828f06761c1
+      observations:
+        - collected: 2026-07-26T21:26:03.691995-04:00
+          description: |
+            [TEST]: 40037dad-ee78-523f-97dc-1f73fabf7d41 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #40037dad-ee78-523f-97dc-1f73fabf7d41: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 921db5eb-b1fe-445c-83da-6d5cd787f41a
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a52
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:26:03.693079-04:00
+      title: Lula Validation Result
+      uuid: b2137313-64ea-482b-aece-73bcd7f13c3b
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: fa3a2446-e669-51fb-89d0-809f86be5882 / Implemented Requirement: 14246452-86b5-58f7-abc8-9ef7f2a9e9f1
+            Automated lula validation for TQP007 (CTRL_TQP_007).
+          related-observations:
+            - observation-uuid: ee2c9f32-631e-4a14-9241-0be1129f1a00
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: A.8.4
+            type: objective-id
+          title: 'Validation Result - Control: A.8.4'
+          uuid: f166b57a-7a92-4cc8-a227-12c91ac2f838
+      observations:
+        - collected: 2026-07-26T21:11:17.394432-04:00
+          description: |
+            [TEST]: 7ce8309c-ecfc-5208-ba63-f6d01d8335b0 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #7ce8309c-ecfc-5208-ba63-f6d01d8335b0: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>}]
+          uuid: ee2c9f32-631e-4a14-9241-0be1129f1a00
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: A.8.4
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:17.394543-04:00
+      title: Lula Validation Result
+      uuid: 21daad19-7f2b-4b72-a97b-480d3af844e9
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 265c3e24-6a08-5306-8c7e-e2c1d830495f / Implemented Requirement: 41943d9b-5ead-5c8e-ace2-b07b769526ac
+            Automated lula validation for SI2.
+          related-observations:
+            - observation-uuid: 3fc39408-6be3-4414-9b06-b98d9e76a834
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: si2
+            type: objective-id
+          title: 'Validation Result - Control: si2'
+          uuid: 5de32aa8-1190-487d-a1f3-3ed9b58dcd80
+      observations:
+        - collected: 2026-07-26T21:11:17.217922-04:00
+          description: |
+            [TEST]: daff725b-aea0-5a5c-981e-df1a30306f2e - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #daff725b-aea0-5a5c-981e-df1a30306f2e: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>}]
+          uuid: 3fc39408-6be3-4414-9b06-b98d9e76a834
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: si2
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:17.218029-04:00
+      title: Lula Validation Result
+      uuid: 6082b8c9-f741-48bb-878a-40a74ebba338
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 2ddc6d0d-c35e-583b-b5bb-12a5a69cbca8 / Implemented Requirement: 50796b20-07f7-5904-acae-cf0e2f117f15
+            Automated lula validation for SC8.
+          related-observations:
+            - observation-uuid: acdce72c-9324-43e5-bcfc-b130431617e3
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: sc8
+            type: objective-id
+          title: 'Validation Result - Control: sc8'
+          uuid: 380fad8c-b015-4d6f-a92b-a2a6502d49db
+      observations:
+        - collected: 2026-07-26T21:11:17.044034-04:00
+          description: |
+            [TEST]: a4ff5a9e-3621-52c6-9c1f-157e6e432b5e - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #a4ff5a9e-3621-52c6-9c1f-157e6e432b5e: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/2 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/3 "missing property 'resource-rule'" <nil>}]
+          uuid: acdce72c-9324-43e5-bcfc-b130431617e3
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: sc8
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:17.044146-04:00
+      title: Lula Validation Result
+      uuid: 5d7db9bf-063c-45ea-9c5c-661b5ffd6eca
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 71af40e7-a7a8-570a-a320-3c4154bea03a / Implemented Requirement: 57b3f09d-e367-5c5c-9876-82f5d837d78b
+            Automated lula validation for SC4.
+          related-observations:
+            - observation-uuid: 164d5f5f-99c8-4340-a7d9-52252333764b
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: sc4
+            type: objective-id
+          title: 'Validation Result - Control: sc4'
+          uuid: cf8d2fa3-62ec-4e0c-8e68-e767255e5952
+      observations:
+        - collected: 2026-07-26T21:11:16.868016-04:00
+          description: |
+            [TEST]: 9b6f9b2e-f19d-54a8-bd5f-47f1fbed0a22 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #9b6f9b2e-f19d-54a8-bd5f-47f1fbed0a22: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>}]
+          uuid: 164d5f5f-99c8-4340-a7d9-52252333764b
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: sc4
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:16.868132-04:00
+      title: Lula Validation Result
+      uuid: c11b236a-dab8-4f25-9c87-92422f8dfb03
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 6957afe5-394b-5641-b059-4d210795dc00 / Implemented Requirement: 4647ae49-b402-5fcd-919b-8a39244aa7f6
+            Automated lula validation for RA5.
+          related-observations:
+            - observation-uuid: 1d44abc3-d648-43b8-9c1b-98e589e748f5
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ra5
+            type: objective-id
+          title: 'Validation Result - Control: ra5'
+          uuid: 501c4d98-49e0-4646-9311-eecdee5be9ee
+      observations:
+        - collected: 2026-07-26T21:11:16.682393-04:00
+          description: |
+            [TEST]: 7a32a7bb-2f37-54ce-a16f-1435d2607512 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #7a32a7bb-2f37-54ce-a16f-1435d2607512: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>}]
+          uuid: 1d44abc3-d648-43b8-9c1b-98e589e748f5
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ra5
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:16.682519-04:00
+      title: Lula Validation Result
+      uuid: 32d67363-f15c-4628-a547-787b5ea69ff0
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 130746b5-8e06-5793-96f5-cbb9ed0cb09e / Implemented Requirement: 41638730-fd45-5c96-a029-f3753269b01c
+            Automated lula validation for MAS TRM S6.
+          related-observations:
+            - observation-uuid: 88863ef5-74b4-41e4-9310-a771026af921
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: mas-trm-s6
+            type: objective-id
+          title: 'Validation Result - Control: mas-trm-s6'
+          uuid: a208723e-1868-470e-8706-270f958a594d
+      observations:
+        - collected: 2026-07-26T21:11:16.510422-04:00
+          description: |
+            [TEST]: 1cd75fa9-7175-5f07-a975-4eed29074d88 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #1cd75fa9-7175-5f07-a975-4eed29074d88: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 88863ef5-74b4-41e4-9310-a771026af921
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.mas.gov.sg/regulation/guidelines/technology-risk-management-guidelines
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: mas-trm-s6
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:16.510532-04:00
+      title: Lula Validation Result
+      uuid: 14f7b16f-1733-4a4d-91a3-697a3dbd60cc
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 27475017-b615-5f28-bc86-137cebf13a3a / Implemented Requirement: 564d9d85-b2a5-5494-83d2-d06334ec06b7
+            Automated lula validation for MAS NOTICE655.
+          related-observations:
+            - observation-uuid: a5fea163-46f4-4874-af42-6561760f69af
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: mas-notice655
+            type: objective-id
+          title: 'Validation Result - Control: mas-notice655'
+          uuid: f5be773e-ebf9-4552-bbbe-4a26e0943f16
+      observations:
+        - collected: 2026-07-26T21:11:16.33768-04:00
+          description: |
+            [TEST]: 31845ca7-3729-5a11-8faa-028892829144 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #31845ca7-3729-5a11-8faa-028892829144: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: a5fea163-46f4-4874-af42-6561760f69af
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://lula.dev
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: mas-notice655
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:16.3378-04:00
+      title: Lula Validation Result
+      uuid: eddb2cac-e623-4ffb-9872-f417bc8d76a8
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 350c54ef-a57a-5117-b4e1-03c257885b21 / Implemented Requirement: 241d9a37-67b7-5deb-914b-5f83e8ed68d8
+            Automated lula validation for MAS FEAT.
+          related-observations:
+            - observation-uuid: 1c233093-a3de-41ed-8348-6f1afc1fea02
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: mas-feat
+            type: objective-id
+          title: 'Validation Result - Control: mas-feat'
+          uuid: cdadaf92-f7cb-4c84-8a53-5cc4b589e1ac
+      observations:
+        - collected: 2026-07-26T21:11:16.160317-04:00
+          description: |
+            [TEST]: 44249863-3ab1-5cb0-9b6f-3a17700a71b2 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #44249863-3ab1-5cb0-9b6f-3a17700a71b2: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 1c233093-a3de-41ed-8348-6f1afc1fea02
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.mas.gov.sg/regulation/guidelines/technology-risk-management-guidelines
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: mas-feat
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:16.160434-04:00
+      title: Lula Validation Result
+      uuid: c47c5ebe-d9ab-4fba-b208-2c4d1e9f6d5b
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 3f2c9f85-c105-5d35-898d-e7fde67638ef / Implemented Requirement: b73bcc6c-d919-5368-bbd3-77f142eb54dd
+            Automated lula validation for ISO001 TOKEN QUOTA (ISO-001).
+          related-observations:
+            - observation-uuid: 81585b06-37c3-4a56-83ad-a62fc5de473c
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: A.4
+            type: objective-id
+          title: 'Validation Result - Control: A.4'
+          uuid: 841eb4f5-1005-4f60-8170-5e418a9c1b0a
+      observations:
+        - collected: 2026-07-26T21:11:15.989857-04:00
+          description: |
+            [TEST]: 9c4c3db2-8fc7-5959-ba63-38e6ffd6ecc9 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #9c4c3db2-8fc7-5959-ba63-38e6ffd6ecc9: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>}]
+          uuid: 81585b06-37c3-4a56-83ad-a62fc5de473c
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: A.4
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:15.98997-04:00
+      title: Lula Validation Result
+      uuid: f7b7f280-2bc1-4581-910b-7ef6fc776cac
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 92301774-6531-538c-ac3f-5509744b1aa0 / Implemented Requirement: 3fdd491f-1d9e-523a-a46d-07abfedf72f1
+            Automated lula validation for IR6.
+          related-observations:
+            - observation-uuid: 9bc49cb9-8ca3-4f73-8c88-4113e9661bd7
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ir6
+            type: objective-id
+          title: 'Validation Result - Control: ir6'
+          uuid: ac9124be-a4ba-4dd9-8ae2-95bd5a5454f0
+      observations:
+        - collected: 2026-07-26T21:11:15.818298-04:00
+          description: |
+            [TEST]: 07d356e8-2cf4-5aa3-8523-cd3e868d4367 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #07d356e8-2cf4-5aa3-8523-cd3e868d4367: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>}]
+          uuid: 9bc49cb9-8ca3-4f73-8c88-4113e9661bd7
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ir6
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:15.818408-04:00
+      title: Lula Validation Result
+      uuid: 8a3f0291-48d7-44c6-ba13-e2d51973e03b
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 8ca3b5e5-0d39-5d8f-a452-020ca7259254 / Implemented Requirement: cce1fd52-f0f5-5788-9a91-ca652f102324
+            Automated lula validation for IA5.
+          related-observations:
+            - observation-uuid: b7bd3b76-852b-49fe-b6e5-546b1a3041b9
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ia5
+            type: objective-id
+          title: 'Validation Result - Control: ia5'
+          uuid: 4cd79f19-410a-4685-9737-f6d8810bd4c1
+      observations:
+        - collected: 2026-07-26T21:11:15.646729-04:00
+          description: |
+            [TEST]: b322b5e6-d8bd-51ab-bbf0-246a45d87b8f - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #b322b5e6-d8bd-51ab-bbf0-246a45d87b8f: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>}]
+          uuid: b7bd3b76-852b-49fe-b6e5-546b1a3041b9
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ia5
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:15.646836-04:00
+      title: Lula Validation Result
+      uuid: 6b7adfe7-49a7-45cc-a3bc-5d325696746b
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: b0982882-d418-5f5f-b01c-c473cbb86fba / Implemented Requirement: a92a8532-0edd-5c5f-800e-a112ff570d38
+            Automated lula validation for IA3.
+          related-observations:
+            - observation-uuid: 91ce8257-2980-49e7-a4c4-cc81ce8f1bec
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ia3
+            type: objective-id
+          title: 'Validation Result - Control: ia3'
+          uuid: 7dc25ce1-9257-4e88-a2dd-470384ffe59b
+      observations:
+        - collected: 2026-07-26T21:11:15.483688-04:00
+          description: |
+            [TEST]: 976c6d03-26a0-5071-86ec-98978bdc5a7e - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #976c6d03-26a0-5071-86ec-98978bdc5a7e: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/2 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/3 "missing property 'resource-rule'" <nil>}]
+          uuid: 91ce8257-2980-49e7-a4c4-cc81ce8f1bec
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ia3
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:15.483799-04:00
+      title: Lula Validation Result
+      uuid: d8297ea9-be45-4778-ab6f-a8cc7ea8ed85
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 64186a87-ffc0-514c-877e-41832df17e5c / Implemented Requirement: c7b6e46e-eac7-5499-80aa-af4dba8e104d
+            Automated lula validation for GDPR ART22.
+          related-observations:
+            - observation-uuid: 4b453bc1-f91b-4a04-9ce7-7673e6f6d80a
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: gdpr-art22
+            type: objective-id
+          title: 'Validation Result - Control: gdpr-art22'
+          uuid: f0e5672d-0e5c-4dca-adc3-c9bcc6331bb7
+      observations:
+        - collected: 2026-07-26T21:11:15.31866-04:00
+          description: |
+            [TEST]: 877aaff1-86c0-5e6d-a9b9-2756af2e6889 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #877aaff1-86c0-5e6d-a9b9-2756af2e6889: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 4b453bc1-f91b-4a04-9ce7-7673e6f6d80a
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32016R0679
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: gdpr-art22
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:15.318772-04:00
+      title: Lula Validation Result
+      uuid: fe5232af-a02a-499b-baf6-de364e1584d5
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 3e5c5cbb-a661-56be-9742-ed8e86fe38f9 / Implemented Requirement: e30d88ac-5dd8-5a04-b6f3-5eaf024e508e
+            Automated lula validation for EU FRIA (EU-001).
+          related-observations:
+            - observation-uuid: c00eb549-3ae6-4f2c-97e3-ec9147a2228f
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: EU_AI_ACT_ART29A
+            type: objective-id
+          title: 'Validation Result - Control: EU_AI_ACT_ART29A'
+          uuid: e562b7f1-13f0-45f3-a1b8-bd6de9a4f82f
+      observations:
+        - collected: 2026-07-26T21:11:15.118728-04:00
+          description: |
+            [TEST]: 3b422f73-7da4-5147-8c46-8abe44f82892 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #3b422f73-7da4-5147-8c46-8abe44f82892: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>}]
+          uuid: c00eb549-3ae6-4f2c-97e3-ec9147a2228f
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://lula.dev
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: EU_AI_ACT_ART29A
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:15.118868-04:00
+      title: Lula Validation Result
+      uuid: a23630f2-b938-4ddc-860e-322120a57729
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 58d1a2f5-47d9-594b-805f-3316a2fdc129 / Implemented Requirement: 5f274328-f25a-5a19-8d0a-4a103d341baf
+            Automated lula validation for EU AI ACT ART9.
+          related-observations:
+            - observation-uuid: c8d13f70-eb35-4a56-8f1d-17166e0b5be8
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: eu-ai-act-art9
+            type: objective-id
+          title: 'Validation Result - Control: eu-ai-act-art9'
+          uuid: 150f7e93-c692-4342-aafa-f62d695c3e1c
+      observations:
+        - collected: 2026-07-26T21:11:14.951165-04:00
+          description: |
+            [TEST]: bf519130-9b51-584d-b88c-d2357f5ab16f - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #bf519130-9b51-584d-b88c-d2357f5ab16f: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: c8d13f70-eb35-4a56-8f1d-17166e0b5be8
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32024R1689
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: eu-ai-act-art9
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:14.951283-04:00
+      title: Lula Validation Result
+      uuid: b006c80a-5605-4441-aacd-62245129bffa
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: b10dffbc-e2ac-5479-8b54-599f18925b3a / Implemented Requirement: d71fd848-246a-5665-9fd1-ad67cd2bc703
+            Automated lula validation for DORA ART10.
+          related-observations:
+            - observation-uuid: edc12c63-4a98-4579-8485-01f1dd9c434a
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: dora-art10
+            type: objective-id
+          title: 'Validation Result - Control: dora-art10'
+          uuid: c04c1664-a326-4b35-8f04-d2ed8431172b
+      observations:
+        - collected: 2026-07-26T21:11:14.782087-04:00
+          description: |
+            [TEST]: eaacb9e8-bb4f-5c67-a1f2-4adb59b47eaa - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #eaacb9e8-bb4f-5c67-a1f2-4adb59b47eaa: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: edc12c63-4a98-4579-8485-01f1dd9c434a
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=CELEX:32022R2554
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: dora-art10
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:14.782204-04:00
+      title: Lula Validation Result
+      uuid: f23476b5-5f5e-4aa7-8e7e-f010ab2cdb1d
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 9dec443c-138b-578d-9255-d6f67fc95c5b / Implemented Requirement: 7054ff11-50ab-5798-80b5-7f28c918da9a
+            Automated lula validation for CM6.
+          related-observations:
+            - observation-uuid: af8d8078-4686-4e2a-8232-0e6cbe72f1a1
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: cm6
+            type: objective-id
+          title: 'Validation Result - Control: cm6'
+          uuid: 794cf636-17f1-4f70-80b0-e060da419303
+      observations:
+        - collected: 2026-07-26T21:11:14.590533-04:00
+          description: |
+            [TEST]: d3a42dd5-3cf9-5ee5-baae-5b72ebd497ab - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #d3a42dd5-3cf9-5ee5-baae-5b72ebd497ab: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>}]
+          uuid: af8d8078-4686-4e2a-8232-0e6cbe72f1a1
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: cm6
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:14.590651-04:00
+      title: Lula Validation Result
+      uuid: b1d2cf3a-67dc-49ef-aae0-4dd762e79ebf
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 257ab77e-1020-5595-a07b-a8ae59511c0d / Implemented Requirement: 4405db85-a4ec-513f-bc34-161e9935bf04
+            Automated lula validation for AU12.
+          related-observations:
+            - observation-uuid: 82835cef-da87-4506-9fb5-e59f4b54ac24
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: au12
+            type: objective-id
+          title: 'Validation Result - Control: au12'
+          uuid: 006d709d-258e-4fc2-9d11-2f5b12b4e0d4
+      observations:
+        - collected: 2026-07-26T21:11:14.411352-04:00
+          description: |
+            [TEST]: 610ee241-76a3-5f1f-b41d-613019559b15 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #610ee241-76a3-5f1f-b41d-613019559b15: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>}]
+          uuid: 82835cef-da87-4506-9fb5-e59f4b54ac24
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: au12
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:14.411468-04:00
+      title: Lula Validation Result
+      uuid: 84bd1f7a-d7cc-4cec-8bab-9a5c2b4ac67c
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: b8efdf73-2801-5ce0-a588-b486e87bd490 / Implemented Requirement: dc9af4f2-aeef-55ae-ac99-95eeed7f3521
+            Automated lula validation for AC3.
+          related-observations:
+            - observation-uuid: b1240d7f-acc0-43ca-ad80-a2bd0045a745
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ac3
+            type: objective-id
+          title: 'Validation Result - Control: ac3'
+          uuid: 090af08c-12f6-4050-947c-357e889ca0d3
+      observations:
+        - collected: 2026-07-26T21:11:13.63784-04:00
+          description: |
+            [TEST]: 73f98590-b9c9-52da-bfac-27cf03ae46af - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #73f98590-b9c9-52da-bfac-27cf03ae46af: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>}]
+          uuid: b1240d7f-acc0-43ca-ad80-a2bd0045a745
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ac3
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:13.637949-04:00
+      title: Lula Validation Result
+      uuid: d25846ae-bb6a-4f00-a595-a420d27a60c4
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 22ce9e77-15c9-5ba5-9d91-a0b0191ebb44 / Implemented Requirement: 18e5a104-64e5-58d5-b8c4-dcd91b3878ce
+            Automated lula validation for AC2.
+          related-observations:
+            - observation-uuid: 0b958207-8314-4509-9dd3-ca2bb660f7e9
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: ac2
+            type: objective-id
+          title: 'Validation Result - Control: ac2'
+          uuid: 6f95ac75-a236-42a7-9e6a-aee9ae159c11
+      observations:
+        - collected: 2026-07-26T21:11:13.470229-04:00
+          description: |
+            [TEST]: 1fcd8ff2-3d20-5d34-a450-0f78901b8039 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #1fcd8ff2-3d20-5d34-a450-0f78901b8039: schema is invalid: [{/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/0 "missing property 'resource-rule'" <nil>} {/properties/domain/$ref/properties/kubernetes-spec/$ref/properties/resources/items/$ref/required https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/resource/required /domain/kubernetes-spec/resources/1 "missing property 'resource-rule'" <nil>}]
+          uuid: 0b958207-8314-4509-9dd3-ca2bb660f7e9
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: ac2
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:13.470338-04:00
+      title: Lula Validation Result
+      uuid: a983f192-dc5b-4128-8669-06888f828a75
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: a3697688-6e46-5205-910e-22c7b44f6bdd / Implemented Requirement: 6915c619-071a-51ea-a57f-60232a68751d
+            Automated lula validation for AARM VECTORS.
+          related-observations:
+            - observation-uuid: 593b1dfe-3555-4d22-8795-a102caeeb473
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: aarm-vectors
+            type: objective-id
+          title: 'Validation Result - Control: aarm-vectors'
+          uuid: 65733a49-cd1d-4aa4-8e41-97fe40e1ec3e
+      observations:
+        - collected: 2026-07-26T21:11:13.313181-04:00
+          description: |
+            [TEST]: ec32ba67-e5a7-50b4-8ff5-eca8aac8da66 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #ec32ba67-e5a7-50b4-8ff5-eca8aac8da66: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 593b1dfe-3555-4d22-8795-a102caeeb473
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://cloudsecurityalliance.org/research/working-groups/artificial-intelligence
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: aarm-vectors
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:13.313296-04:00
+      title: Lula Validation Result
+      uuid: 70b8b967-e894-4ccd-89c7-b60b920a38b0
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 11a88f5e-1f94-5774-94b9-617f7870e62a / Implemented Requirement: 4332a913-0441-5d14-8df5-ba79df3749d5
+            Automated lula validation for A92.
+          related-observations:
+            - observation-uuid: e0a519f3-308b-4ea5-880a-5a0f38e05b8d
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a92
+            type: objective-id
+          title: 'Validation Result - Control: a92'
+          uuid: 9078b702-2f84-460b-9e6f-69a938f343c3
+      observations:
+        - collected: 2026-07-26T21:11:13.1438-04:00
+          description: |
+            [TEST]: 189e411a-b3fb-5db2-b787-349693054e29 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #189e411a-b3fb-5db2-b787-349693054e29: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: e0a519f3-308b-4ea5-880a-5a0f38e05b8d
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a92
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:13.143908-04:00
+      title: Lula Validation Result
+      uuid: aae5f0df-6e79-46e3-8f3b-5da0fa71645b
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 1ece732e-9180-52e4-a04d-bb92f5e01929 / Implemented Requirement: 76dea904-7d5c-53b3-b5d8-2c31702ff8ca
+            Automated lula validation for A53.
+          related-observations:
+            - observation-uuid: 7c05283f-b2a1-4d15-8829-45dec60b7958
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a53
+            type: objective-id
+          title: 'Validation Result - Control: a53'
+          uuid: 34729bcc-a8f9-4608-b047-a568710b436c
+      observations:
+        - collected: 2026-07-26T21:11:12.942029-04:00
+          description: |
+            [TEST]: eb760977-813f-5999-af3f-dcd76b48c7aa - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #eb760977-813f-5999-af3f-dcd76b48c7aa: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 7c05283f-b2a1-4d15-8829-45dec60b7958
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a53
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:12.942135-04:00
+      title: Lula Validation Result
+      uuid: 2cc58c53-550f-4f18-b63f-418600b28a65
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: aa0f365e-7e2d-538a-95d1-c994b78ff302 / Implemented Requirement: 6a8eb074-850a-57b0-8198-0b7a929b92b1
+            Automated lula validation for A52.
+          related-observations:
+            - observation-uuid: b4c01afc-a4aa-49ce-b904-0c6985863907
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a52
+            type: objective-id
+          title: 'Validation Result - Control: a52'
+          uuid: 0a304d6a-25a4-452e-a420-ae1dc32ab83c
+      observations:
+        - collected: 2026-07-26T21:11:12.774626-04:00
+          description: |
+            [TEST]: 40037dad-ee78-523f-97dc-1f73fabf7d41 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #40037dad-ee78-523f-97dc-1f73fabf7d41: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: b4c01afc-a4aa-49ce-b904-0c6985863907
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a52
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:12.775699-04:00
+      title: Lula Validation Result
+      uuid: d31d39af-3d30-466d-9aa0-3c0c53657f1a
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: a3697688-6e46-5205-910e-22c7b44f6bdd / Implemented Requirement: 6915c619-071a-51ea-a57f-60232a68751d
+            Automated lula validation for AARM VECTORS.
+          related-observations:
+            - observation-uuid: b3506717-a424-4dc2-845b-cf5243697b1d
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: aarm-vectors
+            type: objective-id
+          title: 'Validation Result - Control: aarm-vectors'
+          uuid: 53920370-b16f-4aa8-bd95-7e19985c7d55
+      observations:
+        - collected: 2026-07-26T21:11:03.728999-04:00
+          description: |
+            [TEST]: ec32ba67-e5a7-50b4-8ff5-eca8aac8da66 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #ec32ba67-e5a7-50b4-8ff5-eca8aac8da66: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: b3506717-a424-4dc2-845b-cf5243697b1d
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://cloudsecurityalliance.org/research/working-groups/artificial-intelligence
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: aarm-vectors
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:03.729119-04:00
+      title: Lula Validation Result
+      uuid: b4905b97-b5d8-4bba-beae-24a195c24849
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 11a88f5e-1f94-5774-94b9-617f7870e62a / Implemented Requirement: 4332a913-0441-5d14-8df5-ba79df3749d5
+            Automated lula validation for A92.
+          related-observations:
+            - observation-uuid: 0e182495-0bd4-4f0a-bd07-d45194657b58
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a92
+            type: objective-id
+          title: 'Validation Result - Control: a92'
+          uuid: ace02d36-809d-4a6d-b1e0-4480ca29ddeb
+      observations:
+        - collected: 2026-07-26T21:11:03.571597-04:00
+          description: |
+            [TEST]: 189e411a-b3fb-5db2-b787-349693054e29 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #189e411a-b3fb-5db2-b787-349693054e29: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 0e182495-0bd4-4f0a-bd07-d45194657b58
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a92
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:03.57171-04:00
+      title: Lula Validation Result
+      uuid: 66b9a696-d3d2-41c7-a6ce-6f6945b8c91c
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: 1ece732e-9180-52e4-a04d-bb92f5e01929 / Implemented Requirement: 76dea904-7d5c-53b3-b5d8-2c31702ff8ca
+            Automated lula validation for A53.
+          related-observations:
+            - observation-uuid: 358995b9-050c-4487-a860-15c9d4bcb78d
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a53
+            type: objective-id
+          title: 'Validation Result - Control: a53'
+          uuid: bab51d07-36c2-4d03-8c8d-5034ac5e4887
+      observations:
+        - collected: 2026-07-26T21:11:03.408454-04:00
+          description: |
+            [TEST]: eb760977-813f-5999-af3f-dcd76b48c7aa - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #eb760977-813f-5999-af3f-dcd76b48c7aa: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 358995b9-050c-4487-a860-15c9d4bcb78d
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a53
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:03.408562-04:00
+      title: Lula Validation Result
+      uuid: f830678e-5904-49cf-b97d-1591ad00c08c
+    - description: Assessment results for performing Validations with Lula version v0.16.0
+      findings:
+        - description: |
+            Control Implementation: aa0f365e-7e2d-538a-95d1-c994b78ff302 / Implemented Requirement: 6a8eb074-850a-57b0-8198-0b7a929b92b1
+            Automated lula validation for A52.
+          related-observations:
+            - observation-uuid: 758702f5-ab55-42e8-a395-4a612bc1ea55
+          target:
+            status:
+              reason: fail
+              state: not-satisfied
+            target-id: a52
+            type: objective-id
+          title: 'Validation Result - Control: a52'
+          uuid: d62f5379-acd3-417d-9e72-dd1abc75269d
+      observations:
+        - collected: 2026-07-26T21:11:03.251089-04:00
+          description: |
+            [TEST]: 40037dad-ee78-523f-97dc-1f73fabf7d41 - lula-validation-error
+          methods:
+            - TEST
+          props:
+            - name: validation
+              ns: https://docs.lula.dev/oscal/ns
+              value: '#'
+          relevant-evidence:
+            - description: |
+                Result: not-satisfied
+              remarks: |
+                Error getting Lula validation #40037dad-ee78-523f-97dc-1f73fabf7d41: schema is invalid: [{/properties/domain/$ref/properties/api-spec/$ref/properties/requests/type https://github.com/defenseunicorns/lula/tree/main/src/pkg/schemas/validation.json#/definitions/api-spec/properties/requests/type /domain/api-spec/requests "got null, want array" <nil>}]
+          uuid: 758702f5-ab55-42e8-a395-4a612bc1ea55
+      props:
+        - name: threshold
+          ns: https://docs.lula.dev/oscal/ns
+          value: "false"
+        - name: target
+          ns: https://docs.lula.dev/oscal/ns
+          value: https://www.iso.org/standard/81230.html
+      reviewed-controls:
+        control-selections:
+          - description: Controls Assessed by Lula
+            include-controls:
+              - control-id: a52
+        description: Controls validated
+        remarks: Validation performed may indicate full or partial satisfaction
+      start: 2026-07-26T21:11:03.251299-04:00
+      title: Lula Validation Result
+      uuid: 9d70442c-376d-4bfc-98f5-81e758307fa0
     - description: Assessment results for performing Validations with Lula version v0.16.0
       findings:
         - description: |
@@ -4247,4 +11385,4 @@ assessment-results:
       start: 2026-07-01T09:19:14.704173-04:00
       title: Lula Validation Result
       uuid: c9864669-1946-45b7-a366-fede562dc54c
-  uuid: 29822083-5af1-4036-9ff1-20333b92f8ce
+  uuid: 8a5594ff-2d41-46c6-9f4f-3d86bb6c2693


### PR DESCRIPTION
## Summary
Refreshed Lula compliance assessment results and updated README.

## Changes
- Updated compliance/lula/assessment-results.yaml with latest assessment data
- Updated compliance/lula/README.md documentation

## Change Category
Cat-S (Standard) — compliance artifact refresh