### PR TITLE
fix(trustlayers): encode untrusted path segments in provider URLs

### DIFF
--- a/src/integrations/trustlayers/provider.py
+++ b/src/integrations/trustlayers/provider.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 import logging
 import os
 from typing import Any
+from urllib.parse import quote
 
 logger = logging.getLogger("cage.integrations.trustlayers")
 
@@ -114,7 +115,7 @@ class TrustLayersProvider:
 
         from src.gateway.governance.normative_provider import NormativeBaseline
 
-        url = f"{self._endpoint}/legal-baseline/{region}"
+        url = f"{self._endpoint}/legal-baseline/{quote(region, safe='')}"
         try:
             async with httpx.AsyncClient(timeout=self._timeout) as client:
                 resp = await client.get(url, headers=self._headers())
@@ -158,7 +159,7 @@ class TrustLayersProvider:
 
         from src.gateway.governance.normative_provider import EvidenceSeal
 
-        url = f"{self._endpoint}/evidence-chain/{thread_id}"
+        url = f"{self._endpoint}/evidence-chain/{quote(thread_id, safe='')}"
         try:
             async with httpx.AsyncClient(timeout=self._timeout) as client:
                 resp = await client.get(

--- a/tests/test_normative_provider.py
+++ b/tests/test_normative_provider.py
@@ -535,6 +535,67 @@ class TestTrustLayersProvider:
         provider = TrustLayersProvider(endpoint="https://api.trustlayers.example.com/")
         assert provider._endpoint == "https://api.trustlayers.example.com"
 
+    async def test_thread_id_cannot_retarget_request_path(self) -> None:
+        """A thread_id with path separators stays a single encoded segment.
+
+        thread_id reaches submit_evidence from the governed tool-call params
+        (symbolic_governor), so a value like ``../../admin`` must not walk the
+        outbound request off the ``/evidence-chain/`` prefix on the provider host.
+        """
+        import httpx
+
+        captured: dict[str, Any] = {}
+
+        class _Client:
+            def __init__(self, *a: Any, **k: Any) -> None:
+                pass
+
+            async def __aenter__(self) -> _Client:
+                return self
+
+            async def __aexit__(self, *a: Any) -> bool:
+                return False
+
+            async def get(self, url: str, headers: Any = None, params: Any = None):
+                captured["url"] = url
+                raise RuntimeError("stop after URL capture")
+
+        provider = TrustLayersProvider(endpoint="https://api.trustlayers.example.com")
+        with patch("httpx.AsyncClient", _Client):
+            await provider.submit_evidence("../../admin/rotate-key", "HASH")
+
+        target = httpx.URL(captured["url"])
+        assert target.host == "api.trustlayers.example.com"
+        assert target.raw_path.startswith(b"/evidence-chain/")
+
+    async def test_region_cannot_retarget_baseline_path(self) -> None:
+        """A region containing separators stays a single encoded path segment."""
+        import httpx
+
+        captured: dict[str, Any] = {}
+
+        class _Client:
+            def __init__(self, *a: Any, **k: Any) -> None:
+                pass
+
+            async def __aenter__(self) -> _Client:
+                return self
+
+            async def __aexit__(self, *a: Any) -> bool:
+                return False
+
+            async def get(self, url: str, headers: Any = None, params: Any = None):
+                captured["url"] = url
+                raise RuntimeError("stop after URL capture")
+
+        provider = TrustLayersProvider(endpoint="https://api.trustlayers.example.com")
+        with patch("httpx.AsyncClient", _Client):
+            await provider.fetch_baseline("../../secret")
+
+        target = httpx.URL(captured["url"])
+        assert target.host == "api.trustlayers.example.com"
+        assert target.raw_path.startswith(b"/legal-baseline/")
+
 
 class TestDeferReasonExternalValidation:
     """Test that EXTERNAL_VALIDATION DeferReason is properly registered."""


### PR DESCRIPTION
## Summary

`TrustLayersProvider.submit_evidence` builds its request URL by dropping `thread_id` straight into the `/evidence-chain/{thread_id}` path with no encoding. `thread_id` originates in the governed tool-call params (`symbolic_governor` reads `params.get("thread_id")`, which flows through `enforce_fria_boundary` into `_async_attestation`), so a caller-influenced value such as `../../admin/rotate-key` re-targets the outbound GET to a different path on the TrustLayers host rather than staying under `/evidence-chain/`. `fetch_baseline` has the same unescaped `{region}` segment. Both segments are now percent-encoded with `quote(..., safe="")` so an untrusted value can only ever be a single path component.

## Type of Change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no feature/fix, code restructuring
- [ ] `perf` — performance improvement
- [ ] `test` — test additions or corrections
- [ ] `chore` — build, deps, tooling
- [ ] `ci` — CI/CD pipeline
- [ ] `BREAKING CHANGE` — existing behaviour changes

## Related Issues / ADRs

N/A

## Changes Made

- `src/integrations/trustlayers/provider.py`: percent-encode `region` and `thread_id` before interpolating them into the `/legal-baseline/{region}` and `/evidence-chain/{thread_id}` request paths. Valid identifiers (no reserved characters) serialize identically, so the wire behavior for legitimate calls is unchanged.
- `tests/test_normative_provider.py`: two regression tests asserting that a segment containing `../` keeps `raw_path` under the intended prefix and leaves the host untouched.

## Testing

- [x] Unit tests added / updated (`pytest tests/`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Manual smoke test performed (describe below)
- [ ] No tests needed (docs/config only — explain why)

**Manual test steps (if applicable):**
```
uv run pytest tests/test_normative_provider.py::TestTrustLayersProvider -q
# 4 passed; the two new tests fail on the unpatched provider (raw_path
# resolves to /admin/rotate-key and /secret) and pass after encoding.
uv run ruff check src/integrations/trustlayers/provider.py tests/test_normative_provider.py
uv run mypy src/integrations/trustlayers/provider.py
```

## Compliance & Security Checklist

### 🔒 Universal — All contributors must verify (all regions affected)

- [x] No secrets, credentials, or PII in committed files
- [x] Network policy unchanged **or** reviewed by security owner
- [x] OPA policy changes reviewed for correctness (`src/governed_financial_advisor/graph/governance/trade_policy.rego`)
- [x] **Data residency:** Any new storage path, GCS write, Langfuse sink, or telemetry export is guarded by `CAGE_DEPLOYMENT_REGION` (prevents silent cross-region data leakage — GDPR Art. 44 / MAS TRM §4.2)
- [ ] **ISO 42001 / CSA AARM:** Lula assertions unaffected — `lula validate` passes for `lula-validation-a52.yaml`, `lula-validation-a53.yaml`, `lula-validation-aarm-vectors.yaml`
- [x] **No region-specific behaviour introduced without a `cage_deployment_region` guard** — changes to `src/gateway/governance/`, `src/compliance_bridge/`, or `config/` that alter runtime behaviour must branch on `CAGE_DEPLOYMENT_REGION`

> No OPA, storage, or telemetry paths change here; the diff only affects how two existing URLs are encoded.

---

### 🎯 Region-specific depth — Check only your target deployment

**US_FED**
- [x] N/A — not targeting US_FED

**EU_ECB**
- [x] N/A — not targeting EU_ECB

**APAC_MAS**
- [x] N/A — not targeting APAC_MAS

---

### 📋 Shared-module impact declaration

- [x] Not applicable — PR does not touch shared compliance modules

## Deployment Notes

N/A
