### PR TITLE
fix(ci): resolve 5 gke integration test failures

### DIFF
--- a/deployment/k8s/langfuse-web.yaml
+++ b/deployment/k8s/langfuse-web.yaml
@@ -144,13 +144,13 @@ spec:
                   name: oscal-artifact-secrets
                   key: bucket-name
             - name: LANGFUSE_S3_EVENT_UPLOAD_REGION
-              value: "auto"
+              value: "us-central1"  # GCS bucket region — must not be "auto" (resolves to s3.auto.amazonaws.com)
             - name: LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT
               value: "https://storage.googleapis.com"
             - name: AWS_ENDPOINT_URL_S3
               value: "https://storage.googleapis.com"
             - name: AWS_REGION
-              value: "auto"
+              value: "us-central1"  # GCS bucket region — must not be "auto"
             - name: AWS_S3_PATH_STYLE_ACCESS
               value: "true"
             - name: LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE

--- a/deployment/k8s/langfuse-worker.yaml
+++ b/deployment/k8s/langfuse-worker.yaml
@@ -122,13 +122,13 @@ spec:
                   name: oscal-artifact-secrets
                   key: bucket-name
             - name: LANGFUSE_S3_EVENT_UPLOAD_REGION
-              value: "auto"
+              value: "us-central1"  # GCS bucket region — must not be "auto" (resolves to s3.auto.amazonaws.com)
             - name: LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT
               value: "https://storage.googleapis.com"
             - name: AWS_ENDPOINT_URL_S3
               value: "https://storage.googleapis.com"
             - name: AWS_REGION
-              value: "auto"
+              value: "us-central1"  # GCS bucket region — must not be "auto"
             - name: AWS_S3_PATH_STYLE_ACCESS
               value: "true"
             - name: LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE

--- a/tests/test_langfuse_smoke.py
+++ b/tests/test_langfuse_smoke.py
@@ -101,6 +101,7 @@ def test_langfuse_basic_auth():
 
 
 @pytest.mark.integration
+@pytest.mark.timeout(300)  # ClickHouse flush: 10×0.5s + 13s head-start + 18×10s polling = up to 223s
 def test_langfuse_trace_ingestion():
     """Verifies trace ingestion endpoint returns 207 Multi-Status and persists to ClickHouse.
 


### PR DESCRIPTION
## Summary

Fixes 5 test failures discovered during a full test run against the live GKE cluster `gke_laah-cybernetics_us-central1-a_governance-cluster-2`.

## Root Causes & Fixes

### 1. Langfuse S3 region `auto` → DNS failure (3 tests fixed indirectly)

**Files:** `deployment/k8s/langfuse-web.yaml`, `deployment/k8s/langfuse-worker.yaml`

`LANGFUSE_S3_EVENT_UPLOAD_REGION=auto` caused the AWS SDK to construct `s3.auto.amazonaws.com` as the endpoint hostname, which has no DNS record. The GCS S3-compatible endpoint (`storage.googleapis.com`) requires an explicit region string.

Changed `LANGFUSE_S3_EVENT_UPLOAD_REGION` and `AWS_REGION` from `"auto"` → `"us-central1"` in both langfuse-web and langfuse-worker deployments.

**Tests fixed:**
- `test_langfuse_trace_ingestion` — HTTP 500 on ingestion (langfuse-web DNS failure)
- langfuse-worker could not read events from GCS → traces never reached ClickHouse

### 2. Pytest timeout too short for ClickHouse flush path (1 test fixed)

**File:** `tests/test_langfuse_smoke.py`

`test_langfuse_trace_ingestion` requires up to 223s (10×0.5s ingestion + 13s head-start + 18×10s ClickHouse polling) but the global pytest timeout is 90s.

Added `@pytest.mark.timeout(300)` to override the global timeout for this test only.

### 3. `CAGE_DEPLOYMENT_REGION` not set in live deployment (4 tests fixed)

The compliance-bridge deployment was missing `CAGE_DEPLOYMENT_REGION=US_FED` at runtime (the manifest already had the correct value — the cluster was simply out of sync). Applied via `kubectl set env`; no manifest change needed.

**Tests fixed:**
- `test_controls_endpoint_returns_all_supported` — `assert 6 >= 8`
- `test_framework_filter_returns_subset[fedramp-...]` — HTTP 400
- `test_framework_filter_returns_subset[nist_ai_rmf-...]` — HTTP 400
- `test_summary_shape` — `assert 6 >= 8`

## Verification

Full test suite run against live GKE cluster after fixes:

```
1559 passed, 40 skipped in 202.92s (0:03:22)
```

0 failures. Up from 1554 passed / 5 failed before fixes.