### PR TITLE
fix(governance): fix ruff I001 import order and RUF003 char in comments

### DIFF
--- a/src/gateway/governance/cbf.py
+++ b/src/gateway/governance/cbf.py
@@ -183,6 +183,8 @@ return {1, "COMMITTED", tostring(next_cash)}
 
         # ── Attempt 1: externally reconciled balance (POAM-023) ──────────────
         try:
+            import asyncio as _asyncio
+
             from src.compliance_bridge.reconciliation_worker import (
                 read_verified_balance,
             )
@@ -194,8 +196,6 @@ return {1, "COMMITTED", tostring(next_cash)}
             #   "the JSON object must be str, bytes or bytearray, not coroutine"
             # (CBF_USING_SELF_REPORTED_BALANCE log sentinel — POAM-023 async bug).
             from src.gateway.infrastructure.redis_client import sync_redis_client
-
-            import asyncio as _asyncio
 
             verified = await _asyncio.to_thread(
                 read_verified_balance, sync_redis_client

--- a/src/gateway/governance/consensus.py
+++ b/src/gateway/governance/consensus.py
@@ -257,7 +257,7 @@ class ConsensusEngine:
             # causing the test to time out before the consensus gate resolved.
             # 10 s is sufficient for a healthy vLLM instance and still allows
             # the test to complete within its 120 s pytest-timeout budget even
-            # when both critics are unreachable (2 × 10 s = 20 s worst case).
+            # when both critics are unreachable (2 x 10 s = 20 s worst case).
             _CRITIC_TIMEOUT_S: float = float(
                 os.getenv("CONSENSUS_CRITIC_TIMEOUT_S", "10.0")
             )
@@ -271,7 +271,10 @@ class ConsensusEngine:
                         dedicated_client.chat.completions.create(
                             model=model or "default",
                             messages=[
-                                {"role": "system", "content": f"You are a strict {role}."},
+                                {
+                                    "role": "system",
+                                    "content": f"You are a strict {role}.",
+                                },
                                 {"role": "user", "content": prompt},
                             ],
                             temperature=0.0,
@@ -391,12 +394,20 @@ class ConsensusEngine:
                 )
                 decision = "ESCALATE"
                 reason = "consensus_unanimous_error"
-            elif non_error_votes and all(v == "REJECT" for v in non_error_votes) and not error_votes:
+            elif (
+                non_error_votes
+                and all(v == "REJECT" for v in non_error_votes)
+                and not error_votes
+            ):
                 # Genuine unanimous rejection: ALL critics voted and ALL rejected.
                 # No ERRORs present — this is a full quorum denial.
                 decision = "REJECT"
                 reason = f"Unanimous rejection by all critics. Votes: {votes}"
-            elif non_error_votes and all(v == "REJECT" for v in non_error_votes) and error_votes:
+            elif (
+                non_error_votes
+                and all(v == "REJECT" for v in non_error_votes)
+                and error_votes
+            ):
                 # Degraded quorum: some critics errored, remaining non-error votes are
                 # all REJECT.  This is NOT a unanimous rejection — the errored critics
                 # could not participate.  Escalate for human review.

--- a/tests/test_governance_webhook.py
+++ b/tests/test_governance_webhook.py
@@ -115,17 +115,13 @@ class TestWebhookRegistration:
                 secret="test-secret",
             )
         )
-        removed = asyncio.run(
-            registry.deregister(webhook_id)
-        )
+        removed = asyncio.run(registry.deregister(webhook_id))
         assert removed is True
         assert webhook_id not in registry._registrations
 
     def test_deregister_nonexistent_returns_false(self):
         registry = _make_registry()
-        removed = asyncio.run(
-            registry.deregister("nonexistent-id")
-        )
+        removed = asyncio.run(registry.deregister("nonexistent-id"))
         assert removed is False
 
     def test_list_registrations_returns_all(self):
@@ -144,9 +140,7 @@ class TestWebhookRegistration:
                 secret="other-secret",
             )
         )
-        registrations = asyncio.run(
-            registry.list_registrations()
-        )
+        registrations = asyncio.run(registry.list_registrations())
         assert len(registrations) == 2
 
     def test_list_registrations_does_not_include_secret(self):
@@ -158,9 +152,7 @@ class TestWebhookRegistration:
                 secret="super-secret-value",
             )
         )
-        registrations = asyncio.run(
-            registry.list_registrations()
-        )
+        registrations = asyncio.run(registry.list_registrations())
         for reg in registrations:
             assert "secret" not in reg
             assert "super-secret-value" not in str(reg)
@@ -225,9 +217,7 @@ class TestWebhookDispatch:
             return True
 
         with mock.patch.object(registry, "_deliver", side_effect=mock_deliver):
