### PR TITLE
chore(ci): enforce squash-merge policy across CI and agent rules

### DIFF
--- a/.github/branch-protection-rules.md
+++ b/.github/branch-protection-rules.md
@@ -31,6 +31,16 @@
 | Allow force pushes | ❌ Disabled | Protects immutable audit trail on `main` |
 | Allow deletions | ❌ Disabled | `main` must not be deleted |
 
+**Settings → General → Pull Requests** (repository-level, not branch-protection-rule):
+
+| Setting | Value | Rationale |
+|---|---|---|
+| Allow merge commits | ❌ Disabled | Removes the "Create a merge commit" button; enforces squash-only strategy per GIT_WORKFLOW_STANDARDS §4.5 |
+| Allow squash merging | ✅ Enabled — default message: **Pull request title** | One clean commit per PR on `main`; PR title must follow Conventional Commits |
+| Allow rebase merging | ❌ Disabled | Not used in this repository; disabling prevents accidental use |
+
+> **Why this matters:** Without disabling merge commits at the repository level, GitHub presents all three merge buttons regardless of documented policy. PRs #41–#44 were merged with standard merge commits because this setting was never applied. The CI non-squash-merge detection step (see §3) provides a secondary signal if the setting is ever accidentally re-enabled.
+
 ---
 
 ## 2. Branch Protection — `release/**`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,25 @@ on:
       - main
 
 jobs:
+  squash-merge-guard:
+    name: "Squash Merge Guard"
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+      - name: Detect non-squash merge commits on main
+        run: |
+          parents=$(git cat-file -p HEAD | grep -c "^parent ")
+          if [ "$parents" -gt 1 ]; then
+            echo "::error::Non-squash merge commit detected on main ($(git rev-parse HEAD))."
+            echo "::error::GIT_WORKFLOW_STANDARDS §4.5 requires squash merge for all PRs."
+            echo "::error::Fix: Settings → General → Pull Requests → disable 'Allow merge commits'."
+            exit 1
+          fi
+          echo "OK: HEAD is a single-parent commit (squash or direct push)."
+
   license-check:
     runs-on: ubuntu-latest
     steps:

--- a/.roo/rules-commit-convention/commit-convention.md
+++ b/.roo/rules-commit-convention/commit-convention.md
@@ -231,11 +231,34 @@ primary intent, not every commit.
 
 | Branch | Rule |
 |---|---|
-| `main` | No direct push. Requires PR + CI green + 1 reviewer approval. |
+| `main` | No direct push. Requires PR + CI green + 1 reviewer approval. Squash merge only. |
 | `rc-v*` | No direct push. Requires PR + CI green. |
 
 When the user asks to commit or push directly to `main` or `rc-v*`, refuse and
 instead suggest creating a feature branch and opening a PR.
+
+### Merge Strategy Rules
+
+**Squash merge is the only permitted strategy for all PRs into `main`.**
+
+When suggesting how to merge a PR, always say:
+> Use "Squash and merge" on GitHub. Confirm the pre-filled commit message matches
+> the PR title and follows Conventional Commits format before clicking.
+
+Never suggest:
+- `git merge <branch>` into `main` (produces a merge commit)
+- `git merge --no-ff <branch>` (produces a merge commit)
+- Clicking "Create a merge commit" on GitHub
+- Clicking "Rebase and merge" on GitHub
+
+The repository setting **"Allow merge commits"** must be disabled in
+Settings → General → Pull Requests. If it is not, flag this as a configuration
+gap and remind the user to disable it.
+
+A `squash-merge-guard` CI job in `.github/workflows/ci.yml` detects any
+two-parent merge commit that reaches `main` and fails the build. If this job
+fires, the fix is to re-enable the "Allow merge commits: disabled" repository
+setting and investigate how the merge commit was created.
 
 ### Branch Naming Self-Validation
 

--- a/.roo/rules/00-global-standards.md
+++ b/.roo/rules/00-global-standards.md
@@ -73,6 +73,27 @@
 
 ---
 
+## PR Merge Strategy Rules
+
+**Squash merge is the only permitted strategy for all PRs into `main`.**
+
+- Never suggest "Create a merge commit" or rebase merge for PRs targeting `main`.
+- Always instruct the user to use the **"Squash and merge"** button on GitHub.
+- The squash commit message is taken verbatim from the PR title — the PR title must therefore follow Conventional Commits format exactly (see Commit Message Rules above).
+- The repository setting **"Allow merge commits"** must be disabled in Settings → General → Pull Requests. If it is not, flag this as a configuration gap.
+- A `squash-merge-guard` CI job in `.github/workflows/ci.yml` detects any two-parent merge commit that reaches `main` and fails the build. If this job fires, the fix is to re-enable the repository setting and investigate how the merge commit was created.
+
+**When suggesting how to merge a PR, always say:**
+> Use "Squash and merge" on GitHub. Confirm the pre-filled commit message matches the PR title and follows Conventional Commits format before clicking.
+
+**Never suggest:**
+- `git merge <branch>` into `main` (produces a merge commit)
+- `git merge --no-ff <branch>` (produces a merge commit)
+- Clicking "Create a merge commit" on GitHub
+- Clicking "Rebase and merge" on GitHub
+
+---
+
 ## Secret & Credential Hygiene
 
 **Never commit secrets, credentials, API keys, passwords, tokens, or PII.**

--- a/docs/operations/GIT_WORKFLOW_STANDARDS.md
+++ b/docs/operations/GIT_WORKFLOW_STANDARDS.md
@@ -311,6 +311,18 @@ Merge commits are reserved for merging the integration branch (`rc-v*`) into `ma
 
 Rebase merging is not used in this repository.
 
+**Enforcement — repository settings (Settings → General → Pull Requests):**
+
+| Setting | Required value |
+|---|---|
+| Allow merge commits | ❌ Disabled |
+| Allow squash merging | ✅ Enabled — default message: Pull request title |
+| Allow rebase merging | ❌ Disabled |
+
+Disabling merge commits removes the "Create a merge commit" button from the GitHub PR UI, making squash the only available strategy. This is the primary enforcement mechanism. A secondary `squash-merge-guard` job in `.github/workflows/ci.yml` detects any two-parent commit that reaches `main` (e.g., if the setting is accidentally re-enabled) and fails the build with an actionable error message.
+
+> **Root cause of PRs #41–#44 non-squash merges (2026-07-27):** These PRs were merged with standard merge commits because the repository-level "Allow merge commits" setting had never been disabled. The policy was documented here but not technically enforced. The settings above and the CI guard close that gap.
+
 ---
 
 ## 5. Protected Branch Workflow


### PR DESCRIPTION
## Summary

Adds a secondary enforcement layer for the squash-merge-only policy on `main`.

### Changes

- **`.github/workflows/ci.yml`** — new `squash-merge-guard` job: detects two-parent merge commits on `main` and fails with an actionable error annotation
- **`.github/branch-protection-rules.md`** — documents the three required GitHub repository settings (merge commits disabled, squash merging enabled with PR title as default, rebase merging disabled)
- **`docs/operations/GIT_WORKFLOW_STANDARDS.md`** — §4.5 extended with enforcement table and root-cause note for PRs #41–#44
- **`.roo/rules/00-global-standards.md`** — new PR Merge Strategy Rules section instructing all Roo modes to always recommend "Squash and merge"
- **`.roo/rules-commit-convention/commit-convention.md`** — Step 9 extended with Merge Strategy Rules subsection

### Merge instructions

Use **"Squash and merge"** on GitHub. Confirm the pre-filled commit message matches the PR title and follows Conventional Commits format before clicking.