### PR TITLE
fix(governance): reject non-finite or negative amount in cbf barrier

### DIFF
--- a/src/gateway/governance/cbf.py
+++ b/src/gateway/governance/cbf.py
@@ -60,6 +60,7 @@ concurrent trade execution in the stateless Cloud Run environment.
 import asyncio
 import json
 import logging
+import math
 
 # ---------------------------------------------------------------------------
 # Canonical gateway-internal imports (Phase 1.1)
@@ -325,6 +326,30 @@ return {1, "COMMITTED", tostring(next_cash)}
         """Safety function h(x).  Safe when h(x) >= 0."""
         return cash_balance - self.min_cash_balance
 
+    @staticmethod
+    def _resolve_trade_cost(action_name: str, payload: dict[str, Any]) -> float:
+        """Return the validated cash cost for *action_name*.
+
+        Only ``execute_trade`` carries a cash cost; every other action is 0.
+        A non-finite (NaN/inf) or negative ``amount`` is rejected here so it can
+        never reach the barrier certificate or the Redis cash-state write. A
+        negative cost makes ``next_cash = current - cost`` larger than the
+        current balance, so the ``h_next >= (1-gamma)*h_t`` envelope check passes
+        and the atomic commit inflates ``safety:current_cash``; a NaN cost makes
+        every comparison false, so the barrier also passes and the balance is
+        poisoned. This mirrors the finiteness/positive guard that
+        ``FiscalLimitGuard.reserve`` already applies to reservations.
+        """
+        if action_name != "execute_trade":
+            return 0.0
+        cost = float(payload.get("amount", 0.0))
+        if not math.isfinite(cost) or cost < 0:
+            raise ValueError(
+                f"invalid trade amount {payload.get('amount')!r} — "
+                "must be a finite, non-negative number"
+            )
+        return cost
+
     # ------------------------------------------------------------------
     # verify_action
     # ------------------------------------------------------------------
@@ -381,9 +406,20 @@ return {1, "COMMITTED", tostring(next_cash)}
             )
             span.set_attribute("governance.scope", _mrm_meta["scope"])
 
-        cost = 0.0
-        if action_name == "execute_trade":
-            cost = float(payload.get("amount", 0.0))
+        try:
+            cost = self._resolve_trade_cost(action_name, payload)
+        except (TypeError, ValueError) as exc:
+            _mrm_meta = ControlRegistry().get_mapping(
+                GovernanceControl.TRADITIONAL_MRM_VALIDATION
+            )
+            result = (
+                f"[{GovernanceControl.TRADITIONAL_MRM_VALIDATION.value}] "
+                f"{_mrm_meta['primary_framework']} Violation: {exc}"
+            )
+            logger.warning("⛔ CBF check rejected trade: %s", exc)
+            if span:
+                span.set_attribute("safety.result", result)
+            return result
 
         # Reviewer note H53: local intra-window debits subtracted from snapshot to prevent double-spend within TTL window.
         effective_balance = current_cash - self._local_debits
@@ -631,9 +667,12 @@ return {1, "COMMITTED", tostring(next_cash)}
         if redis_client is None:
             raise RuntimeError("Redis client unavailable — cannot run atomic CBF.")
 