-            asyncio.run(
-                registry.dispatch(_make_event("CBF_VIOLATION"))
-            )
+            asyncio.run(registry.dispatch(_make_event("CBF_VIOLATION")))
 
         assert len(delivered_payloads) == 1
         assert delivered_payloads[0]["type"] == "CBF_VIOLATION"
@@ -249,9 +239,7 @@ class TestWebhookDispatch:
             return True
 
         with mock.patch.object(registry, "_deliver", side_effect=mock_deliver):
-            asyncio.run(
-                registry.dispatch(_make_event("CBF_VIOLATION"))
-            )
+            asyncio.run(registry.dispatch(_make_event("CBF_VIOLATION")))
 
         assert delivered_payloads[0]["webhook_id"] == webhook_id
 
@@ -281,16 +269,12 @@ class TestWebhookDispatch:
     def test_dispatch_no_registrations_does_not_raise(self):
         registry = _make_registry()
         # Should not raise even with no registrations
-        asyncio.run(
-            registry.dispatch(_make_event("CBF_VIOLATION"))
-        )
+        asyncio.run(registry.dispatch(_make_event("CBF_VIOLATION")))
 
     def test_dispatch_unknown_event_type_skipped(self):
         registry = _make_registry()
         # Should not raise for non-webhook event types
-        asyncio.run(
-            registry.dispatch({"type": "AUDIT_FINDING", "traceId": "x"})
-        )
+        asyncio.run(registry.dispatch({"type": "AUDIT_FINDING", "traceId": "x"}))
 
     def test_dispatch_missing_type_field_logs_warning(self):
         registry = _make_registry()
@@ -321,9 +305,7 @@ class TestWebhookDispatch:
             return True
 
         with mock.patch.object(registry, "_deliver", side_effect=mock_deliver):
-            asyncio.run(
-                registry.dispatch(_make_event("CBF_VIOLATION"))
-            )
+            asyncio.run(registry.dispatch(_make_event("CBF_VIOLATION")))
 
         assert len(delivered_payloads) == 2
 

--- a/tests/test_symbolic_governor_security.py
+++ b/tests/test_symbolic_governor_security.py
@@ -210,7 +210,8 @@ def test_assert_safe_operational_state_raises_in_production_combined_risk():
     env = {
         k: v
         for k, v in os.environ.items()
-        if k not in ("CBF_FAIL_OPEN", "CAGE_ENV", "ENVIRONMENT", "RECONCILIATION_PROVIDER")
+        if k
+        not in ("CBF_FAIL_OPEN", "CAGE_ENV", "ENVIRONMENT", "RECONCILIATION_PROVIDER")
     }
     env["CBF_FAIL_OPEN"] = "true"
     env["CAGE_ENV"] = "production"
@@ -240,7 +241,8 @@ def test_assert_safe_operational_state_raises_message_mentions_cbf_fail_open():
     env = {
         k: v
         for k, v in os.environ.items()
-        if k not in ("CBF_FAIL_OPEN", "CAGE_ENV", "ENVIRONMENT", "RECONCILIATION_PROVIDER")
+        if k
+        not in ("CBF_FAIL_OPEN", "CAGE_ENV", "ENVIRONMENT", "RECONCILIATION_PROVIDER")
     }
     env["CBF_FAIL_OPEN"] = "true"
     env["CAGE_ENV"] = "production"
@@ -273,7 +275,8 @@ def test_assert_safe_operational_state_does_not_raise_in_production_when_kms_act
     env = {
         k: v
         for k, v in os.environ.items()
-        if k not in ("CBF_FAIL_OPEN", "CAGE_ENV", "ENVIRONMENT", "RECONCILIATION_PROVIDER")
+        if k
+        not in ("CBF_FAIL_OPEN", "CAGE_ENV", "ENVIRONMENT", "RECONCILIATION_PROVIDER")
     }
     env["CBF_FAIL_OPEN"] = "true"
     env["CAGE_ENV"] = "production"


### PR DESCRIPTION
## Problem

Two pre-existing ruff lint errors in `main` were blocking the Dependabot PR #39 (`Lint` CI job):

1. **`I001`** in `src/gateway/governance/cbf.py:198`: `import asyncio as _asyncio` appeared *after* two `from` imports inside a `try` block, violating isort ordering.
2. **`RUF003`** in `src/gateway/governance/consensus.py:260`: Unicode `×` (MULTIPLICATION SIGN U+00D7) used in a comment instead of ASCII `x`.

## Fix

- `cbf.py`: moved `import asyncio as _asyncio` before the `from` imports in the `try` block.
- `consensus.py`: replaced `×` with `x` in the timeout comment.

## Verification

```
uv run ruff check .
# All checks passed!
```

Closes the lint blocker on PR #39.