### PR TITLE
fix(compliance): match webhook region guard on full dns labels

### DIFF
--- a/src/compliance_bridge/governance_webhook.py
+++ b/src/compliance_bridge/governance_webhook.py
@@ -212,7 +212,7 @@ class WebhookRegistry:
             return  # No restriction configured
 
         parsed = urlparse(endpoint_url)
-        hostname = parsed.hostname or ""
+        hostname = (parsed.hostname or "").lower()
 
         # LOW-7 fix: only allow loopback addresses for EU_ECB and APAC_MAS regions.
         # The previous code also allowed RFC-1918 private ranges (10.x, 192.168.x)
@@ -221,9 +221,15 @@ class WebhookRegistry:
         if hostname in ("localhost", "127.0.0.1", "::1"):
             return
 
-        # Check if hostname contains an allowed region suffix
+        # Match the region designator only when it is a full dot-delimited DNS
+        # label of the hostname. The earlier `suffix in hostname` test was an
+        # unanchored substring match, so a host that merely embeds the region
+        # token inside a longer label (e.g. "europe-west1-attacker.com" for
+        # EU_ECB) passed the guard even though it is not in-region.
+        labels = hostname.split(".")
         for suffix in allowed_suffixes:
-            if suffix in hostname:
+            token = suffix.strip(".")
+            if token and token in labels:
                 return
 
         raise ValueError(

--- a/tests/test_governance_webhook.py
+++ b/tests/test_governance_webhook.py
@@ -383,3 +383,39 @@ class TestRegionGuard:
             )
         )
         assert webhook_id is not None
+
+    def test_eu_ecb_allows_region_as_subdomain_label(self):
+        registry = _make_registry(region="EU_ECB")
+        # region token as an interior DNS label is still in-region
+        webhook_id = asyncio.run(
+            registry.register(
+                endpoint_url="https://svc.europe-west1.example.com/events",
+                event_types=["CBF_VIOLATION"],
+                secret="test-secret",
+            )
+        )
+        assert webhook_id is not None
+
+    def test_eu_ecb_embedded_region_token_rejected(self):
+        registry = _make_registry(region="EU_ECB")
+        # "europe-west1" here is only part of a longer label, not a full label,
+        # so the host is not in-region and must be rejected.
+        with pytest.raises(ValueError, match="region guard"):
+            asyncio.run(
+                registry.register(
+                    endpoint_url="https://europe-west1-attacker.com/events",
+                    event_types=["CBF_VIOLATION"],
+                    secret="test-secret",
+                )
+            )
+
+    def test_apac_mas_embedded_region_token_rejected(self):
+        registry = _make_registry(region="APAC_MAS")
+        with pytest.raises(ValueError, match="region guard"):
+            asyncio.run(
+                registry.register(
+                    endpoint_url="https://asia-southeast1x.attacker.com/events",
+                    event_types=["CBF_VIOLATION"],
+                    secret="test-secret",
+                )
+            )


### PR DESCRIPTION
## Summary

`_check_region_guard` in `src/compliance_bridge/governance_webhook.py` enforces the EU_ECB / APAC_MAS data-residency rule for webhook endpoints with `suffix in hostname`. That unanchored substring test also matches a host where the region token is only embedded in a longer DNS label, so an out-of-region endpoint such as `europe-west1-attacker.com` (EU_ECB) passes the guard that `WebhookRegistry.register()` relies on. The check now matches the region designator only when it is a full dot-delimited label of the parsed hostname.

## Type of Change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no feature/fix, code restructuring
- [ ] `perf` — performance improvement
- [ ] `test` — test additions or corrections
- [ ] `chore` — build, deps, tooling
- [ ] `ci` — CI/CD pipeline
- [ ] `BREAKING CHANGE` — existing behaviour changes

## Related Issues / ADRs

N/A

## Changes Made

- `src/compliance_bridge/governance_webhook.py` — split the parsed hostname into labels and accept a region only when the configured designator equals one of those labels, instead of testing it as a substring. Hostname is lowercased once before the loopback and label checks.
- `tests/test_governance_webhook.py` — add regression cases: region token embedded in a longer label is rejected for both EU_ECB and APAC_MAS, and the region token as an interior subdomain label stays allowed.

## Testing

- [x] Unit tests added / updated (`pytest tests/`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Manual smoke test performed (describe below)
- [ ] No tests needed (docs/config only — explain why)

**Manual test steps (if applicable):**
```
uv run pytest tests/test_governance_webhook.py -q
# 28 passed; the two new *_embedded_region_token_rejected cases fail on the
# pre-patch tree (DID NOT RAISE) and pass after the change.
uv run ruff check src/compliance_bridge/governance_webhook.py tests/test_governance_webhook.py
uv run mypy src/compliance_bridge/governance_webhook.py
```

## Compliance & Security Checklist

### 🔒 Universal — All contributors must verify (all regions affected)

- [x] No secrets, credentials, or PII in committed files
- [x] Network policy unchanged **or** reviewed by security owner
- [x] OPA policy changes reviewed for correctness (no OPA changes)
- [x] **Data residency:** the change tightens the existing `CAGE_DEPLOYMENT_REGION` residency guard; no new storage path or sink is introduced
- [x] **ISO 42001 / CSA AARM:** Lula assertions unaffected
- [x] **No region-specific behaviour introduced without a `cage_deployment_region` guard** — the guard already branches on `CAGE_DEPLOYMENT_REGION`; valid in-region hosts and the localhost carve-out are unchanged

---

### 🎯 Region-specific depth — Check only your target deployment

**US_FED**
- [x] N/A — US_FED has no geographic restriction, so its guard path (empty suffix list) is unaffected

**EU_ECB**
- [ ] N/A — not targeting EU_ECB
- [x] EU AI Act compliance posture unaffected — no new High-Risk AI behaviour
- [x] GDPR data residency preserved — the fix strengthens containment to `europe-west1` labels
- [x] DORA Art. 10 audit logging still enabled
- [x] SR 26-2 telemetry suppression intact

**APAC_MAS**
- [ ] N/A — not targeting APAC_MAS
- [x] MAS FEAT compliance posture unaffected
- [x] MAS TRM §4.2 data residency preserved — the fix strengthens containment to `asia-southeast1` labels
- [x] MAS Notice 655 audit logging still enabled
- [x] SR 26-2 telemetry suppression intact

---

### 📋 Shared-module impact declaration

- [ ] Not applicable — PR does not touch shared compliance modules
- [x] **Impact assessed across all three regions**

**Cross-region impact summary (if applicable):**
```
US_FED impact:  none — no residency restriction, guard returns early on empty suffix list.
EU_ECB impact:  hosts that only embed "europe-west1" inside a larger label are now rejected; genuine europe-west1 labels still pass.
APAC_MAS impact: same tightening for "asia-southeast1".
```

## Deployment Notes

N/A

## PR Title Format

`fix(compliance): match webhook region guard on full dns labels`
