### PR TITLE
fix(ci): pin pyasn1>=0.6.4 and setuptools>=83.0.0 to remediate pip-audit CVEs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,11 @@ dev = [
     "bcrypt>=5.0.0",
     # kfp: Kubeflow Pipelines SDK — required by test_pipeline_compilation.py
     "kfp>=2.0,<3.0",
+    # Security: pin transitive deps to versions that fix known CVEs
+    # pyasn1 0.6.3: CVE-2026-59884/59885/59886 (DoS in BER/OID/Real decode) — fixed in 0.6.4
+    "pyasn1>=0.6.4",
+    # setuptools 82.0.1: CVE-2026-59890 (MANIFEST.in NFC/NFD bypass on macOS APFS) — fixed in 83.0.0
+    "setuptools>=83.0.0",
 ]
 
 deployment = [

--- a/tests/test_langfuse_smoke.py
+++ b/tests/test_langfuse_smoke.py
@@ -101,7 +101,7 @@ def test_langfuse_basic_auth():
 
 
 @pytest.mark.integration
-@pytest.mark.timeout(300)  # ClickHouse flush: 10×0.5s + 13s head-start + 18×10s polling = up to 223s
+@pytest.mark.timeout(300)  # ClickHouse flush: 10x0.5s + 13s head-start + 18x10s polling = up to 223s
 def test_langfuse_trace_ingestion():
     """Verifies trace ingestion endpoint returns 207 Multi-Status and persists to ClickHouse.
 

--- a/uv.lock
+++ b/uv.lock
@@ -1017,7 +1017,7 @@ wheels = [
 
 [[package]]
 name = "cybernetic-governance-engine"
-version = "0.2.0"
+version = "2.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "cachetools" },
@@ -1099,12 +1099,14 @@ dev = [
     { name = "pandas" },
     { name = "pip-audit" },
     { name = "pip-licenses" },
+    { name = "pyasn1" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
     { name = "respx" },
     { name = "scikit-learn", version = "1.7.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "scikit-learn", version = "1.9.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "setuptools" },
 ]
 
 [package.metadata]
@@ -1173,11 +1175,13 @@ dev = [
     { name = "pandas", specifier = ">=2.2.0" },
     { name = "pip-audit", specifier = ">=2.10.0" },
     { name = "pip-licenses", specifier = ">=5.0.0" },
+    { name = "pyasn1", specifier = ">=0.6.4" },
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-asyncio", specifier = ">=0.23.7" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "respx", specifier = ">=0.22.0" },
     { name = "scikit-learn", specifier = ">=1.4.0" },
+    { name = "setuptools", specifier = ">=83.0.0" },
 ]
 
 [[package]]
@@ -4397,11 +4401,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]
@@ -5306,11 +5310,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.1"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4f/db/cfac1baf10650ab4d1c111714410d2fbb77ac5a616db26775db562c8fab2/setuptools-82.0.1.tar.gz", hash = "sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9", size = 1152316, upload-time = "2026-03-09T12:47:17.221Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9d/76/f789f7a86709c6b087c5a2f52f911838cad707cc613162401badc665acfe/setuptools-82.0.1-py3-none-any.whl", hash = "sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb", size = 1006223, upload-time = "2026-03-09T12:47:15.026Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Remediates 4 CVEs (5 findings) that block the `Python Dependency Vulnerability Scan` CI check on PR #39 (Dependabot GHA bump).

## Vulnerabilities fixed

### `pyasn1` 0.6.3 → 0.6.4
| ID | CVE | Description |
|---|---|---|
| PYSEC-2026-3455 | CVE-2026-59884 | BER long-form tag unbounded integer DoS |
| PYSEC-2026-3456 | CVE-2026-59885 | OID quadratic decode time DoS |
| PYSEC-2026-3457 | CVE-2026-59886 | Real type float conversion DoS |

### `setuptools` 82.0.1 → 83.0.0
| ID | CVE | Description |
|---|---|---|
| PYSEC-2026-3447 | CVE-2026-59890 | MANIFEST.in Unicode NFC/NFD bypass on macOS APFS/HFS+ |

## Approach

Both packages are **transitive** dependencies (not direct). Added explicit lower-bound constraints to the `[dependency-groups] dev` section in `pyproject.toml` so `uv` resolves to the patched versions. Ran `uv lock --upgrade-package pyasn1 --upgrade-package setuptools` to regenerate `uv.lock`.

## After merge

Once this lands on `main`, comment `@dependabot rebase` on PR #39 so it re-runs CI against the updated lockfile, then approve and squash-merge PR #39.

## Checklist
- [x] `pyasn1` upgraded 0.6.3 → 0.6.4 in `uv.lock`
- [x] `setuptools` upgraded 82.0.1 → 83.0.0 in `uv.lock`
- [x] Explicit lower-bound constraints added to `pyproject.toml` dev group
- [x] No secrets or credentials introduced
- [x] No production deployment changes