### PR TITLE
chore(governance): bump package version to v2.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cybernetic-governance-engine"
-version = "0.2.0"
+version = "2.1.0"
 description = "CAGE — Cybernetic AI Governance Engine"
 authors = [{ name = "OSS Maintainer", email = "oss-maintainer@example.com" }]
 license = "Apache-2.0"

--- a/src/cybernetic_governance_engine/__init__.py
+++ b/src/cybernetic_governance_engine/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Empty init file
+__version__ = "2.1.0"


### PR DESCRIPTION
## Summary
Version bump to v2.1.0 for the release cycle.

## Changes
- Updated pyproject.toml version to v2.1.0
- Updated src/cybernetic_governance_engine/__init__.py version string

## Change Category
Cat-S (Standard) — version bump only