-        cost = 0.0
-        if action_name == "execute_trade":
-            cost = float(payload.get("amount", 0.0))
+        try:
+            cost = self._resolve_trade_cost(action_name, payload)
+        except (TypeError, ValueError) as exc:
+            reason = f"UNSAFE: {exc}"
+            logger.warning("⛔ CBF atomic check rejected trade: %s", exc)
+            return (False, reason)
 
         keys = ["safety:current_cash", "audit:state_ledger"]
         argv = [

--- a/tests/test_cbf_amount_validation.py
+++ b/tests/test_cbf_amount_validation.py
@@ -1,0 +1,113 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Regression tests: the CBF barrier must reject a non-finite or negative trade
+``amount`` instead of treating it as SAFE.
+
+A negative ``amount`` makes ``next_cash = current - cost`` larger than the
+current balance, so the ``h_next >= (1-gamma)*h_t`` envelope check passes and
+``atomic_verify_and_commit`` writes the inflated balance back to Redis; a NaN
+``amount`` makes every comparison false, so the barrier also passes. Both let
+attacker-supplied trade parameters defeat the cash barrier. FiscalLimitGuard.reserve
+already applies the same finiteness/positive guard to reservations.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("fakeredis", reason="fakeredis required for CBF state tests")
+
+import fakeredis.aioredis  # type: ignore[import]
+
+from src.gateway.governance.cbf import ControlBarrierFunction
+
+_INVALID_AMOUNTS = [-1_000_000.0, float("nan"), float("inf"), float("-inf")]
+
+
+@pytest.mark.local
+@pytest.mark.asyncio
+async def test_do_verify_action_rejects_invalid_amount() -> None:
+    """The read-only barrier returns a non-SAFE result for negative / NaN / inf
+    amounts, and still returns SAFE for a valid positive trade."""
+    cbf = ControlBarrierFunction()
+
+    for amount in _INVALID_AMOUNTS:
+        result = await cbf._do_verify_action(
+            "execute_trade",
+            {"amount": amount},
+            current_cash=100_000.0,
+            balance_source="self_reported",
+            span=None,
+        )
+        assert result != "SAFE", (
+            f"amount={amount!r} must be rejected by the barrier; got SAFE "
+            "(negative/NaN amount bypasses the CBF envelope check)"
+        )
+
+    ok = await cbf._do_verify_action(
+        "execute_trade",
+        {"amount": 1_000.0},
+        current_cash=100_000.0,
+        balance_source="self_reported",
+        span=None,
+    )
+    assert ok == "SAFE", f"a valid positive trade must still pass; got {ok!r}"
+
+
+@pytest.mark.local
+@pytest.mark.asyncio
+async def test_atomic_verify_rejects_invalid_amount_without_mutating_balance() -> None:
+    """The atomic check+commit rejects an invalid amount and leaves the persisted
+    cash balance untouched — a negative amount must not inflate it."""
+    fake_redis = fakeredis.aioredis.FakeRedis(decode_responses=False)
+    await fake_redis.set("safety:current_cash", "100000.0")
+
+    cbf = ControlBarrierFunction()
+    cbf.tracer = None
+
+    mock_redis_module = MagicMock()
+    mock_redis_module.get_raw_client.return_value = fake_redis
+
+    with pytest.MonkeyPatch().context() as mp:
+        mp.setattr("src.gateway.governance.cbf.redis_client", mock_redis_module)
+
+        for amount in _INVALID_AMOUNTS:
+            committed, reason = await cbf.atomic_verify_and_commit(
+                action_name="execute_trade",
+                payload={"amount": amount},
+            )
+            assert committed is False, (
+                f"amount={amount!r} must not commit; got committed=True"
+            )
+            assert "UNSAFE" in reason, f"reason must flag UNSAFE; got {reason!r}"
+            balance = (await fake_redis.get("safety:current_cash")).decode()
+            assert float(balance) == 100_000.0, (
+                f"balance must stay 100000.0 after rejecting amount={amount!r}; "
+                f"got {balance} (negative amount inflated the persisted balance)"
+            )
+
+        # A valid trade still commits and debits the balance.
+        committed, reason = await cbf.atomic_verify_and_commit(
+            action_name="execute_trade",
+            payload={"amount": 1_000.0},
+        )
+        assert committed is True, f"valid trade must commit; got reason={reason!r}"
+        balance = (await fake_redis.get("safety:current_cash")).decode()
+        assert float(balance) == 99_000.0, (
+            f"balance must debit to 99000.0; got {balance}"
+        )


### PR DESCRIPTION
## Summary

`ControlBarrierFunction` reads the trade cost as `float(payload["amount"])` in both `_do_verify_action` and `atomic_verify_and_commit` with no finiteness or sign check. A negative amount makes `next_cash = current - cost` larger than the current balance, so the `h_next >= (1 - gamma) * h_t` envelope check passes and the atomic commit writes the inflated balance back to `safety:current_cash`; a NaN amount makes every comparison false, so the barrier also returns SAFE. The `amount` is agent/tool-supplied on `execute_trade`, so a crafted negative value pumps the persisted cash balance and a later oversized real trade then clears the barrier against the inflated state. Both entry points now validate the cost before it reaches the certificate or the Redis write, mirroring the guard `FiscalLimitGuard.reserve` already applies to reservations.

## Type of Change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no feature/fix, code restructuring
- [ ] `perf` — performance improvement
- [ ] `test` — test additions or corrections
- [ ] `chore` — build, deps, tooling
- [ ] `ci` — CI/CD pipeline
- [ ] `BREAKING CHANGE` — existing behaviour changes

## Related Issues / ADRs

N/A

## Changes Made

- `src/gateway/governance/cbf.py` — add `_resolve_trade_cost()`, which rejects a non-finite (NaN/inf) or negative `amount`, and call it from `_do_verify_action` (returns an UNSAFE result string) and `atomic_verify_and_commit` (returns `(False, reason)` before the Lua commit). Finite non-negative amounts, including `0` and existing positive trades, resolve to the same cost as before.
- `tests/test_cbf_amount_validation.py` — regression test that the read-only barrier and the atomic check+commit both reject negative / NaN / inf amounts, that `safety:current_cash` is not inflated on rejection, and that a valid trade still commits.

## Testing

- [x] Unit tests added / updated (`pytest tests/`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Manual smoke test performed (describe below)
- [ ] No tests needed (docs/config only — explain why)

**Manual test steps (if applicable):**
```
uv run pytest tests/test_cbf_amount_validation.py tests/test_symbolic_governor_cbf_atomicity.py -q -m local
# The two new cases fail on the pre-patch tree (a -1_000_000 amount returns
# committed=True and inflates the balance to 1_100_000) and pass after the change.
uv run ruff check src/gateway/governance/cbf.py tests/test_cbf_amount_validation.py
uv run mypy src/gateway/governance/cbf.py
```

## Compliance & Security Checklist

### 🔒 Universal — All contributors must verify (all regions affected)

- [x] No secrets, credentials, or PII in committed files
- [x] Network policy unchanged **or** reviewed by security owner
- [x] OPA policy changes reviewed for correctness (no OPA changes)
- [x] **Data residency:** no new storage path, GCS write, Langfuse sink, or telemetry export is introduced
- [x] **ISO 42001 / CSA AARM:** Lula assertions unaffected
- [x] **No region-specific behaviour introduced without a `cage_deployment_region` guard** — the CBF cash barrier is deterministic and universal; the guard added here rejects invalid trade amounts identically in every region

---

### 🎯 Region-specific depth — Check only your target deployment

**US_FED**
- [x] N/A — the barrier fix is universal, not US_FED-specific
- [x] NIST SP 800-53 control mappings unaffected — no control behaviour changed for valid inputs
- [x] SR 26-2 / FINRA / SEC Reg S-P implications considered — the fix tightens the CBF/RBC cash-barrier check that CTRL_MRM_004 already governs

**EU_ECB**
- [x] N/A — not targeting EU_ECB specifically
- [x] EU AI Act compliance posture unaffected — no new High-Risk AI behaviour
- [x] GDPR data residency preserved — no new data path
- [x] DORA Art. 10 audit logging still enabled
- [x] SR 26-2 telemetry suppression intact

**APAC_MAS**
- [x] N/A — not targeting APAC_MAS specifically
- [x] MAS FEAT compliance posture unaffected
- [x] MAS TRM §4.2 data residency preserved — no new data path
- [x] MAS Notice 655 audit logging still enabled
- [x] SR 26-2 telemetry suppression intact

---

### 📋 Shared-module impact declaration

- [ ] Not applicable — PR does not touch shared compliance modules
- [x] **Impact assessed across all three regions**

**Cross-region impact summary (if applicable):**
```
US_FED impact:  negative/NaN/inf execute_trade amounts are now rejected by the CBF barrier instead of passing; valid trades unchanged.
EU_ECB impact:  identical — the barrier is region-agnostic.
APAC_MAS impact: identical — the barrier is region-agnostic.
```

## Deployment Notes

N/A

## PR Title Format

`fix(governance): reject non-finite or negative amount in cbf barrier`
