### PR TITLE
feat(governance)!: v3.0.0 breaking changes — schema, API, auto-apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,51 @@ Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+---
+
+## [3.0.0] - 2026-08-15
+
+### Breaking Changes
+- Removed `stpa_validator.py` shim module — use `GeneratedSTPAValidator` directly
+- Removed `safety.py` re-export shim — import from `text_filter` and `cbf` directly
+- Removed `GovernanceClient`, `RedisClient`, `HybridClient` aliases
+- Removed `check_safety_constraints` legacy tool alias — use `simulate_governance_check`
+- Removed `create_ftra_node()` deprecated params (`registry_path`, `plan_key`)
+- Removed `CONTROL_META`, `EVIDENCE_SLA_SECONDS`, `ISO_CONTROL_MAP` aliases — use region-aware accessors
+- Removed `config/settings.py` module-level aliases — use `Config.X` class attributes
+- Migrated threshold env vars to `config/governance_thresholds.json` (env vars still work as overrides)
+- (CR-1) Removed Evidence Stream v1.0 schema support — v1.1 is now the only supported schema
+- (CR-2) Removed NeMo auto-apply path (`NEMO_AUTO_APPLY_ENABLED`) — all refinements require human approval
+- (CR-3) Renamed `update_state()` → `_update_state_unsafe()` — use `atomic_verify_and_commit()` instead
+
+### Added
+- `config/governance_thresholds.json` v2.0.0 schema with FRIA, confidence, and causal thresholds
+- Threshold accessor functions in `src/gateway/governance/schemas/thresholds.py`
+- Region-aware control metadata accessors (`get_control_meta()`, `get_sla_seconds()`, `get_iso_control_map()`)
+
+### Changed
+- `FtraNodeConfig` is now required for `create_ftra_node()` (no fallback extractors)
+- Threshold values loaded from config file with env var overrides
+- `SafetyBoundaryProtocol` no longer exposes `update_state()` method
+
+### Migration
+See [MIGRATION_GUIDE_v3.md](docs/MIGRATION_GUIDE_v3.md) for detailed upgrade instructions.
+
+---
+
+## [2.1.2] - 2026-08-13
+
+### Fixed
+- feat(governance): atomic nonce burn via `verify_and_consume_seal()` Redis SETNX (POAM-2026-043)
+- feat(governance): dynamic standing re-check in `revalidate_post_hitl()` (POAM-2026-044)
+- feat(governance): `RefusalReceipt` parameter binding extended to `validate_action()` and `revalidate_post_hitl()` paths
+- fix(governance): `defer_node.py` field-name mismatch and non-existent `enqueue()` call corrected; DeferQueue now persists tokens to Redis db=1 (POAM-2026-045)
+- test(governance): `tests/test_defer_node.py` added covering durable park and failure propagation
+
+---
+
+## [Unreleased — pre-2.1.2]
+
 ### Added
 - `KmsSigner.sign()` now embeds `signed_at` Unix timestamp in every signed payload; `verify()` rejects payloads older than `MAX_KMS_PAYLOAD_AGE_SECONDS` (300 s), closing replay-attack vector.
 - `CbfGovernor._local_debits` intra-window debit ledger: `verify_action()` computes `effective_balance = snapshot - local_debits` to prevent double-spend within KMS TTL window; `reset_local_debits()` added for reconciliation daemon.

--- a/docs/BREAKING_CHANGES_v3.md
+++ b/docs/BREAKING_CHANGES_v3.md
@@ -1,0 +1,210 @@
+# CAGE v3.0.0 Breaking Changes
+
+> **Status:** Released — v3.0.0 shipped 2026-08-15. See
+> [`CHANGELOG.md`](../CHANGELOG.md) for the full release notes. This document
+> describes the breaking changes included in this release. Item IDs (`SR-#`,
+> `MR-#`, `CR-#`, `FF-#`, `EV-#`) match
+> [`docs/MAJOR_VERSION_CLEANUP_PLAN.md`](MAJOR_VERSION_CLEANUP_PLAN.md) 1:1
+> so the two documents can be cross-referenced.
+
+## Overview
+
+CAGE `v3.0.0` removes deprecated shims, backward-compatibility aliases, and
+ad hoc environment-variable configuration that have been carrying
+`DeprecationWarning`s since `v2.x`. It also graduates (or explicitly declines
+to graduate) two feature flags to their stable default, and consolidates
+scattered `os.getenv()` threshold reads into versioned `config/thresholds/`
+files.
+
+**Scope at a glance:**
+
+| Category | Count | Risk |
+|---|---|---|
+| Safe Removals (deprecated shims/aliases) | 7 (SR-1–SR-7) | Low |
+| Migration-Required Removals (region-aware accessor migration) | 4 (MR-1–MR-4); MR-5 reclassified into CR-2 | Medium |
+| Coordinated Removals (compliance-critical, sign-off gated) | 3 (CR-1–CR-3) | High |
+| Feature Flag Graduations | 2 (FF-1, FF-2) | Medium–High if graduated |
+| Environment Variable Consolidations | 6 (EV-1–EV-6) | Low–Medium |
+
+**Who is affected:** Any consumer that (a) imports directly from the
+deprecated modules/aliases listed below, (b) calls the legacy
+`check_safety_constraints` MCP tool name, (c) passes `registry_path`/`plan_key`
+directly to `create_ftra_node()`, (d) reads the flat/universal-only
+`CONTROL_META` / `EVIDENCE_SLA_SECONDS` / `ISO_CONTROL_MAP` dicts instead of
+the region-aware accessor functions, (e) imports module-level names directly
+from [`config/settings.py`](../config/settings.py:137), or (f) sets any of
+the environment variables listed under [Configuration Changes](#configuration-changes).
+
+**Not affected:** Consumers already using the canonical replacement
+symbols/accessors/config files listed in each table below experience no
+behavior change in `v3.0.0`.
+
+---
+
+## API Changes
+
+### Removed Modules
+
+| Module | Replacement | Migration |
+|--------|-------------|-----------|
+| [`src/gateway/governance/stpa_validator.py`](../src/gateway/governance/stpa_validator.py) (`STPAValidator` class) | [`src/gateway/governance/generated_stpa_validator.py`](../src/gateway/governance/generated_stpa_validator.py:38) (`GeneratedSTPAValidator`) | Replace `from src.gateway.governance.stpa_validator import STPAValidator` with `from src.gateway.governance.generated_stpa_validator import GeneratedSTPAValidator`; replace `.validate(action_name, params)` calls with `.validate_generated(action_name, params)`. |
+| [`src/gateway/governance/safety.py`](../src/gateway/governance/safety.py) (entire file) | [`src/gateway/governance/text_filter.py`](../src/gateway/governance/text_filter.py) (`ac_keyword_scan`); [`src/gateway/governance/cbf.py`](../src/gateway/governance/cbf.py) (`ControlBarrierFunction`, `safety_filter`) | Replace `from src.gateway.governance.safety import ac_keyword_scan` with `from src.gateway.governance.text_filter import ac_keyword_scan`; replace `from src.gateway.governance.safety import ControlBarrierFunction, safety_filter` with `from src.gateway.governance.cbf import ControlBarrierFunction, safety_filter`. |
+
+### Removed Classes/Functions
+
+| Symbol | Module | Replacement | Migration |
+|--------|--------|-------------|-----------|
+| `GovernanceClient` (alias) | [`src/governed_financial_advisor/infrastructure/governance_client.py:323`](../src/governed_financial_advisor/infrastructure/governance_client.py:323) | `StructuredLLMClient` (same module) | Replace `GovernanceClient(...)` with `StructuredLLMClient(...)`; update any type hints from `GovernanceClient` to `StructuredLLMClient`. |
+| `RedisClient` (alias) | [`src/governed_financial_advisor/infrastructure/redis_client.py:268`](../src/governed_financial_advisor/infrastructure/redis_client.py:268) | `AsyncRedisClient` (same module) | Replace `RedisClient()` with `AsyncRedisClient()`. **Note:** do not confuse with the unrelated `_AsyncRedisClient`/`_SyncRedisClient` pair in [`src/gateway/infrastructure/redis_client.py`](../src/gateway/infrastructure/redis_client.py) — that module is untouched by this removal. |
+| `HybridClient` (alias) | [`src/governed_financial_advisor/infrastructure/llm_client.py:23`](../src/governed_financial_advisor/infrastructure/llm_client.py:23) | `GatewayClient` from [`src/gateway/core/llm.py`](../src/gateway/core/llm.py) | Replace `from src.governed_financial_advisor.infrastructure.llm_client import HybridClient` with `from src.gateway.core.llm import GatewayClient`. |
+| `check_safety_constraints` (tool alias) | [`src/governed_financial_advisor/agents/evaluator/agent.py:193`](../src/governed_financial_advisor/agents/evaluator/agent.py:193); [`src/gateway/server/mcp_tool_server.py:483`](../src/gateway/server/mcp_tool_server.py:483); [`src/governed_financial_advisor/tools/api.py:87-88`](../src/governed_financial_advisor/tools/api.py:87); [`src/governed_financial_advisor/graph/nodes/evaluator_node.py:22,147`](../src/governed_financial_advisor/graph/nodes/evaluator_node.py:22) | `simulate_governance_check` | Rename every reference to the tool/function name `check_safety_constraints` to `simulate_governance_check` across all 4 call sites (they must land in one atomic PR). |
+| `create_ftra_node(registry_path=..., plan_key=...)` deprecated params | [`src/gateway/governance/ftra/node_factory.py:145-149`](../src/gateway/governance/ftra/node_factory.py:145) | `config: FtraNodeConfig` parameter (same function) | Replace `create_ftra_node(registry_path="x", plan_key="y")` with `create_ftra_node(config=FtraNodeConfig(registry_path="x", plan_key="y"))`. See [Migration Guide](MIGRATION_GUIDE_v3.md#step-3-update-api-calls) for the full before/after. |
+| `CONTROL_META` (module-level dict alias) | [`src/compliance_bridge/types.py:340`](../src/compliance_bridge/types.py:340) | `get_control_meta(region)` | Replace `from src.compliance_bridge.types import CONTROL_META` + direct iteration with `from src.compliance_bridge.types import get_control_meta` and call `get_control_meta(CAGE_DEPLOYMENT_REGION)`. **Behavior note:** `CONTROL_META` contained universal (ISO 42001) controls only — `get_control_meta(region)` returns universal + jurisdictional controls merged for the given region. Passing `"universal"` (or any unrecognized region string) reproduces the old universal-only subset. |
+| `EVIDENCE_SLA_SECONDS` (module-level dict alias) | [`src/compliance_bridge/types.py:446`](../src/compliance_bridge/types.py:446) | `get_sla_seconds(region)` | Replace direct dict access with `get_sla_seconds(region)`. Same universal-only → region-merged behavior note as `CONTROL_META` applies. |
+| `ISO_CONTROL_MAP` (module-level dict alias — **two distinct symbols**) | [`src/compliance_bridge/types.py:512`](../src/compliance_bridge/types.py:512) **and** [`src/gateway/governance/ontology.py:197-234`](../src/gateway/governance/ontology.py:197) (`TradingKnowledgeGraph.ISO_CONTROL_MAP` class attribute) | `get_iso_control_map(region)` (types.py); `get_control_map(region)` (ontology.py) | These are **two unrelated symbols with the same name in two different modules** — migrate each independently. `src/compliance_bridge/types.py` callers use `get_iso_control_map(region)`; `TradingKnowledgeGraph` callers use `get_control_map(region)`. |
+| `update_state()` — no signature change, but internal-use-only in v3.0.0 | [`src/gateway/governance/cbf.py:907-998`](../src/gateway/governance/cbf.py:907) | `atomic_verify_and_commit()` (same module) | `update_state()` is **not deleted** in v3.0.0 (see [CR-3 rationale](../docs/MAJOR_VERSION_CLEANUP_PLAN.md) §2.3) — it is retained as an internal primitive. New code must call `atomic_verify_and_commit()`, which performs the CBF safety check and the state commit atomically, closing the TOCTOU window documented in `update_state()`'s own deprecation warning (MED-5). If the CR-3 rename decision (`update_state()` → `_update_state_unsafe()`) is adopted during implementation, direct external calls to `update_state()` will break — track this uncertainty in your upgrade testing. |
+
+### Removed Endpoints
+
+No CAGE HTTP endpoint is removed in v3.0.0. `POST /v1/nemo/apply-refinement`
+(the legacy NeMo auto-apply route) **stays** — only its
+`NEMO_AUTO_APPLY_ENABLED=true` internal code branch is removed (see CR-2
+below). No consumer-facing route signature changes.
+
+| Endpoint | Replacement | Migration |
+|----------|-------------|-----------|
+| `POST /v1/nemo/apply-refinement` with `NEMO_AUTO_APPLY_ENABLED=true` (legacy auto-apply branch) | `POST /v1/nemo/propose-refinement` → `POST /v1/nemo/approve-refinement/{proposal_id}` (human-gated flow, already available in v2.x) | Consumers relying on `NEMO_AUTO_APPLY_ENABLED=true` for automatic, unattended refinement application must switch to the propose/approve flow: call `propose-refinement` to stage a change, then have a human risk officer call `approve-refinement/{id}` with `approved`, `reviewer`, and `rationale`. See [`server.py:844-934`](../src/governed_financial_advisor/server.py:844) for the full staged-proposal contract. |
+
+### Changed Signatures
+
+| Function | Old Signature | New Signature |
+|----------|--------------|---------------|
+| `create_ftra_node()` | `create_ftra_node(config=None, registry_path=None, plan_key=None)` | `create_ftra_node(config: FtraNodeConfig | None = None)` — `registry_path` and `plan_key` keyword arguments are removed; pass them as fields of a `FtraNodeConfig` instance instead. |
+| `ControlBarrierFunction.update_state()` (**conditional** — pending CR-3 architectural decision) | `async def update_state(self, cost: float, governance_signature: str | None = None) -> None` (public) | Recommended outcome per the cleanup plan: renamed to `_update_state_unsafe()` (internal-only), called exclusively by `atomic_verify_and_commit()`. **This is flagged as an open architectural decision, not finalized** — consult the CR-3 design-review record before assuming this signature change ships as described. |
+
+---
+
+## Configuration Changes
+
+### Removed Environment Variables
+
+None of the following are hard-deleted in Wave 1–3 of the cleanup plan —
+they are **consolidated into `config/thresholds/` JSON files** and their
+direct `os.getenv()` reads are removed from source. Setting these
+environment variables in `v3.0.0` will have **no effect** once the
+corresponding module is migrated; use the config file instead.
+
+| Variable | Replacement | Migration |
+|----------|-------------|-----------|
+| `FRIA_ZONE_ALLOW`, `FRIA_ZONE_DEFER` | `config/thresholds/*.json` (per-region FTRA boundary thresholds) | Move the values you previously set via env var into the appropriate region file under [`config/thresholds/`](../config/thresholds/). This migration also fixes a latent drift bug where [`src/gateway/governance/ftra/graph_analyzer.py:73-74`](../src/gateway/governance/ftra/graph_analyzer.py:73) hardcoded `0.70` independent of the env var — after migration, both `symbolic_governor.py` and `graph_analyzer.py` read the same config value. |
+| `AGENT_CONFIDENCE_THRESHOLD` | `config/thresholds/*.json` | Move the value into config; the two independent read sites in [`symbolic_governor.py:1088-1097,1366-1368`](../src/gateway/governance/symbolic_governor.py:1088) are consolidated into a single read. |
+| `CAUSAL_LOCK_P_VALUE_THRESHOLD`, `CAUSAL_LOCK_PLACEBO_EFFECT_MAGNITUDE`, `CAUSAL_LOCK_RISK_BOUNDARY` | `config/thresholds/*.json` | Move MRM/ISO 42001 §A.9.4-governed threshold values from env vars ([`src/gateway/governance/causal_gatekeeper.py:80-110`](../src/gateway/governance/causal_gatekeeper.py:80)) into the versioned config file. This also gives an audit trail for threshold changes. |
+| `NEMO_AUTO_APPLY_ENABLED` | *(deleted, not migrated)* | This variable is removed entirely as part of CR-2 (the legacy auto-apply code path is deleted). Setting it in v3.0.0 has no effect regardless of value. |
+| `KMS_BATCH_MAX_SIZE`, `KMS_BATCH_ENABLED` | `config/thresholds/*.json` | **Precondition:** the default-value discrepancy between [`kms_batch_signer.py:75`](../src/compliance_bridge/kms_batch_signer.py:75) (`"true"`) and [`main.py:211-212`](../src/compliance_bridge/main.py:211)'s comment (`"false"`) must be resolved before this migration is finalized — confirm the actual production default with your deployment's release notes before relying on the migrated config value. |
+| `CAUSAL_MIN_SAMPLES`, `CAUSAL_CACHE_TTL_SECONDS`, `TELEMETRY_MAX_STALENESS_SECONDS` | `config/thresholds/*.json` | Same consolidation target as the other `causal_gatekeeper.py`-adjacent variables; bundled with the above item. |
+
+### New Required Configuration
+
+| Config | Purpose | Default |
+|--------|---------|---------|
+| `config/thresholds/<REGION>_BASELINE.json` — FTRA zone keys (`fria_zone_allow`, `fria_zone_defer`) | Replaces `FRIA_ZONE_ALLOW`/`FRIA_ZONE_DEFER` env vars | `0.95` / `0.70` (matches current env var defaults) |
+| `config/thresholds/<REGION>_BASELINE.json` — `agent_confidence_threshold` key | Replaces `AGENT_CONFIDENCE_THRESHOLD` | Matches current env var default (confirm exact value in [`symbolic_governor.py`](../src/gateway/governance/symbolic_governor.py:1088) before upgrading) |
+| `config/thresholds/<REGION>_BASELINE.json` — `causal_lock_*` keys | Replaces the three `CAUSAL_LOCK_*` env vars | Matches current env var defaults; confirm with MRM/ISO 42001 owner before upgrading |
+| `config/thresholds/<REGION>_BASELINE.json` — `kms_batch_*` keys | Replaces `KMS_BATCH_MAX_SIZE`/`KMS_BATCH_ENABLED` | **Uncertain** — pending Wave 0 discrepancy resolution; do not assume a default until confirmed |
+| `config/thresholds/<REGION>_BASELINE.json` — `causal_min_samples`, `causal_cache_ttl_seconds`, `telemetry_max_staleness_seconds` keys | Replaces the three misc causal/telemetry env vars | Matches current env var defaults documented in [`docs/governance/CAUSAL_AND_CBF_GOVERNANCE.md:76,96`](../docs/governance/CAUSAL_AND_CBF_GOVERNANCE.md:76) |
+
+### Feature Flags Graduated
+
+| Flag | New Behavior |
+|------|--------------|
+| `CAGE_DEFER_ENABLED` | **Not graduated in v3.0.0** (explicit recommendation in the cleanup plan §2.4). The flag remains, still defaulting to `"true"`. If your deployment currently sets this to `"false"` to force the DENY-fallback path, that behavior is **unchanged** in v3.0.0. This is a deliberate deviation from the "graduate stable flags" theme of this release — flagged here so consumers do not assume removal. |
+| `KMS_BATCH_ENABLED` | **Status uncertain pending Wave 0 discrepancy resolution.** [`kms_batch_signer.py:75`](../src/compliance_bridge/kms_batch_signer.py:75) currently defaults this to `"true"`; [`main.py:211-212`](../src/compliance_bridge/main.py:211)'s comment claims the production default is `"false"`. **Do not assume this flag is graduated to any particular value until the CAGE release notes for your specific `v3.0.0` build confirm the resolved default.** If graduated, the flag is hardcoded and the `KMS_BATCH_ENABLED` env var (see above) is removed. |
+
+---
+
+## Behavioral Changes
+
+- **Region-aware control/SLA/event-map lookups become mandatory.** Any code
+  path that previously read the flat `CONTROL_META`, `EVIDENCE_SLA_SECONDS`,
+  or `ISO_CONTROL_MAP` dicts saw **universal (ISO 42001) entries only**. After
+  migrating to `get_control_meta(region)` / `get_sla_seconds(region)` /
+  `get_iso_control_map(region)`, callers that pass a recognized
+  `CAGE_DEPLOYMENT_REGION` value (`US_FED`, `EU_ECB`, `APAC_MAS`) will now see
+  **additional jurisdictional entries merged in** that were previously
+  invisible to universal-only consumers. If your integration relied on the
+  old universal-only behavior (e.g., counting exactly 4 SLA entries), that
+  count will change once you pass a real region instead of an unrecognized
+  placeholder.
+- **`create_ftra_node()` no longer emits `DeprecationWarning` for
+  `registry_path`/`plan_key`** — because those parameters no longer exist,
+  attempting to pass them raises `TypeError: unexpected keyword argument`
+  instead of a warning.
+- **NeMo refinement can no longer be applied without human approval**, even
+  in environments that previously set `NEMO_AUTO_APPLY_ENABLED=true`. All
+  refinement changes must go through the `propose-refinement` →
+  `approve-refinement` flow. This closes the "recursive self-authentication"
+  loop flagged in [`server.py:849-851`](../src/governed_financial_advisor/server.py:849).
+- **`CBF.update_state()` may become internal-only** (pending the CR-3
+  decision). If your integration calls `update_state()` directly instead of
+  `atomic_verify_and_commit()`, it may need to migrate to the atomic wrapper
+  to avoid a `TypeError`/`AttributeError` after the rename, or to close the
+  MED-5 TOCTOU window regardless of whether the rename ships.
+- **Threshold overrides via environment variable stop taking effect** for
+  every variable listed under [Removed Environment Variables](#removed-environment-variables).
+  Any CI/CD pipeline, Helm chart, or Terraform variable that injects these as
+  env vars will silently have no effect post-migration — the values must be
+  moved into the corresponding `config/thresholds/*.json` file instead. This
+  is the single most likely "silent" breaking change in this release since
+  no exception is raised; verify with the [Migration Guide's test
+  verification step](MIGRATION_GUIDE_v3.md#step-4-test-verification).
+
+---
+
+## Compliance Impact
+
+Per [`AGENTS.md`](../AGENTS.md) Architecture & Design Standards, changes to
+`src/compliance_bridge/`, `config/compliance/`, and `config/thresholds/` are
+shared cross-region modules deployed simultaneously to all three regional
+postures. The following items affect compliance posture:
+
+- **MR-1 (`CONTROL_META`), MR-2 (`EVIDENCE_SLA_SECONDS`), MR-3
+  (`ISO_CONTROL_MAP`)** — impact **all three regions** (`US_FED`, `EU_ECB`,
+  `APAC_MAS`) because the accessor functions these aliases are replaced by
+  are the mechanism through which jurisdictional controls (NIST SP 800-53,
+  EU AI Act/DORA, MAS FEAT/Notice 655) become visible to consumers. No
+  control is *removed* from any framework mapping — the change is purely in
+  how much of the merged view a given caller sees. Confirm your OSCAL SSP
+  export ([`src/gateway/governance/oscal_ssp_exporter.py`](../src/gateway/governance/oscal_ssp_exporter.py:436))
+  and Lula validation manifests (`compliance/lula/`) do not reference the
+  deprecated symbol names directly.
+- **CR-1 (Evidence Stream dual-schema v1.0/v1.1)** — **US_FED, EU_ECB,
+  APAC_MAS all impacted.** This is the cryptographic hash-chain integrity
+  mechanism for the audit evidence trail. Per the cleanup plan, this item
+  requires a **data-migration completeness gate** (100% of production
+  evidence records migrated v1.0 → v1.1) and Compliance/OSCAL + Security
+  sign-off *before* it can ship — it is not gated purely on code review.
+  Historical v1.0 records remain verifiable via a retained archival/read-only
+  path even after live-write v1.0 support is removed.
+- **CR-2 (NeMo auto-apply removal)** — governance-integrity concern, not a
+  region-specific compliance-framework change; affects the audit trail for
+  NeMo Guardrails refinement across all regions equally.
+- **CR-3 (CBF `update_state()`)** — financial-invariant/concurrency-safety
+  concern; not itself a compliance-framework mapping change, but flagged to
+  Security given the CBF's role in fiscal control enforcement (`SC-4`).
+- **SR-1 (`stpa_validator.py`)** — confirm Lula validation manifests in
+  `compliance/lula/` do not reference the deleted module path; confirm the
+  OSCAL SSP export still resolves STPA control evidence via
+  `generated_stpa_validator.py` post-removal.
+- **EV-3/EV-6 (Causal Lock / telemetry threshold consolidation)** — MRM- and
+  ISO 42001 §A.9.4-governed thresholds; migrating them into a versioned
+  config file is a compliance **improvement** (adds an audit trail for
+  threshold changes) but requires coordination with the same compliance
+  owner as CR-1 given the shared governance surface.
+
+**Action required for compliance-touching PRs:** per [`AGENTS.md`](../AGENTS.md)
+Compliance Artifact Obligations, an OSCAL component update in
+`compliance/oscal/` is required within 2 business days of merge for any PR
+implementing MR-1–3 or CR-1. Region-gated CI must be run explicitly for all
+three postures (`CAGE_DEPLOYMENT_REGION=US_FED|EU_ECB|APAC_MAS`) before
+considering these items complete — see the [Migration Guide's test
+verification step](MIGRATION_GUIDE_v3.md#step-4-test-verification).

--- a/docs/MAJOR_VERSION_CLEANUP_PLAN.md
+++ b/docs/MAJOR_VERSION_CLEANUP_PLAN.md
@@ -1,0 +1,451 @@
+# CAGE v3.0.0 Major Version Cleanup Plan
+
+> **Status:** Completed — v3.0.0 released 2026-08-15. This document preserves
+> the planning rationale and implementation sequence for the major version
+> cleanup. Per [`AGENTS.md`](../AGENTS.md), CAGE is a reference architecture;
+> this plan follows the same illustrative-pattern convention used elsewhere
+> in the repository for release-governance documents.
+
+**Released version:** `3.0.0` (per [`pyproject.toml`](../pyproject.toml:3))
+**Release date:** 2026-08-15
+**Source analysis:** Phase 1 codebase deprecation/dead-code audit (this document was Phase 2 of that effort)
+
+---
+
+## 1. Executive Summary
+
+This plan enumerates every deprecated shim, backward-compatibility alias,
+graduated feature flag, and env-var-based configuration item identified in
+the Phase 1 codebase analysis, and sequences their removal for the CAGE
+`v3.0.0` release.
+
+**Scope:** 18 discrete cleanup items across 4 risk tiers:
+- 7 **Safe Removals** (§2.1) — deprecated shims/aliases with no call-site
+  ambiguity; removal is a mechanical delete + import-site fix.
+- 5 **Migration-Required Removals** (§2.2) — aliases with multiple live call
+  sites across `src/compliance_bridge/` and `src/governed_financial_advisor/`
+  that must be migrated to region-aware accessors before the alias is deleted.
+- 3 **Coordinated Removals** (§2.3) — items touching compliance-critical
+  paths (evidence chain integrity, NeMo auto-apply audit trail, CBF
+  atomicity) that require sign-off from Compliance/Security before removal,
+  per [`AGENTS.md`](../AGENTS.md) Compliance Artifact Obligations.
+- 2 **Feature Flag Graduations** (§2.4) — flags stable enough at their
+  current default to hardcode.
+- 6 **Environment Variable Consolidations** (§2.5) — ad hoc `os.getenv()`
+  reads to migrate into `config/thresholds/` per the R-14 consolidation
+  effort already referenced in [`config/settings.py`](../config/settings.py:21).
+
+**Timeline framing:** Per user instruction, this plan does **not** assign
+level-of-effort time estimates. Sequencing is expressed purely in terms of
+dependency order and release-branch gating (feature-freeze on `rc-v3.0.0`,
+squash-merge per [`AGENTS.md`](../AGENTS.md) Branch Naming & Merge Strategy).
+
+**Key open question:** The two High-Risk items (Evidence Stream dual-schema,
+NeMo legacy auto-apply) are included as *candidates* for v3.0.0 per user
+direction, but each carries an explicit compliance-sign-off gate in §2.3 and
+§6 — if sign-off is not obtained before the `rc-v3.0.0` feature freeze, they
+must be deferred to `v3.1.0`/`v4.0.0` rather than block the rest of the
+release.
+
+---
+
+## 2. Cleanup Categories
+
+### 2.1 Safe Removals (Low Risk)
+
+Items with a single canonical replacement already in production use, no
+ambiguous call sites, and an existing `DeprecationWarning` at the point of
+use. Removal is a mechanical delete + import-site fix, verifiable entirely by
+the existing test suite.
+
+| # | Item | Location | Replacement | Notes |
+|---|------|----------|--------------|-------|
+| SR-1 | `stpa_validator.py` deprecated shim | [`src/gateway/governance/stpa_validator.py`](../src/gateway/governance/stpa_validator.py:15) (`STPAValidator` class, lines 15–60) | `GeneratedSTPAValidator` in [`src/gateway/governance/generated_stpa_validator.py`](../src/gateway/governance/generated_stpa_validator.py:38) | `symbolic_governor.py` already bypasses this shim (line 42 comment). Remaining callers: [`ingress/aaif_adapter.py:78`](../src/gateway/governance/ingress/aaif_adapter.py:78) (string reference in a capability manifest, not an import), [`governed_financial_advisor/agents/evaluator/auditor.py:38`](../src/governed_financial_advisor/agents/evaluator/auditor.py:38) (`try/except ImportError` fallback path — safe to delete along with the shim). |
+| SR-2 | `safety.py` `__getattr__` re-export shim | [`src/gateway/governance/safety.py`](../src/gateway/governance/safety.py:1) (entire file, 74 lines) | `src.gateway.governance.text_filter.ac_keyword_scan`; `src.gateway.governance.cbf.ControlBarrierFunction`/`safety_filter` | Docstring (lines 32–35) already lists all migrated callers as complete. No known remaining production callers found in `src/`. |
+| SR-3 | `GovernanceClient` alias | [`src/governed_financial_advisor/infrastructure/governance_client.py:323`](../src/governed_financial_advisor/infrastructure/governance_client.py:323) | `StructuredLLMClient` (same module) | Test `test_governance_client_alias` in [`tests/test_governance_client.py:251`](../tests/test_governance_client.py:251) asserts `GovernanceClient is StructuredLLMClient` — this test must be deleted, not just updated, since the identity relationship ceases to exist once the alias is removed. |
+| SR-4 | `RedisClient` alias | [`src/governed_financial_advisor/infrastructure/redis_client.py:268`](../src/governed_financial_advisor/infrastructure/redis_client.py:268) | `AsyncRedisClient` (same module) | Actively imported by [`tests/test_redis_config.py:22`](../tests/test_redis_config.py:22) (3 call sites). Note this is a **different** `RedisClient` from the unrelated `_AsyncRedisClient`/`_SyncRedisClient` pair in `src/gateway/infrastructure/redis_client.py` (exercised by [`tests/test_gateway_redis_client.py`](../tests/test_gateway_redis_client.py:33)) — do not conflate the two modules during removal. |
+| SR-5 | `HybridClient` alias | [`src/governed_financial_advisor/infrastructure/llm_client.py:23`](../src/governed_financial_advisor/infrastructure/llm_client.py:23) | `GatewayClient` (same module) | No test references found in the current `tests/` search; verify with a final grep before deletion in case of dynamic/string-based imports. |
+| SR-6 | `check_safety_constraints` legacy tool alias | [`src/governed_financial_advisor/agents/evaluator/agent.py:193`](../src/governed_financial_advisor/agents/evaluator/agent.py:193) (alias definition); [`src/gateway/server/mcp_tool_server.py:483`](../src/gateway/server/mcp_tool_server.py:483) (MCP tool-registry alias); [`src/governed_financial_advisor/tools/api.py:87-88`](../src/governed_financial_advisor/tools/api.py:87) (dispatch alias) | `simulate_governance_check` | 3 production files must change together (see §3 dependency graph — these are a single atomic unit). Also imported by [`src/governed_financial_advisor/graph/nodes/evaluator_node.py:22`](../src/governed_financial_advisor/graph/nodes/evaluator_node.py:22) and called at line 147 — this is a **4th** production call site not listed in the Phase 1 summary and must be migrated too. Test file [`tests/test_evaluator_mcp.py:29-55`](../tests/test_evaluator_mcp.py:29) exercises the alias name directly and must be updated to call `simulate_governance_check`. |
+| SR-7 | `create_ftra_node()` deprecated params (`registry_path`, `plan_key`) | [`src/gateway/governance/ftra/node_factory.py:145-199`](../src/gateway/governance/ftra/node_factory.py:145) | `config: FtraNodeConfig` parameter (same function) | **Highest test-surface item in this tier** — [`tests/test_ftra_package.py`](../tests/test_ftra_package.py:20) has 30+ call sites passing `registry_path=` directly (lines 463, 481, 497, 516, 536, 560, 606, 633, 657, 696, 722, 741–749, 764, 788, 1026, 1048, 1074, 1104, 1165, 1185, 1279, 1311, 1362, 1441, 1473, 1526, 1571, 1693, 1721). Removing the deprecated params is a breaking API change for every one of these call sites; they must all be rewritten to construct `FtraNodeConfig(registry_path=...)` explicitly. This is mechanical but high-volume. |
+
+**Common thread across SR-1–SR-7:** every item already emits a
+`DeprecationWarning` (or is a plain re-export with a "will be removed" docstring),
+meaning production code that ignores warnings continues to function until the
+literal line is deleted. This is what makes them Low Risk despite SR-6/SR-7
+having several call sites — the compatibility contract was already
+communicated to callers.
+
+### 2.2 Migration-Required Removals (Medium Risk)
+
+Items with a region-aware or consolidated replacement already implemented,
+but with multiple live production call sites across `src/compliance_bridge/`
+and `src/governed_financial_advisor/` that iterate the flat/deprecated form
+directly. Removal requires migrating each call site to the accessor function
+**before** the alias can be deleted, because the alias and the accessor are
+not always equivalent (the alias is universal-only; the accessor is
+region-merged).
+
+| # | Item | Location | Replacement Accessor | Call Sites Requiring Migration |
+|---|------|----------|----------------------|----------------------------------|
+| MR-1 | `CONTROL_META` alias | [`src/compliance_bridge/types.py:340`](../src/compliance_bridge/types.py:340) (`CONTROL_META: dict = _UNIVERSAL_CONTROLS`) | `get_control_meta(region)` | [`src/compliance_bridge/main.py:75,1387-1388`](../src/compliance_bridge/main.py:75); [`src/compliance_bridge/eval_dataset.py:42,69-105`](../src/compliance_bridge/eval_dataset.py:42) (4 usages); [`src/compliance_bridge/audit_workflow.py:96,513`](../src/compliance_bridge/audit_workflow.py:96); [`src/compliance_bridge/oscal_exporter.py:59,191`](../src/compliance_bridge/oscal_exporter.py:59). Test coverage: [`tests/test_compliance_bridge_tier2.py:133-139`](../tests/test_compliance_bridge_tier2.py:133), [`tests/test_oscal_ssp_exporter.py:34-37,496-544`](../tests/test_oscal_ssp_exporter.py:34) explicitly assert on `CONTROL_META` contents and the "universal-only" invariant — these tests encode the exact backward-compat contract that must be preserved by the accessor migration. |
+| MR-2 | `EVIDENCE_SLA_SECONDS` alias | [`src/compliance_bridge/types.py:446`](../src/compliance_bridge/types.py:446) (`EVIDENCE_SLA_SECONDS: dict = _UNIVERSAL_SLA`) | `get_sla_seconds(region)` | `sla_monitor.py` has **already been migrated** — [`src/compliance_bridge/sla_monitor.py:79-81`](../src/compliance_bridge/sla_monitor.py:79) explicitly documents replacing "the previous direct iteration over the deprecated flat EVIDENCE_SLA_SECONDS alias" (FINDING-05). Remaining consumers: [`src/compliance_bridge/aarm_mapper.py:272-274`](../src/compliance_bridge/aarm_mapper.py:272) (docstring reference only — verify no runtime dependency). Test coverage: [`tests/test_compliance_bridge_tier2.py:142-152`](../tests/test_compliance_bridge_tier2.py:142) asserts `EVIDENCE_SLA_SECONDS` is a dict and that critical controls have entries — must be re-pointed at `get_sla_seconds("universal")` or equivalent. [`tests/test_compliance_bridge_integration.py:63,71-72,1174-1224`](../tests/test_compliance_bridge_integration.py:63) reads the env var `EVIDENCE_SLA_SECONDS` directly for a live-GKE integration assertion — **this is a distinct env-var usage, not the Python alias**, and is out of scope for this item (tracked separately in §2.5 if consolidation is desired). |
+| MR-3 | `ISO_CONTROL_MAP` alias | [`src/compliance_bridge/types.py:512`](../src/compliance_bridge/types.py:512) (`ISO_CONTROL_MAP: dict = _UNIVERSAL_CONTROL_MAP`) | `get_iso_control_map(region)` | [`src/governed_financial_advisor/utils/langfuse_utils.py:33,229,264`](../src/governed_financial_advisor/utils/langfuse_utils.py:33) — 2 runtime call sites (`saga_rollback` control lookups). A **second, unrelated** `ISO_CONTROL_MAP` class attribute exists on `TradingKnowledgeGraph` in [`src/gateway/governance/ontology.py:197-234`](../src/gateway/governance/ontology.py:197) — its own docstring (line 197) explicitly calls it "retained as a backward-compat alias" and directs new code to `get_control_map(region)`. These are **two separate symbols in two separate modules** with the same name; both must be migrated, and the plan/PR description must disambiguate them to avoid a partial fix. Test coverage: [`tests/test_compliance_bridge_tier1.py:87-131`](../tests/test_compliance_bridge_tier1.py:87) (single-source-of-truth tests, including an identity check `lf_map is canonical` at line 109 that will need rework once `langfuse_utils` calls the accessor instead of re-exporting the module attribute), [`tests/test_compliance_bridge.py:474-480`](../tests/test_compliance_bridge.py:474), [`tests/test_ontology.py:104-112`](../tests/test_ontology.py:104), [`tests/test_oscal_ssp_exporter.py:517-533`](../tests/test_oscal_ssp_exporter.py:517). |
+| MR-4 | `config/settings.py` module-level aliases (R-14 consolidation) | [`config/settings.py:137-157`](../config/settings.py:137) (`MODEL_NAME`, `MODEL_FAST`, `MODEL_REASONING`, `MODEL_CONSENSUS`, `TRANSPILER_MODEL`, `VLLM_FAST_MODEL`, `REMEDIATION_MODEL`, `VLLM_FAST_API_BASE`, `VLLM_REASONING_API_BASE`, `VLLM_GATEWAY_URL`, `GATEWAY_API_BASE`, `PORT`, `REDIS_URL`, `GOVERNANCE_SALT`, `KMS_GOVERNANCE_KEY`, `KMS_GOVERNANCE_PUBLIC_PEM`, `OPA_URL`, `OPA_AUTH_TOKEN`, `SANDBOX_URL` — 19 module-level names) | Unified Pydantic `BaseSettings` class (explicitly flagged as future work at [`config/settings.py:21`](../config/settings.py:21), "Future consolidation (R-14)") | This is the **largest blast-radius item in the entire plan**. Direct `from config.settings import <NAME>` or `from config.settings import Config` usage found in: [`src/governed_financial_advisor/infrastructure/governance_client.py:191`](../src/governed_financial_advisor/infrastructure/governance_client.py:191), [`src/gateway/core/llm.py:20`](../src/gateway/core/llm.py:20), [`src/gateway/core/policy.py:32`](../src/gateway/core/policy.py:32), [`src/gateway/governance/consensus.py:116`](../src/gateway/governance/consensus.py:116), [`src/governed_financial_advisor/infrastructure/mcp_client.py:147`](../src/governed_financial_advisor/infrastructure/mcp_client.py:147), [`src/governed_financial_advisor/server.py:47,347`](../src/governed_financial_advisor/server.py:47), [`src/governed_financial_advisor/evaluators/evaluate_traces.py:29`](../src/governed_financial_advisor/evaluators/evaluate_traces.py:29), [`src/governed_financial_advisor/agents/execution_analyst/agent.py:21,197`](../src/governed_financial_advisor/agents/execution_analyst/agent.py:21), [`src/governed_financial_advisor/graph/nodes/explainer_node.py:20`](../src/governed_financial_advisor/graph/nodes/explainer_node.py:20), [`src/governed_financial_advisor/agents/explainer/agent.py:17`](../src/governed_financial_advisor/agents/explainer/agent.py:17) — **10 files**, mixing both `Config.X` attribute access and bare module-level `X` imports. R-14 itself (the `BaseSettings` consolidation) is **not yet designed**; this item should be treated as **two sub-phases**: (a) design + land the unified `BaseSettings` class alongside the existing `Config` class (non-breaking), then (b) migrate all 10 call sites and delete the 19 module-level duplicate names. Sub-phase (a) is itself a prerequisite design task, not a mechanical removal — flag as **uncertain scope** until R-14's design is written. |
+| MR-5 | `POST /v1/nemo/apply-refinement` legacy endpoint | [`src/governed_financial_advisor/server.py:1038-1039`](../src/governed_financial_advisor/server.py:1038) (route handler `apply_nemo_refinement`); request model at [`server.py:249-251`](../src/governed_financial_advisor/server.py:249) | New KFP-driven propose/apply flow (`/v1/nemo/propose-refinement`, referenced in [`server.py:849-851`](../src/governed_financial_advisor/server.py:849) comment block) | This item overlaps significantly with the High-Risk `NEMO_AUTO_APPLY_ENABLED` item in §2.3 — **the endpoint itself is not deprecated**, only its legacy auto-apply branch is. Reclassify: the endpoint stays; only the `NEMO_AUTO_APPLY_ENABLED=true` code path (lines 1046–1089) is the actual removal candidate, tracked in §2.3 as CR-2. Test coverage referencing the endpoint directly (not just the flag) includes [`tests/test_cybernetic_loop.py:23-31,74-354`](../tests/test_cybernetic_loop.py:23) — this suite's `TestApplyRefinementRequest`/`TestKfpComponentEndpoint` classes must remain green regardless of which sub-item ships. |
+
+**Migration sequencing note:** MR-1, MR-2, and MR-3 all follow the identical
+pattern established in `src/compliance_bridge/types.py` (universal alias +
+region-aware accessor + jurisdictional dict) and should be migrated together
+as one coordinated PR touching `src/compliance_bridge/` and
+`src/governed_financial_advisor/utils/langfuse_utils.py`, since they share
+the same underlying region-guard rationale described in
+[`AGENTS.md`](../AGENTS.md) Architecture & Design Standards (shared-module
+cross-region impact). MR-4 is independent and substantially larger; it should
+not be bundled with MR-1–3.
+
+### 2.3 Coordinated Removals (High Risk)
+
+Items touching compliance-critical paths. Each requires explicit
+Compliance/Security/regulatory-owner sign-off before removal, per
+[`AGENTS.md`](../AGENTS.md) Compliance Artifact Obligations and Architecture &
+Design Standards. **None of these should be merged to `rc-v3.0.0` without a
+documented sign-off artifact attached to the PR.**
+
+| # | Item | Location | Why High Risk | Sign-off Required From |
+|---|------|----------|----------------|--------------------------|
+| CR-1 | Evidence Stream dual-schema v1.0/v1.1 support | [`src/compliance_bridge/evidence_stream.py`](../src/compliance_bridge/evidence_stream.py:51) — `EvidenceRecord` (lines 169–255), `VerifyResult` (264–278), `_compute_hash`/schema selection (420–499), `verify_record()` dual-path (505–608), `migrate_record_1_0_to_1_1()` (622–677), reverse-chain version detection (700–702) | This is the **cryptographic hash-chain integrity mechanism** for the audit evidence trail. Schema v1.0 records still exist in historical evidence chains; removing v1.0 verification support before all existing chains are migrated would make historical records unverifiable — a direct compliance/audit-trail integrity regression. The Phase 1 analysis explicitly flags this as "Compliance critical." | Compliance/OSCAL owner (per [`AGENTS.md`](../AGENTS.md) Compliance Artifact Obligations — OSCAL component update required); Security (hash-chain integrity is a control-mapped item, `A.9.2`/`SC-4` per [`compliance/lula/lula-validation-sc4.yaml`](../compliance/lula/lula-validation-sc4.yaml)). **Precondition, not just sign-off:** a documented, executed migration of all production evidence chains from v1.0 → v1.1 (via the existing `migrate_record_1_0_to_1_1()` utility) must complete and be verified *before* the v1.0 code path is deleted. This is a data-migration gate, not merely a code-review gate. |
+| CR-2 | NeMo legacy auto-apply path (`NEMO_AUTO_APPLY_ENABLED`) | [`src/governed_financial_advisor/server.py:849-863,1042-1089`](../src/governed_financial_advisor/server.py:849) | Removing this collapses the recursive self-authentication loop the code comment explicitly warns about (line 850: "The system modified its own governance rules based on its own telemetry"). The flag defaults to `false` in production already, so removal is primarily a dead-code deletion — **but** the code path is exercised by the dev/test auto-apply flow, and any lingering dependency on it in CI or local dev workflows must be identified first. Also overlaps with MR-5 (§2.2) — the request model and route decorator stay; only lines 1046–1089's `if _NEMO_AUTO_APPLY:` branch and its warning-log block are the removal target. | Security (self-authentication loop is a governance-integrity concern raised in the code's own comments); Gateway governance engineering owner. Lower actual risk than CR-1 since default is already `false`, but included in High Risk per the Phase 1 classification and because it touches the NeMo refinement audit trail referenced by [`tests/test_cybernetic_loop.py`](../tests/test_cybernetic_loop.py:22). |
+| CR-3 | CBF `update_state()` atomicity warning (MED-5 finding) | [`src/gateway/governance/cbf.py:903-998`](../src/gateway/governance/cbf.py:903) (`update_state()` method); deprecation warning at lines 932–937 | `update_state()` does not atomically re-verify the CBF safety condition before committing — a documented TOCTOU window (MED-5). The safe replacement, `atomic_verify_and_commit()`, already exists (referenced in the deprecation message and at [`cbf.py:1107-1109`](../src/gateway/governance/cbf.py:1107)). **This is not a simple deletion**: `update_state()` is exercised extensively by the existing test suite as a *unit-level* primitive independent of the higher-level atomic wrapper — see [`tests/test_cbf_chaos.py:134-246`](../tests/test_cbf_chaos.py:134), [`tests/test_cbf_negative_paths.py:514-632`](../tests/test_cbf_negative_paths.py:514), [`tests/test_fence_epoch.py:84-110,549-580`](../tests/test_fence_epoch.py:84), [`tests/test_symbolic_governor_cbf_atomicity.py:145-147`](../tests/test_symbolic_governor_cbf_atomicity.py:145) (this file's own docstring explicitly warns about the TOCTOU race if `verify_action()` + `update_state()` are used instead of the atomic wrapper — i.e., this test file exists *specifically to guard against* the failure mode that removal would eliminate the *demonstration* of). Removing `update_state()` outright would delete meaningful regression coverage for the WATCH/MULTI/EXEC retry logic itself (fence-epoch increments, NOSCRIPT retry, retry exhaustion) unless that coverage is first ported to exercise `atomic_verify_and_commit()`'s equivalent code paths. | Gateway governance engineering owner (primary — this is a correctness/concurrency-safety change, not a compliance-artifact change); flag to Security for awareness given the financial-invariant nature of CBF. **Recommended approach:** do not delete `update_state()` in v3.0.0. Instead, keep it as an explicitly `Protected`/internal-only primitive (rename or mark private, e.g. `_update_state_unsafe()`) that `atomic_verify_and_commit()` calls internally, and prevent *external* callers from invoking it directly. Full deletion of the retry-logic test surface should be deferred until equivalent coverage exists against the atomic wrapper. |
+
+**Flagged uncertainty:** CR-3's risk assessment is the least certain in this
+plan. Unlike CR-1/CR-2 (which have a clear "flag flip" or "data migration"
+completion criterion), CR-3 requires an architectural decision (rename vs.
+delete vs. keep-with-warning) before a removal date can even be scheduled.
+This item should be routed through Architect-mode design review separately
+before it enters an implementation checklist.
+
+### 2.4 Feature Flag Graduation
+
+Flags that have run at their current default long enough to be considered
+stable, per the Phase 1 analysis.
+
+| # | Flag | Current Default | Location(s) | Graduation Action |
+|---|------|------------------|--------------|---------------------|
+| FF-1 | `CAGE_DEFER_ENABLED` | `"true"` | [`src/gateway/governance/symbolic_governor.py:195-196`](../src/gateway/governance/symbolic_governor.py:195); [`src/gateway/server/agent_gateway_adapter.py:113-115`](../src/gateway/server/agent_gateway_adapter.py:113) | **Do not hardcode ON in v3.0.0 without a decision.** This flag exists specifically for "gradual rollout safety" and "backward compatibility" (both files' own comments). It is exercised extensively as an on/off toggle in [`tests/test_classify_violation.py`](../tests/test_classify_violation.py:48), [`tests/test_symbolic_governor.py:190-224`](../tests/test_symbolic_governor.py:190), [`tests/test_defer_e2e_flow.py:65-229`](../tests/test_defer_e2e_flow.py:65), [`tests/test_agent_gateway_adapter.py:587-593`](../tests/test_agent_gateway_adapter.py:587) — over a dozen tests explicitly set it to `"false"` to assert the DENY-fallback path still works. If hardcoded ON, this fallback path (and its dedicated regression tests) become dead code that must be deliberately removed, not just left in place with an unreachable branch. **Recommendation:** keep the flag through v3.0.0; revisit at v4.0.0 once DEFER has a full release cycle of production telemetry confirming no rollback need (this mirrors the "DEFER regression guard" decision point already documented in [`plans/CAGE_IMPLEMENTATION_PLAN.md`](../plans/CAGE_IMPLEMENTATION_PLAN.md:790)). |
+| FF-2 | `KMS_BATCH_ENABLED` | `"true"` (in [`kms_batch_signer.py:75`](../src/compliance_bridge/kms_batch_signer.py:75)) — **note: inconsistent with `main.py`'s comment** | [`src/compliance_bridge/kms_batch_signer.py:51-75`](../src/compliance_bridge/kms_batch_signer.py:51); referenced in [`src/compliance_bridge/main.py:210-228`](../src/compliance_bridge/main.py:210) | **Discrepancy found during Phase 2 verification:** `kms_batch_signer.py` line 75 defaults this flag to `"true"`, but `main.py`'s comment at lines 211–212 states "The signer is disabled by default (KMS_BATCH_ENABLED=false)". This inconsistency must be resolved (confirm actual runtime default in each deployment posture) **before** deciding whether hardcoding ON is a no-op or a behavior change. If the true production default is `false` (as `main.py` claims), hardcoding ON is a **behavior change**, not a graduation, and belongs in §2.3 (Coordinated) rather than here. Flag as **uncertain** pending this discrepancy's resolution. |
+
+### 2.5 Environment Variable Consolidation
+
+Ad hoc `os.getenv()` reads to migrate into `config/thresholds/` JSON-backed
+configuration, consistent with the pattern already used for other governance
+thresholds.
+
+| # | Variable(s) | Current Location | Consolidation Target |
+|---|-------------|-------------------|------------------------|
+| EV-1 | `FRIA_ZONE_ALLOW`, `FRIA_ZONE_DEFER` | [`src/gateway/governance/symbolic_governor.py:169-192`](../src/gateway/governance/symbolic_governor.py:169) (module-level constants, read once at import); also independently defined as a **hardcoded** `0.70` constant (not env-driven) in [`src/gateway/governance/ftra/graph_analyzer.py:73-74`](../src/gateway/governance/ftra/graph_analyzer.py:73) and referenced in [`src/gateway/governance/ftra/models.py:67-74`](../src/gateway/governance/ftra/models.py:67) and [`src/gateway/governance/defer_queue.py:102-104`](../src/gateway/governance/defer_queue.py:102) | `config/thresholds/` — **this consolidation must also resolve the drift between the env-driven value in `symbolic_governor.py` and the hardcoded `0.70` literal in `graph_analyzer.py`**, which is a second, independently discovered inconsistency: if an operator overrides `FRIA_ZONE_DEFER` via env var, `symbolic_governor.py` picks it up but `graph_analyzer.py`'s FTRA boundary check silently does not. This is a correctness bug latent in the current design, not just a style cleanup — recommend flagging to Security/Gateway governance owner regardless of whether this consolidation ships in v3.0.0. |
+| EV-2 | `AGENT_CONFIDENCE_THRESHOLD` | [`src/gateway/governance/symbolic_governor.py:1088-1097,1366-1368`](../src/gateway/governance/symbolic_governor.py:1088) (read twice, independently, at two different call sites within the same file) | `config/thresholds/` — consolidating to a single read also fixes the "read twice" duplication. |
+| EV-3 | `CAUSAL_LOCK_P_VALUE_THRESHOLD`, `CAUSAL_LOCK_PLACEBO_EFFECT_MAGNITUDE`, `CAUSAL_LOCK_RISK_BOUNDARY` | [`src/gateway/governance/causal_gatekeeper.py:80-110`](../src/gateway/governance/causal_gatekeeper.py:80) | `config/thresholds/` — these are SR 26-2 MRM-governed and ISO 42001 §A.9.4-governed thresholds ([`docs/governance/CAUSAL_AND_CBF_GOVERNANCE.md:30-31`](../docs/governance/CAUSAL_AND_CBF_GOVERNANCE.md:30)); migrating them into a versioned config file also gives an audit trail for threshold changes, which is arguably a compliance *improvement*, not just a cleanup. Coordinate with the same owner as CR-1 given the shared MRM/ISO governance surface. |
+| EV-4 | `NEMO_AUTO_APPLY_ENABLED` | [`src/governed_financial_advisor/server.py:857-863`](../src/governed_financial_advisor/server.py:857) | If CR-2 (§2.3) removes the code path entirely, this env var becomes moot and should be deleted rather than migrated — do not consolidate a variable that is being removed. Listed here only to flag the overlap; the action is "delete," not "migrate." |
+| EV-5 | `KMS_BATCH_MAX_SIZE`, `KMS_BATCH_ENABLED` | [`src/compliance_bridge/kms_batch_signer.py:51-75`](../src/compliance_bridge/kms_batch_signer.py:51) | `config/thresholds/` — bundle with FF-2's discrepancy resolution; do not consolidate the value until the default-value inconsistency is fixed, or the wrong default will be baked into the config file. |
+| EV-6 | `CAUSAL_MIN_SAMPLES`, `CAUSAL_CACHE_TTL_SECONDS`, `TELEMETRY_MAX_STALENESS_SECONDS` | [`docs/governance/CAUSAL_AND_CBF_GOVERNANCE.md:76,96`](../docs/governance/CAUSAL_AND_CBF_GOVERNANCE.md:76) (documents the env vars; verify exact source lines in `causal_gatekeeper.py` during implementation) | `config/thresholds/` — **not explicitly named in the Phase 1 summary provided**, but discovered during Phase 2 verification as closely related threshold env vars living in the same module as EV-3. Flagged as an **addition to scope**, pending confirmation this was an intentional omission from Phase 1 or should be folded into EV-3's PR. |
+
+**Flagged uncertainty:** EV-1's hardcoded/env-driven drift and FF-2's
+default-value discrepancy were **not** identified in the original Phase 1
+item list provided for this plan — they surfaced during Phase 2 file
+verification. Both should be triaged (bug vs. intentional) before their
+respective cleanup items are scheduled, since the "cleanup" action differs
+depending on which value is actually correct in production today.
+
+---
+
+## 3. Removal Order & Dependencies
+
+Items are grouped into 5 sequential waves. Within a wave, items may proceed
+in parallel (independent PRs); waves themselves are ordered because later
+waves depend on earlier waves either technically (shared code path) or
+procedurally (compliance sign-off lead time).
+
+```mermaid
+flowchart TD
+    W0[Wave 0 Preconditions] --> W1[Wave 1 Safe Removals SR-1..SR-7]
+    W0 --> W2[Wave 2 Migration-Required MR-1..MR-4]
+    W1 --> W3[Wave 3 Coordinated High-Risk CR-1..CR-3]
+    W2 --> W3
+    W3 --> W4[Wave 4 Flag Graduation and Env Consolidation FF and EV]
+    W4 --> W5[Wave 5 Release Finalization]
+
+    subgraph W0notes [Wave 0 items]
+      direction TB
+      A[Resolve KMS_BATCH_ENABLED default discrepancy]
+      B[Resolve FRIA_ZONE_DEFER env vs hardcoded drift]
+      C[Design R-14 unified BaseSettings]
+      D[Execute evidence chain v1.0 to v1.1 data migration]
+    end
+```
+
+| Wave | Items | Rationale |
+|------|-------|-----------|
+| **Wave 0 — Preconditions** | Resolve the two discovered discrepancies (`KMS_BATCH_ENABLED` default drift, `FRIA_ZONE_DEFER` hardcoded-vs-env drift); begin R-14 `BaseSettings` design (MR-4 prerequisite); begin CR-1's evidence-chain v1.0→v1.1 data migration execution (this can start immediately and run in the background throughout Waves 1–3, since it is a data-migration task independent of code changes) | These are blocking discoveries/prerequisites, not cleanup actions themselves. Nothing in later waves should assume a resolved default until Wave 0 confirms it. |
+| **Wave 1 — Safe Removals** (SR-1 – SR-7) | Independent of every other wave; no shared code paths between items. SR-6 (`check_safety_constraints`) is the only multi-file item within this wave — its 4 files must land in a single PR (see §2.1). SR-7 (`create_ftra_node` params) has the largest test-rewrite volume and should be scheduled with dedicated review time before the freeze. | Zero cross-item dependencies; can start immediately without waiting on Wave 0. Recommended to complete this wave first to reduce total diff surface before touching riskier items. |
+| **Wave 2 — Migration-Required** (MR-1 – MR-4) | MR-1/MR-2/MR-3 bundled as one PR (shared `compliance_bridge/types.py` pattern, per §2.2 note). MR-4 (`config/settings.py`) is independent but depends on Wave 0's R-14 design landing first — **cannot start implementation until Wave 0's design sub-phase is signed off.** MR-5 is reclassified into CR-2 (Wave 3) — no separate action here. | MR-1–3 touch `src/compliance_bridge/` and `config/compliance/`, which are shared cross-region modules per [`AGENTS.md`](../AGENTS.md) — their PR description must include the 4-point cross-region impact callout (US_FED / EU_ECB / APAC_MAS / region-guard placement) regardless of wave sequencing. |
+| **Wave 3 — Coordinated High-Risk** (CR-1 – CR-3) | CR-1 code-path removal can only proceed after Wave 0's data migration is verified complete (not just started). CR-2 depends on nothing technical but requires its own sign-off lead time — start the sign-off request at the beginning of Wave 1 so it is not the critical-path bottleneck. CR-3 requires the architectural decision (rename vs. delete) to be made *before* this wave — treat as an Architect-mode sub-task that can run in parallel with Waves 0–2. | This wave has the longest procedural lead time (compliance sign-off, data migration verification) — start the sign-off/decision processes as early as Wave 0 even though the code changes land last. |
+| **Wave 4 — Flag Graduation & Env Consolidation** (FF-1, FF-2, EV-1 – EV-6) | FF-2 and EV-5 depend on Wave 0's `KMS_BATCH_ENABLED` discrepancy resolution. EV-1 depends on Wave 0's `FRIA_ZONE_DEFER` drift resolution. FF-1 is explicitly **recommended to not graduate in v3.0.0** (§2.4) — if that recommendation is accepted, remove it from this wave's scope entirely rather than deferring it silently. EV-3/EV-6 should be bundled (same module, `causal_gatekeeper.py`). EV-2 and EV-4 are independent; EV-4 is a no-op if CR-2 already deleted the code path in Wave 3. | Ordered last because several items depend on Wave 0 resolutions and because env-var consolidation is the lowest-urgency category — it improves auditability but fixes no active defect (except the two discovered drift bugs, which are already elevated to Wave 0). |
+| **Wave 5 — Release Finalization** | Bump `pyproject.toml` version to `3.0.0`; update `CHANGELOG`/release notes citing every SR/MR/CR/FF/EV item ID; run full §7 verification suite; tag `rc-v3.0.0` per [`AGENTS.md`](../AGENTS.md) Release Versioning. | Final wave — no cleanup code should land after this point without restarting the RC cycle. |
+
+**Cross-wave dependency callouts:**
+- SR-1 (`stpa_validator.py`) and CR-3 (CBF) both live in `src/gateway/governance/` but do not share code — no ordering constraint between them.
+- MR-4's `Config` class deletion cannot happen until **every** one of the 10 files listed in §2.2 is migrated — this is an all-or-nothing cutover within Wave 2, not an incremental one, because `config/settings.py` module-level names are imported directly (not through an intermediate accessor) and Python does not support partial module attribute deprecation without the `__getattr__` shim pattern used elsewhere (SR-2). **Recommendation:** apply the same `__getattr__` deprecation-shim pattern to `config/settings.py`'s legacy names during Wave 2, rather than deleting them outright, so Wave 2 and Wave 5 do not need to be perfectly synchronized across all 10 call sites in a single atomic PR.
+
+---
+
+## 4. Test Impact Assessment
+
+Per-item breakdown of tests that will need updates (U), deletion (D), or net-new
+coverage (N) as a result of each removal.
+
+| Item | Test File(s) | Impact Type | Detail |
+|------|--------------|--------------|--------|
+| SR-1 | [`tests/test_generated_artifacts.py:228-247`](../tests/test_generated_artifacts.py:228), [`tests/test_coverage_80pct_bridge.py:36-62`](../tests/test_coverage_80pct_bridge.py:36), [`tests/red_team/test_adversarial.py:29,59-66`](../tests/red_team/test_adversarial.py:29), [`tests/test_ftra_boundary_check.py:158-160`](../tests/test_ftra_boundary_check.py:158) | D (shim tests), U (adversarial/boundary tests) | `test_coverage_80pct_bridge.py`'s entire `stpa_validator` shim test class (lines 44–62) must be **deleted** — it tests behavior that will no longer exist. `red_team/test_adversarial.py` imports `STPAValidator` from the shim directly (line 29) and must be repointed to `GeneratedSTPAValidator`. `test_ftra_boundary_check.py` and other files passing `stpa_validator=None` as a constructor kwarg to `SymbolicGovernor` are unaffected (kwarg name stays; only the shim module import path changes for real instances). |
+| SR-2 | No direct test file found importing `src.gateway.governance.safety` in the current test suite search results. | N (verification) | Add a one-time grep-based CI assertion or manual verification step confirming zero remaining imports before deletion, since absence-of-evidence is not conclusive from static search alone. |
+| SR-3 | [`tests/test_governance_client.py:42-44,75-78,251-253`](../tests/test_governance_client.py:42) | D | `test_governance_client_alias()` (line 251) must be **deleted outright** — it asserts `GovernanceClient is StructuredLLMClient`, an identity relationship that ceases to exist once the alias is removed. The fixture at line 75-78 (`def client() -> GovernanceClient`) must be updated to type-hint `StructuredLLMClient` instead. |
+| SR-4 | [`tests/test_redis_config.py:22,36,50,57`](../tests/test_redis_config.py:22) | U | 3 call sites (`RedisClient()` instantiations at lines 36, 50, 57) must be repointed to `AsyncRedisClient()`. Do not confuse with [`tests/test_gateway_redis_client.py`](../tests/test_gateway_redis_client.py:33) — that file tests the unrelated `src.gateway.infrastructure.redis_client` module and needs **no changes** for this item. |
+| SR-5 | None found in current search. | N (verification) | Same caveat as SR-2 — confirm no dynamic/string-based import exists before deletion. |
+| SR-6 | [`tests/test_evaluator_mcp.py:29-55`](../tests/test_evaluator_mcp.py:29) | U | Rename the imported symbol and the call at lines 30 and 50 to `simulate_governance_check`; update the log messages at lines 49 and 55 for clarity (cosmetic, not required for correctness). |
+| SR-7 | [`tests/test_ftra_package.py`](../tests/test_ftra_package.py:20) — 30+ call sites (see §2.1 full line list) | U (large volume), D (deprecation-warning-specific tests) | Tests asserting `pytest.warns(DeprecationWarning)` when `registry_path`/`plan_key` are passed directly (lines 496, 656, 734-749) must be **deleted** since that code path will no longer exist. All other call sites using `registry_path=` as a kwarg must be rewritten to `config=FtraNodeConfig(registry_path=...)`. This is the single largest test-file rewrite in the entire plan by line count. |
+| MR-1 | [`tests/test_compliance_bridge_tier2.py:133-139`](../tests/test_compliance_bridge_tier2.py:133), [`tests/test_oscal_ssp_exporter.py:34-37,490-544`](../tests/test_oscal_ssp_exporter.py:34) | U | Tests iterating `CONTROL_META` directly must be repointed to `get_control_meta("universal")` (or whichever region is under test) once call sites migrate; the "backward-compat alias" comments at lines 502, 539-541 explaining the universal-only subset behavior become stale and must be removed/updated. |
+| MR-2 | [`tests/test_compliance_bridge_tier2.py:142-152`](../tests/test_compliance_bridge_tier2.py:142) | U | Repoint to `get_sla_seconds(region)`. Note [`tests/test_compliance_bridge_integration.py`](../tests/test_compliance_bridge_integration.py:63) reads the **env var** of the same name — unaffected by this Python-symbol change, do not touch. |
+| MR-3 | [`tests/test_compliance_bridge_tier1.py:87-131`](../tests/test_compliance_bridge_tier1.py:87), [`tests/test_compliance_bridge.py:474-480`](../tests/test_compliance_bridge.py:474), [`tests/test_ontology.py:104-112`](../tests/test_ontology.py:104), [`tests/test_oscal_ssp_exporter.py:517-533`](../tests/test_oscal_ssp_exporter.py:517) | U (significant rework) | `test_compliance_bridge_tier1.py`'s `test_langfuse_utils_reexports_canonical_map` (identity check `lf_map is canonical`, line 109) is the highest-risk test rewrite in this item — once `langfuse_utils.py` calls `get_iso_control_map(region)` instead of re-exporting the module attribute, an identity check no longer makes sense and must be replaced with a value-equality or accessor-based check. `test_ontology.py`'s tests target the **separate** `TradingKnowledgeGraph.ISO_CONTROL_MAP` class attribute — confirm during implementation which of the two `ISO_CONTROL_MAP` symbols each test file actually exercises before editing. |
+| MR-4 | No single dedicated test file — impacts are diffused across any test that imports from `config.settings` (10+ files per §2.2) | U (broad, low-depth) | Recommend a dedicated `tests/test_config_settings_migration.py` (new) asserting the `BaseSettings` class and the legacy `Config`/module-level names remain equivalent during the Wave 2 shim period, then asserting the shim raises `DeprecationWarning` post-shim, mirroring the pattern in [`tests/test_config_manager.py`](../tests/test_config_manager.py:1). |
+| MR-5 / CR-2 | [`tests/test_cybernetic_loop.py:74-354`](../tests/test_cybernetic_loop.py:74) (`TestKfpComponentEndpoint`, `TestApplyRefinement`) | U | These tests must continue to pass against the retained endpoint; only tests specifically exercising `NEMO_AUTO_APPLY_ENABLED=true` behavior (if any exist beyond what was found — verify during implementation) would need deletion. |
+| CR-1 | No dedicated `evidence_stream.py` test file was found by name in the current search; verify exact file during implementation (likely `tests/test_evidence_stream.py` or covered within `tests/test_evidence_chain_blocking.py`, currently open in the editor per environment context) | U (compliance-critical — requires new coverage) | **This item needs net-new test coverage, not just updates**: a test asserting that 100% of production evidence records have been migrated to v1.1 *before* the v1.0 code path is deleted (a "no v1.0 records remain" gate), plus regression tests confirming historical v1.0 hash-chain segments remain verifiable via an archival/read-only path even after live-write v1.0 support is removed. |
+| CR-3 | [`tests/test_cbf_chaos.py:134-246`](../tests/test_cbf_chaos.py:134), [`tests/test_cbf_negative_paths.py:514-632`](../tests/test_cbf_negative_paths.py:514), [`tests/test_fence_epoch.py:84-110,549-580`](../tests/test_fence_epoch.py:84), [`tests/test_symbolic_governor_cbf_atomicity.py`](../tests/test_symbolic_governor_cbf_atomicity.py:145), [`tests/test_governance_contracts.py:78-132`](../tests/test_governance_contracts.py:78), [`tests/test_governance_contracts_runtime.py:76-213`](../tests/test_governance_contracts_runtime.py:76), [`tests/test_gateway_compliance_bridge_contract.py:385-411`](../tests/test_gateway_compliance_bridge_contract.py:385) | N (port coverage first), then U/D | **Do not delete any of these tests until equivalent WATCH/MULTI/EXEC retry-logic coverage exists against `atomic_verify_and_commit()`.** This is the largest test-portability risk in the plan — `test_governance_contracts.py`/`test_governance_contracts_runtime.py` test the `SafetyFilter` **Protocol** itself (structural typing), and any signature change to `update_state()` (e.g., renaming to `_update_state_unsafe()`) ripples into every concrete implementation satisfying that Protocol, including test doubles like the one at [`test_gateway_compliance_bridge_contract.py:385-411`](../tests/test_gateway_compliance_bridge_contract.py:385). |
+| FF-1 | [`tests/test_classify_violation.py`](../tests/test_classify_violation.py:48) (12+ references), [`tests/test_symbolic_governor.py:190-224`](../tests/test_symbolic_governor.py:190), [`tests/test_defer_e2e_flow.py:65-229`](../tests/test_defer_e2e_flow.py:65), [`tests/test_agent_gateway_adapter.py:587-593`](../tests/test_agent_gateway_adapter.py:587) | D (if graduated) | **If** FF-1 is graduated to hardcoded-ON (against this plan's recommendation in §2.4), every `monkeypatch.setenv("CAGE_DEFER_ENABLED", "false")` test path (the DENY-fallback assertions) becomes untestable and must be deleted — roughly 5+ distinct test methods across 4 files. This is the single biggest test-deletion risk of any item in the plan if FF-1 is graduated; reinforces the §2.4 recommendation to **not** graduate this flag in v3.0.0. |
+| FF-2 | No dedicated flag-toggle test found for `KMS_BATCH_ENABLED` in the current search. | N | Add a test asserting the resolved (post-Wave-0) default before any graduation decision is finalized. |
+| EV-1 | Indirectly covered wherever `FRIA_ZONE_DEFER` is set via `monkeypatch.setenv` — [`tests/test_classify_violation.py`](../tests/test_classify_violation.py:51,171-172,512-525), [`tests/test_symbolic_governor.py:191-192`](../tests/test_symbolic_governor.py:191), [`tests/test_defer_e2e_flow.py:66-67,228-229`](../tests/test_defer_e2e_flow.py:66) | U | Once migrated to `config/thresholds/`, these `monkeypatch.setenv` calls must be replaced with a config-fixture override mechanism (e.g., a `tmp_path`-based threshold file or a monkeypatched config loader) — a non-trivial refactor of the test fixture pattern used across all three files. Also must add a **new** regression test proving `graph_analyzer.py`'s FTRA boundary check now honors the same override (closing the drift bug identified in §2.5). |
+| EV-2 – EV-6 | No dedicated flag-toggle tests found beyond what's covered under EV-1/CR-1/CR-2/FF-2 above. | N | Recommend a lightweight `tests/test_config_thresholds_consolidation.py` (new) verifying each migrated variable resolves identically whether read via legacy env var or new config file, for one deprecation-window release. |
+
+**Test-suite-wide regression run requirement:** Given the volume of changes
+touching `SymbolicGovernor`, `ControlBarrierFunction`, and
+`compliance_bridge.types`, every wave in §3 should conclude with a full
+`uv run pytest tests/ --run-integration` pass against live GKE dev (per
+[`AGENTS.md`](../AGENTS.md) Test Execution standard) — not just the
+`local`/`unit` marker subset — before proceeding to the next wave, given how
+many of these items touch compliance-critical or financial-invariant code
+paths.
+
+---
+
+## 5. Risk Assessment Matrix
+
+| Item | Risk Level | Rollback Plan | Verification Method |
+|------|------------|-----------------|------------------------|
+| SR-1 `stpa_validator.py` shim | Low | `git revert` the deletion commit; shim has no state, purely structural | `uv run pytest tests/test_generated_artifacts.py tests/red_team/test_adversarial.py -v` |
+| SR-2 `safety.py` shim | Low | `git revert`; zero known production callers | Grep-based zero-import verification + `uv run pytest tests/ -k safety` |
+| SR-3 `GovernanceClient` alias | Low | `git revert`; single-line alias | `uv run pytest tests/test_governance_client.py -v` |
+| SR-4 `RedisClient` alias | Low | `git revert`; single-line alias | `uv run pytest tests/test_redis_config.py tests/test_gateway_redis_client.py -v` |
+| SR-5 `HybridClient` alias | Low | `git revert`; single-line alias | `uv run pytest tests/ -k llm_client -v` |
+| SR-6 `check_safety_constraints` alias | Low | `git revert` across the 4-file atomic PR | `uv run pytest tests/test_evaluator_mcp.py tests/test_gfa_nodes_coverage.py -v` |
+| SR-7 `create_ftra_node()` deprecated params | Low-Medium (volume, not complexity) | `git revert`; params can be re-added without data loss since they were pure pass-through | `uv run pytest tests/test_ftra_package.py -v` (full 1700+ line file) |
+| MR-1 `CONTROL_META` alias | Medium | Keep alias as a `__getattr__`-based deprecation shim for 1 minor release before hard removal; revert PR if OSCAL export regresses | `uv run pytest tests/test_compliance_bridge_tier2.py tests/test_oscal_ssp_exporter.py -v`; manually diff OSCAL SSP export output pre/post migration |
+| MR-2 `EVIDENCE_SLA_SECONDS` alias | Medium | Same shim-first strategy as MR-1 | `uv run pytest tests/test_compliance_bridge_tier2.py -v`; confirm `sla_monitor.py` breach-alert behavior unchanged in staging |
+| MR-3 `ISO_CONTROL_MAP` alias (2 symbols) | Medium (disambiguation risk) | Revert per-symbol; the `compliance_bridge.types` and `ontology.py` symbols can be reverted independently since they are unrelated code | `uv run pytest tests/test_compliance_bridge_tier1.py tests/test_compliance_bridge.py tests/test_ontology.py tests/test_oscal_ssp_exporter.py -v` |
+| MR-4 `config/settings.py` aliases | Medium-High (blast radius) | Land as `__getattr__` shim (not hard delete) per §3 recommendation, allowing instant rollback by reverting only the final hard-delete commit, not the entire migration | `uv run pytest tests/test_config_manager.py -v` + manual smoke test of all 10 dependent modules' import paths |
+| MR-5 (reclassified into CR-2) | — | See CR-2 | See CR-2 |
+| CR-1 Evidence Stream dual-schema | **High** | **Not code-revertible after data migration** — the rollback plan is procedural: retain the v1.0 verification code in an isolated read-only/archival module (do not delete outright) so historical chains remain auditable even if the live-write path is removed. Full code revert is only safe *before* the data migration is executed. | Data migration completeness gate (100% v1.0→v1.1) verified via a dedicated audit query; `uv run pytest tests/ -k evidence_stream --run-integration -v`; manual OSCAL/Lula sign-off artifact attached to PR |
+| CR-2 NeMo auto-apply removal | **High** (procedural, not technical) | `git revert`; default is already `false` in production so revert risk is low, but the audit-trail/sign-off artifact must be re-obtained if reverted and re-attempted later | `uv run pytest tests/test_cybernetic_loop.py -v --run-integration`; confirm dev/CI workflows do not depend on the auto-apply branch before removal |
+| CR-3 CBF `update_state()` | **High** (uncertain — see §2.3 flag) | Recommended approach avoids a hard-revert scenario by not deleting outright (rename to `_update_state_unsafe()` instead); if the rename itself needs reverting, `git revert` is safe since it is a pure signature change | `uv run pytest tests/test_cbf_chaos.py tests/test_cbf_negative_paths.py tests/test_fence_epoch.py tests/test_symbolic_governor_cbf_atomicity.py tests/test_governance_contracts.py tests/test_governance_contracts_runtime.py tests/test_gateway_compliance_bridge_contract.py -v` |
+| FF-1 `CAGE_DEFER_ENABLED` graduation | Medium-High if graduated (recommend: do not graduate) | If graduated and rollback is needed, re-introducing the flag requires restoring the deleted DENY-fallback branch and its tests from version control — non-trivial | If graduated: `uv run pytest tests/test_classify_violation.py tests/test_symbolic_governor.py tests/test_defer_e2e_flow.py tests/test_agent_gateway_adapter.py -v` must all still pass minus the deleted fallback-specific tests |
+| FF-2 `KMS_BATCH_ENABLED` graduation | **Uncertain** (default discrepancy unresolved) | Cannot assess until Wave 0 resolves the `main.py` vs. `kms_batch_signer.py` default discrepancy | Add regression test asserting resolved default; `uv run pytest tests/ -k kms_batch -v` |
+| EV-1 `FRIA_ZONE_ALLOW`/`FRIA_ZONE_DEFER` consolidation | Medium (correctness bug embedded) | `git revert`; also revert the `graph_analyzer.py` drift fix independently if it introduces unexpected FTRA boundary behavior changes | `uv run pytest tests/test_classify_violation.py tests/test_symbolic_governor.py tests/test_defer_e2e_flow.py tests/test_ftra_package.py -v`; new regression test proving `graph_analyzer.py` honors the override |
+| EV-2 `AGENT_CONFIDENCE_THRESHOLD` consolidation | Low | `git revert` | `uv run pytest tests/test_symbolic_governor.py -v` |
+| EV-3 Causal Lock thresholds consolidation | Medium (MRM/ISO governed) | `git revert`; coordinate with CR-1's compliance owner given shared governance surface | `uv run pytest tests/test_causal_gatekeeper.py -v` |
+| EV-4 `NEMO_AUTO_APPLY_ENABLED` (delete, not migrate) | Low | N/A — deletion tracked under CR-2's rollback plan | See CR-2 |
+| EV-5 `KMS_BATCH_MAX_SIZE`/`KMS_BATCH_ENABLED` consolidation | **Uncertain** (blocked on FF-2 discrepancy) | Cannot assess until Wave 0 resolves discrepancy | See FF-2 |
+| EV-6 Causal/telemetry misc env vars | Low (scope-addition item) | `git revert`; confirm with Phase 1 owner whether this was an intentional omission | `uv run pytest tests/test_causal_gatekeeper.py -v` |
+
+**Overall risk distribution:** 7 Low, 6 Medium, 3 High, 2 explicitly
+Uncertain (FF-2, EV-5 — both blocked on the same unresolved default-value
+discrepancy discovered during Phase 2 verification). The 2 Uncertain items
+should be resolved to a definite risk level in Wave 0 before this matrix is
+considered final.
+
+---
+
+## 6. Implementation Checklist
+
+Ordered per the §3 wave structure. Each top-level item corresponds to one
+PR (or one atomic multi-file PR where noted). No cleanup execution has
+occurred — this checklist is for a future implementation task.
+
+### Wave 0 — Preconditions
+- [ ] Resolve `KMS_BATCH_ENABLED` default discrepancy between [`kms_batch_signer.py:75`](../src/compliance_bridge/kms_batch_signer.py:75) (`"true"`) and [`main.py:211-212`](../src/compliance_bridge/main.py:211)'s comment (`"false"`) — determine actual production behavior in each region posture
+- [ ] Resolve `FRIA_ZONE_DEFER` drift between env-driven [`symbolic_governor.py:192`](../src/gateway/governance/symbolic_governor.py:192) and hardcoded `0.70` in [`graph_analyzer.py:74`](../src/gateway/governance/ftra/graph_analyzer.py:74) — confirm whether this is an intentional isolation or a bug
+- [ ] Write R-14 unified `BaseSettings` design doc (prerequisite for MR-4); route through Architect-mode review
+- [ ] Begin executing evidence-chain v1.0 → v1.1 data migration in all live regions (prerequisite for CR-1); this runs in the background through Wave 3
+- [ ] Route CR-3's `update_state()` rename-vs-delete architectural decision through Architect-mode review (can run in parallel with Waves 1–2)
+- [ ] Open compliance/security sign-off requests for CR-1 and CR-2 (lead time — do not wait for Wave 3 to start these)
+
+### Wave 1 — Safe Removals
+- [ ] SR-1: Delete [`stpa_validator.py`](../src/gateway/governance/stpa_validator.py:1); update [`ingress/aaif_adapter.py:78`](../src/gateway/governance/ingress/aaif_adapter.py:78) capability manifest string; remove fallback import in [`auditor.py:37-41`](../src/governed_financial_advisor/agents/evaluator/auditor.py:37); delete shim tests in `test_coverage_80pct_bridge.py`; repoint `test_adversarial.py:29`
+- [ ] SR-2: Delete [`safety.py`](../src/gateway/governance/safety.py:1) after confirming zero remaining production imports
+- [ ] SR-3: Delete alias at [`governance_client.py:323`](../src/governed_financial_advisor/infrastructure/governance_client.py:323); delete `test_governance_client_alias()`; update fixture type hint
+- [ ] SR-4: Delete alias at [`redis_client.py:268`](../src/governed_financial_advisor/infrastructure/redis_client.py:268); update 3 call sites in `test_redis_config.py`
+- [ ] SR-5: Delete alias at [`llm_client.py:23`](../src/governed_financial_advisor/infrastructure/llm_client.py:23) after final grep confirmation
+- [ ] SR-6 (atomic multi-file PR): Update [`agent.py:193`](../src/governed_financial_advisor/agents/evaluator/agent.py:193), [`mcp_tool_server.py:483`](../src/gateway/server/mcp_tool_server.py:483), [`tools/api.py:87-88`](../src/governed_financial_advisor/tools/api.py:87), [`evaluator_node.py:22,147`](../src/governed_financial_advisor/graph/nodes/evaluator_node.py:22) together; update `test_evaluator_mcp.py`
+- [ ] SR-7: Remove `registry_path`/`plan_key` params from [`create_ftra_node()`](../src/gateway/governance/ftra/node_factory.py:145); rewrite 30+ call sites in `test_ftra_package.py`; delete `pytest.warns(DeprecationWarning)` assertions
+- [ ] Wave 1 gate: `uv run pytest tests/ --run-integration -v` full pass
+
+### Wave 2 — Migration-Required
+- [ ] MR-1/MR-2/MR-3 (bundled PR): Migrate `main.py`, `eval_dataset.py`, `audit_workflow.py`, `oscal_exporter.py` off `CONTROL_META`; migrate `sla_monitor.py`-adjacent `aarm_mapper.py` reference off `EVIDENCE_SLA_SECONDS`; migrate `langfuse_utils.py` off `ISO_CONTROL_MAP`; disambiguate and migrate `ontology.py`'s `TradingKnowledgeGraph.ISO_CONTROL_MAP` separately; land `CONTROL_META`/`EVIDENCE_SLA_SECONDS`/`ISO_CONTROL_MAP` as `__getattr__` deprecation shims (not hard deletes) in `types.py`
+- [ ] MR-1/MR-2/MR-3: Rework identity-based test at `test_compliance_bridge_tier1.py:109`; update `test_compliance_bridge_tier2.py`, `test_compliance_bridge.py`, `test_ontology.py`, `test_oscal_ssp_exporter.py`
+- [ ] MR-1/MR-2/MR-3: Attach cross-region impact callout (US_FED/EU_ECB/APAC_MAS/region-guard) to PR description per [`AGENTS.md`](../AGENTS.md)
+- [ ] MR-4: Land unified `BaseSettings` class per Wave 0 design (non-breaking, alongside existing `Config`)
+- [ ] MR-4: Migrate all 10 call sites (`governance_client.py`, `llm.py`, `policy.py`, `consensus.py`, `mcp_client.py`, `server.py` ×2, `evaluate_traces.py`, `execution_analyst/agent.py` ×2, `explainer_node.py`, `explainer/agent.py`) to `BaseSettings`
+- [ ] MR-4: Apply `__getattr__` shim to legacy `config/settings.py` module-level names (do not hard-delete in this wave)
+- [ ] MR-4: Add `tests/test_config_settings_migration.py` (new)
+- [ ] Wave 2 gate: `uv run pytest tests/ --run-integration -v` full pass
+
+### Wave 3 — Coordinated High-Risk
+- [ ] CR-1: Verify 100% of production evidence records migrated v1.0 → v1.1 (data-migration completeness gate — must be independently confirmed, not assumed)
+- [ ] CR-1: Obtain Compliance/OSCAL and Security sign-off artifact; attach to PR
+- [ ] CR-1: Retain v1.0 verification logic in an isolated read-only/archival module rather than deleting outright; remove only the live-write v1.0 path
+- [ ] CR-1: Add data-migration-completeness regression test and archival-readability regression test
+- [ ] CR-2: Obtain Security/Gateway governance sign-off; confirm no CI/dev workflow depends on `NEMO_AUTO_APPLY_ENABLED=true`
+- [ ] CR-2: Delete `if _NEMO_AUTO_APPLY:` branch at [`server.py:1046-1089`](../src/governed_financial_advisor/server.py:1046) and the `_NEMO_AUTO_APPLY` flag itself; keep the `/v1/nemo/apply-refinement` route intact
+- [ ] CR-2: Delete `EV-4` (`NEMO_AUTO_APPLY_ENABLED`) as part of this same PR
+- [ ] CR-3: Apply the Wave 0 architectural decision (recommended: rename `update_state()` → `_update_state_unsafe()`, called internally by `atomic_verify_and_commit()`, external direct calls disallowed)
+- [ ] CR-3: If renaming, update `SafetyFilter` Protocol in `contracts.py` and every concrete implementation satisfying it (`test_governance_contracts.py`, `test_governance_contracts_runtime.py`, `test_gateway_compliance_bridge_contract.py`)
+- [ ] CR-3: Do not delete existing WATCH/MULTI/EXEC retry-logic test coverage until equivalent coverage exists against `atomic_verify_and_commit()`
+- [ ] Wave 3 gate: `uv run pytest tests/ --run-integration -v` full pass + attached sign-off artifacts for CR-1 and CR-2
+
+### Wave 4 — Flag Graduation & Env Consolidation
+- [ ] FF-1: **Decision point** — confirm whether to graduate `CAGE_DEFER_ENABLED` to hardcoded ON. Default recommendation: **do not graduate in v3.0.0**; if overridden, delete the DENY-fallback branch and its ~5+ dedicated tests across 4 files
+- [ ] FF-2: Apply Wave 0's resolved `KMS_BATCH_ENABLED` default; decide graduation only after resolution
+- [ ] EV-1: Migrate `FRIA_ZONE_ALLOW`/`FRIA_ZONE_DEFER` to `config/thresholds/`; fix the `graph_analyzer.py` hardcoded-value drift in the same PR; rework `monkeypatch.setenv` fixture pattern in `test_classify_violation.py`, `test_symbolic_governor.py`, `test_defer_e2e_flow.py`; add regression test proving FTRA boundary check honors the override
+- [ ] EV-2: Migrate `AGENT_CONFIDENCE_THRESHOLD` to `config/thresholds/`; consolidate the two independent read sites in `symbolic_governor.py`
+- [ ] EV-3/EV-6 (bundled): Migrate `CAUSAL_LOCK_P_VALUE_THRESHOLD`, `CAUSAL_LOCK_PLACEBO_EFFECT_MAGNITUDE`, `CAUSAL_LOCK_RISK_BOUNDARY`, `CAUSAL_MIN_SAMPLES`, `CAUSAL_CACHE_TTL_SECONDS`, `TELEMETRY_MAX_STALENESS_SECONDS` to `config/thresholds/`; coordinate with CR-1's compliance owner
+- [ ] EV-4: Confirm no-op if CR-2 already removed the code path; otherwise delete directly
+- [ ] EV-5: Apply Wave 0's resolved `KMS_BATCH_ENABLED`/`KMS_BATCH_MAX_SIZE` values to `config/thresholds/`
+- [ ] Add `tests/test_config_thresholds_consolidation.py` (new)
+- [ ] Wave 4 gate: `uv run pytest tests/ --run-integration -v` full pass
+
+### Wave 5 — Release Finalization
+- [ ] Bump [`pyproject.toml:3`](../pyproject.toml:3) version `2.1.2` → `3.0.0`
+- [ ] Update CHANGELOG / release notes citing every SR/MR/CR/FF/EV item ID from this plan
+- [ ] Run full §7 post-cleanup verification suite
+- [ ] Branch `rc-v3.0.0` from `main`; feature freeze applies immediately per [`AGENTS.md`](../AGENTS.md) Release Versioning
+- [ ] Tag `v3.0.0` as an annotated tag once RC validation completes: `git tag -a v3.0.0 -m "release: v3.0.0 — ..."`
+
+---
+
+## 7. Post-Cleanup Verification
+
+Commands and checks to run after all waves complete, confirming the cleanup
+is both functionally complete and that no dangling references remain.
+
+### 7.1 Static verification — confirm zero remaining references
+
+```bash
+# Confirm the 7 Safe Removal symbols no longer exist anywhere in src/ or tests/
+grep -rn "from src.gateway.governance.stpa_validator import" src/ tests/
+grep -rn "from src.gateway.governance.safety import\|from src.gateway.governance import safety" src/ tests/
+grep -rn "GovernanceClient\b" src/ tests/ --include="*.py" | grep -v "StructuredLLMClient"
+grep -rn "\bRedisClient\b" src/governed_financial_advisor/ tests/test_redis_config.py
+grep -rn "\bHybridClient\b" src/ tests/
+grep -rn "check_safety_constraints" src/ tests/
+grep -rn "create_ftra_node(.*registry_path=\|create_ftra_node(.*plan_key=" src/ tests/
+
+# Confirm the 3 Medium-Risk aliases are gone (or downgraded to a shim, per Wave 2 plan)
+grep -rn "\bCONTROL_META\b" src/ tests/ | grep -v "get_control_meta"
+grep -rn "\bEVIDENCE_SLA_SECONDS\b" src/ tests/ | grep -v "get_sla_seconds"
+grep -rn "\bISO_CONTROL_MAP\b" src/ tests/ | grep -v "get_iso_control_map\|get_control_map"
+
+# Confirm config/settings.py module-level names are gone or shimmed
+grep -rn "^from config.settings import\|^import config.settings" src/
+```
+
+Each command above should return **zero matches** (or only matches inside
+the file that legitimately defines the accessor/replacement) once its
+corresponding wave is complete. Any unexpected match indicates an
+incomplete migration.
+
+### 7.2 Dynamic verification — full regression suite
+
+```bash
+# Per AGENTS.md Test Execution standard — never bare pytest
+source .env
+export CAGE_ENV=dev
+export CAGE_DEPLOYMENT_REGION="${CAGE_DEPLOYMENT_REGION:-LOCAL}"
+export CAGE_ROUTING_SEAL_SECRET="${CAGE_ROUTING_SEAL_SECRET:-dev-only-insecure-placeholder-not-for-production-use}"
+export GOVERNANCE_SALT="${GOVERNANCE_SALT:-dev-only-insecure-placeholder-not-for-production-use}"
+export LANGFUSE_POSTURE_DRY_RUN=true
+uv run pytest tests/ --run-integration -v --tb=short
+```
+
+Baseline to compare against: **2553 passed, 51 skipped, 1 failed** (last
+known result, 2026-08-10, per [`AGENTS.md`](../AGENTS.md) Test Execution).
+Post-cleanup, expect the passed count to **decrease** by the number of
+tests deleted in §4 (shim tests, identity tests, deprecation-warning tests)
+and the skipped/failed counts to remain in the same ballpark — any large
+unexplained shift in skip count indicates a region-guard regression.
+
+### 7.3 Region-posture verification (cross-region shared modules)
+
+Since MR-1–MR-3 and EV-3/EV-6 touch `src/compliance_bridge/` and
+`config/thresholds/` (shared cross-region modules per
+[`AGENTS.md`](../AGENTS.md) Architecture & Design Standards), run the
+region-gated CI matrix explicitly for all three postures rather than relying
+on the default posture alone:
+
+```bash
+CAGE_DEPLOYMENT_REGION=US_FED uv run pytest tests/ -v
+CAGE_DEPLOYMENT_REGION=EU_ECB uv run pytest tests/ -v
+CAGE_DEPLOYMENT_REGION=APAC_MAS uv run pytest tests/ -v
+```
+
+Confirm no region-specific control mapping (NIST SP 800-53, EU AI Act/DORA,
+MAS FEAT/Notice 655) silently disappears from `get_control_meta(region)` /
+`get_sla_seconds(region)` / `get_iso_control_map(region)` output as a side
+effect of removing the universal-only aliases.
+
+### 7.4 Compliance artifact verification (CR-1 specifically)
+
+```bash
+# Confirm zero unmigrated v1.0 evidence records remain before/after CR-1 lands
+python -m src.compliance_bridge.evidence_stream --audit-schema-versions  # (illustrative — confirm actual CLI entrypoint exists before relying on this)
+```
+
+- [ ] Confirm OSCAL SSP export ([`src/gateway/governance/oscal_ssp_exporter.py`](../src/gateway/governance/oscal_ssp_exporter.py:436)) still references `generated_stpa_validator.py` correctly post-SR-1
+- [ ] Confirm Lula validation manifests in `compliance/lula/` do not reference any deleted module paths (`stpa_validator`, `safety.py`)
+- [ ] Update the relevant OSCAL component in `compliance/oscal/` within 2 business days of merge for any control-implementation-touching PR (MR-1–3, CR-1), per [`AGENTS.md`](../AGENTS.md) Compliance Artifact Obligations
+
+### 7.5 CI pipeline verification
+
+```bash
+uv run python scripts/check_stpa_freshness.py       # if STPA source files were touched by SR-1's removal
+uv run python scripts/verify_langfuse_posture.py     # if ISO_CONTROL_MAP/langfuse_utils.py changed (MR-3)
+```
+
+- [ ] Confirm `license-check`, `stpa-freshness-check`, `langfuse-posture-check`, `pytest-logic`, `ai600-unit-tests`, and `security-scan` CI jobs are all green on the final `rc-v3.0.0` branch commit before tagging
+- [ ] Confirm no CI job was disabled or skipped as a workaround during this cleanup, per [`AGENTS.md`](../AGENTS.md) Debugging Standards ("Never suggest disabling or skipping a CI check as a fix")
+
+### 7.6 Sign-off artifact checklist (High-Risk items only)
+
+- [ ] CR-1: Compliance/OSCAL sign-off document attached to the merged PR, referencing the verified 100% v1.0→v1.1 migration completeness
+- [ ] CR-1: Security sign-off document attached, confirming archival read-path preserves audit-trail verifiability
+- [ ] CR-2: Security/Gateway governance sign-off attached, confirming no production or CI dependency on the auto-apply path
+- [ ] CR-3: Architect-mode design decision record attached (rename vs. delete), referenced from the implementing PR
+
+---
+
+## Appendix: Items Requiring Follow-Up Before This Plan Is Final
+
+The following were discovered during Phase 2 verification and were **not**
+part of the original Phase 1 item list. They should be triaged by the
+Phase 1 analysis owner before Wave 0 begins:
+
+1. **`KMS_BATCH_ENABLED` default discrepancy** — [`kms_batch_signer.py:75`](../src/compliance_bridge/kms_batch_signer.py:75) defaults to `"true"`; [`main.py:211-212`](../src/compliance_bridge/main.py:211) comment claims `"false"` is the default. Affects FF-2 and EV-5's risk classification.
+2. **`FRIA_ZONE_DEFER` hardcoded/env-driven drift** — [`symbolic_governor.py:192`](../src/gateway/governance/symbolic_governor.py:192) reads from env; [`graph_analyzer.py:74`](../src/gateway/governance/ftra/graph_analyzer.py:74) hardcodes `0.70`. Affects EV-1's scope and may be an independent latent bug regardless of this cleanup plan.
+3. **`CAUSAL_MIN_SAMPLES`, `CAUSAL_CACHE_TTL_SECONDS`, `TELEMETRY_MAX_STALENESS_SECONDS`** — documented in [`docs/governance/CAUSAL_AND_CBF_GOVERNANCE.md`](../docs/governance/CAUSAL_AND_CBF_GOVERNANCE.md:76) but not named in the original Phase 1 env-var list; tentatively folded into EV-6, pending confirmation this is in scope.
+4. **MR-5's reclassification** — the original Phase 1 list described `POST /v1/nemo/apply-refinement` itself as the removal candidate; this plan's verification found only its legacy auto-apply *branch* (not the endpoint) is actually deprecated, and reclassified it as CR-2. Confirm this reclassification is accepted before Wave 3 begins.
+5. **CR-3's remediation approach** — this plan recommends *not* deleting `update_state()` outright (rename to a private/internal method instead), which is a narrower action than the "removal" framing implied by the original Phase 1 item description. Confirm this narrower scope is acceptable, or route through Architect-mode design review for an alternative approach.

--- a/docs/MIGRATION_GUIDE_v3.md
+++ b/docs/MIGRATION_GUIDE_v3.md
@@ -1,0 +1,578 @@
+# CAGE v3.0.0 Migration Guide
+
+> **Status:** Released — v3.0.0 shipped 2026-08-15. This guide helps you
+> migrate from v2.x to v3.0.0. Companion to
+> [`docs/BREAKING_CHANGES_v3.md`](BREAKING_CHANGES_v3.md) and
+> [`docs/MAJOR_VERSION_CLEANUP_PLAN.md`](MAJOR_VERSION_CLEANUP_PLAN.md). Item
+> IDs (`SR-#`, `MR-#`, `CR-#`, `FF-#`, `EV-#`) match those documents 1:1.
+
+## Prerequisites
+
+Before upgrading from `v2.x` to `v3.0.0`:
+
+1. **Upgrade to the latest `v2.1.x` patch release first.** Every removed
+   symbol in this guide already emits a `DeprecationWarning` in `v2.1.2`+
+   (per [`pyproject.toml:3`](../pyproject.toml:3)). Run your test suite with
+   `-W error::DeprecationWarning` against `src.gateway.governance` and
+   `src.governed_financial_advisor` to surface every call site that needs
+   migration **before** you touch `v3.0.0`.
+2. **Grep your own integration code** for the removed symbols listed in
+   [`BREAKING_CHANGES_v3.md`](BREAKING_CHANGES_v3.md#api-changes) — do not
+   rely solely on `DeprecationWarning` output, since warnings filtered or
+   suppressed in your logging configuration will not surface.
+3. **Inventory your environment variable overrides.** If your deployment
+   (Helm values, Terraform `tfvars`, `.env` files, CI secrets) sets any of
+   the variables listed in
+   [`BREAKING_CHANGES_v3.md` § Removed Environment Variables](BREAKING_CHANGES_v3.md#removed-environment-variables),
+   plan the equivalent `config/thresholds/*.json` entries **before**
+   upgrading — these overrides silently stop taking effect post-upgrade.
+4. **If you operate a live evidence chain** (compliance-critical, CR-1),
+   confirm with your Compliance/OSCAL owner that the v1.0 → v1.1 evidence
+   schema data migration has been executed and verified for your deployment.
+   Do not upgrade to a `v3.0.0` build that has removed v1.0 verification
+   support until this migration is confirmed complete.
+5. **Back up your current configuration** (`config/thresholds/`,
+   `config/compliance/`, `.env`) and note your current `pyproject.toml`
+   version (`2.1.2` or later) so you have a known-good rollback point (see
+   [Rollback Procedure](#rollback-procedure)).
+6. **Read [`BREAKING_CHANGES_v3.md`](BREAKING_CHANGES_v3.md) in full** —
+   this guide assumes familiarity with its tables and does not repeat the
+   rationale for each change.
+
+## Step-by-Step Migration
+
+### Step 1: Update Import Statements
+
+#### SR-1 — `stpa_validator.py` → `generated_stpa_validator.py`
+
+```python
+# BEFORE (v2.x)
+from src.gateway.governance.stpa_validator import STPAValidator
+
+validator = STPAValidator()
+violations = validator.validate(action_name, params)
+```
+
+```python
+# AFTER (v3.0.0)
+from src.gateway.governance.generated_stpa_validator import GeneratedSTPAValidator
+
+validator = GeneratedSTPAValidator()
+violations = validator.validate_generated(action_name, params)
+```
+
+#### SR-2 — `safety.py` → `text_filter.py` / `cbf.py`
+
+```python
+# BEFORE (v2.x)
+from src.gateway.governance.safety import (
+    ac_keyword_scan,
+    ControlBarrierFunction,
+    safety_filter,
+)
+```
+
+```python
+# AFTER (v3.0.0)
+from src.gateway.governance.text_filter import ac_keyword_scan
+from src.gateway.governance.cbf import ControlBarrierFunction, safety_filter
+```
+
+#### SR-5 — `HybridClient` → `GatewayClient`
+
+```python
+# BEFORE (v2.x)
+from src.governed_financial_advisor.infrastructure.llm_client import HybridClient
+
+client = HybridClient(...)
+```
+
+```python
+# AFTER (v3.0.0)
+from src.gateway.core.llm import GatewayClient
+
+client = GatewayClient(...)
+```
+
+#### SR-3 — `GovernanceClient` → `StructuredLLMClient`
+
+```python
+# BEFORE (v2.x)
+from src.governed_financial_advisor.infrastructure.governance_client import (
+    GovernanceClient,
+)
+
+client: GovernanceClient = GovernanceClient()
+```
+
+```python
+# AFTER (v3.0.0)
+from src.governed_financial_advisor.infrastructure.governance_client import (
+    StructuredLLMClient,
+)
+
+client: StructuredLLMClient = StructuredLLMClient()
+```
+
+#### SR-4 — `RedisClient` → `AsyncRedisClient`
+
+```python
+# BEFORE (v2.x)
+from src.governed_financial_advisor.infrastructure.redis_client import RedisClient
+
+cache = RedisClient()
+```
+
+```python
+# AFTER (v3.0.0)
+from src.governed_financial_advisor.infrastructure.redis_client import (
+    AsyncRedisClient,
+)
+
+cache = AsyncRedisClient()
+```
+
+> **Note:** do not confuse this with the unrelated
+> `src.gateway.infrastructure.redis_client` module (`_AsyncRedisClient`/
+> `_SyncRedisClient`) — that module is untouched by this migration.
+
+#### MR-1/MR-2/MR-3 — Region-aware accessor migration
+
+```python
+# BEFORE (v2.x)
+from src.compliance_bridge.types import (
+    CONTROL_META,
+    EVIDENCE_SLA_SECONDS,
+    ISO_CONTROL_MAP,
+)
+
+for control_id, meta in CONTROL_META.items():
+    ...
+
+sla_seconds = EVIDENCE_SLA_SECONDS.get("SC-4")
+control_id = ISO_CONTROL_MAP.get("nemo_input_scan")
+```
+
+```python
+# AFTER (v3.0.0)
+import os
+
+from src.compliance_bridge.types import (
+    get_control_meta,
+    get_iso_control_map,
+    get_sla_seconds,
+)
+
+region = os.environ.get("CAGE_DEPLOYMENT_REGION", "universal")
+
+for control_id, meta in get_control_meta(region).items():
+    ...
+
+sla_seconds = get_sla_seconds(region).get("SC-4")
+control_id = get_iso_control_map(region).get("nemo_input_scan")
+```
+
+For the **separate** `ontology.py` symbol:
+
+```python
+# BEFORE (v2.x)
+from src.gateway.governance.ontology import TradingKnowledgeGraph
+
+control_id = TradingKnowledgeGraph.ISO_CONTROL_MAP.get("nemo_input_scan")
+```
+
+```python
+# AFTER (v3.0.0)
+from src.gateway.governance.ontology import TradingKnowledgeGraph
+
+control_id = TradingKnowledgeGraph.get_control_map(region).get("nemo_input_scan")
+```
+
+### Step 2: Update Configuration
+
+#### EV-1 — `FRIA_ZONE_ALLOW`/`FRIA_ZONE_DEFER` → `config/thresholds/`
+
+```bash
+# BEFORE (v2.x) — set via environment
+export FRIA_ZONE_ALLOW=0.95
+export FRIA_ZONE_DEFER=0.70
+```
+
+```json
+// AFTER (v3.0.0) — config/thresholds/US_FED_BASELINE.json (or your active region file)
+{
+  "fria_zone_allow": 0.95,
+  "fria_zone_defer": 0.70
+}
+```
+
+Remove the `FRIA_ZONE_ALLOW`/`FRIA_ZONE_DEFER` exports from your `.env`,
+Helm values, or Terraform `tfvars` — they have no effect once
+`symbolic_governor.py` and `graph_analyzer.py` are migrated to read from the
+config file.
+
+#### EV-2 — `AGENT_CONFIDENCE_THRESHOLD` → `config/thresholds/`
+
+```bash
+# BEFORE (v2.x)
+export AGENT_CONFIDENCE_THRESHOLD=0.80
+```
+
+```json
+// AFTER (v3.0.0) — config/thresholds/<REGION>_BASELINE.json
+{
+  "agent_confidence_threshold": 0.80
+}
+```
+
+#### EV-3/EV-6 — Causal Lock & telemetry thresholds → `config/thresholds/`
+
+```bash
+# BEFORE (v2.x)
+export CAUSAL_LOCK_P_VALUE_THRESHOLD=0.05
+export CAUSAL_LOCK_PLACEBO_EFFECT_MAGNITUDE=0.1
+export CAUSAL_LOCK_RISK_BOUNDARY=0.2
+export CAUSAL_MIN_SAMPLES=30
+export CAUSAL_CACHE_TTL_SECONDS=3600
+export TELEMETRY_MAX_STALENESS_SECONDS=300
+```
+
+```json
+// AFTER (v3.0.0) — config/thresholds/<REGION>_BASELINE.json
+{
+  "causal_lock_p_value_threshold": 0.05,
+  "causal_lock_placebo_effect_magnitude": 0.1,
+  "causal_lock_risk_boundary": 0.2,
+  "causal_min_samples": 30,
+  "causal_cache_ttl_seconds": 3600,
+  "telemetry_max_staleness_seconds": 300
+}
+```
+
+> Coordinate this migration with your MRM/ISO 42001 §A.9.4 compliance owner
+> — these are governed thresholds per
+> [`docs/governance/CAUSAL_AND_CBF_GOVERNANCE.md`](governance/CAUSAL_AND_CBF_GOVERNANCE.md).
+
+#### EV-4 — `NEMO_AUTO_APPLY_ENABLED` (delete, do not migrate)
+
+```bash
+# BEFORE (v2.x) — dev/test only
+export NEMO_AUTO_APPLY_ENABLED=true
+```
+
+```bash
+# AFTER (v3.0.0) — remove this variable entirely.
+# Use the propose/approve flow instead (see Step 3 below).
+```
+
+#### EV-5 — `KMS_BATCH_MAX_SIZE`/`KMS_BATCH_ENABLED` → `config/thresholds/`
+
+```bash
+# BEFORE (v2.x)
+export KMS_BATCH_MAX_SIZE=32
+export KMS_BATCH_ENABLED=true
+```
+
+```json
+// AFTER (v3.0.0) — config/thresholds/<REGION>_BASELINE.json
+// CAUTION: confirm the resolved production default with your release notes
+// before relying on this value — see BREAKING_CHANGES_v3.md's Feature Flags
+// Graduated section for the known kms_batch_signer.py vs. main.py discrepancy.
+{
+  "kms_batch_max_size": 32,
+  "kms_batch_enabled": true
+}
+```
+
+### Step 3: Update API Calls
+
+#### SR-6 — `check_safety_constraints` → `simulate_governance_check`
+
+```python
+# BEFORE (v2.x)
+result = await evaluator_agent.check_safety_constraints(
+    action_name="place_trade",
+    params={"symbol": "AAPL", "quantity": 100},
+)
+```
+
+```python
+# AFTER (v3.0.0)
+result = await evaluator_agent.simulate_governance_check(
+    action_name="place_trade",
+    params={"symbol": "AAPL", "quantity": 100},
+)
+```
+
+If you call this via the MCP tool registry directly:
+
+```python
+# BEFORE (v2.x)
+response = await mcp_client.call_tool(
+    "check_safety_constraints",
+    {"action_name": "place_trade", "params": {...}},
+)
+```
+
+```python
+# AFTER (v3.0.0)
+response = await mcp_client.call_tool(
+    "simulate_governance_check",
+    {"action_name": "place_trade", "params": {...}},
+)
+```
+
+#### SR-7 — `create_ftra_node()` deprecated params → `FtraNodeConfig`
+
+```python
+# BEFORE (v2.x)
+from src.gateway.governance.ftra.node_factory import create_ftra_node
+
+ftra_node_fn = create_ftra_node(
+    registry_path="config/ftra/terminal_registry.json",
+    plan_key="execution_plan_output",
+)
+```
+
+```python
+# AFTER (v3.0.0)
+from src.gateway.governance.ftra.node_factory import create_ftra_node
+from src.gateway.governance.langgraph_harness.types import FtraNodeConfig
+
+ftra_node_fn = create_ftra_node(
+    config=FtraNodeConfig(
+        registry_path="config/ftra/terminal_registry.json",
+        plan_key="execution_plan_output",
+    )
+)
+```
+
+If you were relying on the default (no params at all), no change is
+required:
+
+```python
+# UNCHANGED in v3.0.0
+ftra_node_fn = create_ftra_node()
+```
+
+#### MR-5 / CR-2 — NeMo legacy auto-apply → propose/approve flow
+
+```python
+# BEFORE (v2.x) — dev/test env with NEMO_AUTO_APPLY_ENABLED=true
+response = await http_client.post(
+    "/v1/nemo/apply-refinement",
+    json={
+        "control_id": "A.9.2",
+        "verdict": "FAIL",
+        "source": "langfuse_webhook",
+    },
+)
+# Refinement is applied immediately, no human review.
+```
+
+```python
+# AFTER (v3.0.0) — human-gated propose/approve flow (works in all environments)
+propose_response = await http_client.post(
+    "/v1/nemo/propose-refinement",
+    json={
+        "control_id": "A.9.2",
+        "verdict": "FAIL",
+        "source": "langfuse_webhook",
+    },
+)
+proposal_id = propose_response.json()["proposal_id"]
+
+# A human risk officer reviews the proposal, then approves it explicitly:
+approve_response = await http_client.post(
+    f"/v1/nemo/approve-refinement/{proposal_id}",
+    json={
+        "approved": True,
+        "reviewer": "jane.doe@example.com",
+        "rationale": "Reviewed telemetry; refinement reduces false-negative rate.",
+    },
+)
+```
+
+### Step 4: Test Verification
+
+#### 4.1 Static verification — confirm zero remaining references to removed symbols
+
+```bash
+# Safe Removals (SR-1 – SR-7)
+grep -rn "from src.gateway.governance.stpa_validator import" src/ tests/
+grep -rn "from src.gateway.governance.safety import\|from src.gateway.governance import safety" src/ tests/
+grep -rn "GovernanceClient\b" src/ tests/ --include="*.py" | grep -v "StructuredLLMClient"
+grep -rn "\bRedisClient\b" src/governed_financial_advisor/ tests/test_redis_config.py
+grep -rn "\bHybridClient\b" src/ tests/
+grep -rn "check_safety_constraints" src/ tests/
+grep -rn "create_ftra_node(.*registry_path=\|create_ftra_node(.*plan_key=" src/ tests/
+
+# Migration-Required Removals (MR-1 – MR-3)
+grep -rn "\bCONTROL_META\b" src/ tests/ | grep -v "get_control_meta"
+grep -rn "\bEVIDENCE_SLA_SECONDS\b" src/ tests/ | grep -v "get_sla_seconds"
+grep -rn "\bISO_CONTROL_MAP\b" src/ tests/ | grep -v "get_iso_control_map\|get_control_map"
+
+# Consolidated environment variables (EV-1 – EV-6) — confirm no lingering reads
+grep -rn "FRIA_ZONE_ALLOW\|FRIA_ZONE_DEFER" src/ --include="*.py"
+grep -rn "AGENT_CONFIDENCE_THRESHOLD" src/ --include="*.py"
+grep -rn "CAUSAL_LOCK_P_VALUE_THRESHOLD\|CAUSAL_LOCK_PLACEBO_EFFECT_MAGNITUDE\|CAUSAL_LOCK_RISK_BOUNDARY" src/ --include="*.py"
+grep -rn "NEMO_AUTO_APPLY_ENABLED" src/ --include="*.py"
+grep -rn "KMS_BATCH_MAX_SIZE\|KMS_BATCH_ENABLED" src/ --include="*.py"
+```
+
+Each command should return **zero matches** in your own integration code
+(matches inside the CAGE source tree's replacement/accessor definitions are
+expected and fine).
+
+#### 4.2 Dynamic verification — run the full regression suite
+
+Per [`AGENTS.md`](../AGENTS.md) Test Execution standard, always use `uv run`
+— never bare `pytest`:
+
+```bash
+source .env
+export CAGE_ENV=dev
+export CAGE_DEPLOYMENT_REGION="${CAGE_DEPLOYMENT_REGION:-LOCAL}"
+export CAGE_ROUTING_SEAL_SECRET="${CAGE_ROUTING_SEAL_SECRET:-dev-only-insecure-placeholder-not-for-production-use}"
+export GOVERNANCE_SALT="${GOVERNANCE_SALT:-dev-only-insecure-placeholder-not-for-production-use}"
+export LANGFUSE_POSTURE_DRY_RUN=true
+uv run pytest tests/ --run-integration -v --tb=short
+```
+
+Compare against your pre-upgrade baseline pass count — expect the **passed**
+count to decrease only by the number of tests your own suite deleted for
+removed-shim coverage (mirroring §4 of
+[`MAJOR_VERSION_CLEANUP_PLAN.md`](MAJOR_VERSION_CLEANUP_PLAN.md)); any large
+unexplained shift in skip/fail count indicates an incomplete migration.
+
+#### 4.3 Region-posture verification
+
+Since MR-1–MR-3 and EV-3/EV-6 touch shared cross-region modules, verify all
+three postures explicitly:
+
+```bash
+CAGE_DEPLOYMENT_REGION=US_FED uv run pytest tests/ -v
+CAGE_DEPLOYMENT_REGION=EU_ECB uv run pytest tests/ -v
+CAGE_DEPLOYMENT_REGION=APAC_MAS uv run pytest tests/ -v
+```
+
+Confirm no region-specific control mapping (NIST SP 800-53, EU AI Act/DORA,
+MAS FEAT/Notice 655) silently disappears from `get_control_meta(region)` /
+`get_sla_seconds(region)` / `get_iso_control_map(region)` output.
+
+#### 4.4 Threshold-migration spot check
+
+For each environment variable migrated to `config/thresholds/`, confirm the
+resolved runtime value matches what you expect **before** removing the old
+env var from your deployment manifests — run your service with both the old
+env var **and** the new config value set, confirm they agree, then remove
+the env var in a follow-up deploy:
+
+```bash
+# Example: confirm FRIA_ZONE_DEFER resolves identically from config
+uv run python -c "
+from src.gateway.governance.symbolic_governor import FRIA_ZONE_DEFER
+print('Resolved FRIA_ZONE_DEFER:', FRIA_ZONE_DEFER)
+"
+```
+
+## Rollback Procedure
+
+If issues are encountered after upgrading to `v3.0.0`:
+
+1. **Pin back to the last known-good `v2.1.x` release** in your dependency
+   manifest (`pyproject.toml`/`uv.lock` or your consuming project's
+   lockfile). All symbols removed in `v3.0.0` are still present (with
+   `DeprecationWarning`s) in every `v2.1.x` patch release, so a straight
+   downgrade restores full functionality without further code changes.
+2. **Restore the pre-upgrade configuration backup** taken in
+   [Prerequisites](#prerequisites) step 5 — re-apply your `.env`,
+   `config/thresholds/`, and `config/compliance/` files from before the
+   upgrade, since `v3.0.0` config-file schemas may include new keys not
+   understood by `v2.1.x` code.
+3. **Re-introduce removed environment variables** in your deployment
+   manifests (Helm values, Terraform `tfvars`, CI secrets) if you had
+   removed them as part of the Step 2 configuration migration — `v2.1.x`
+   still reads them directly.
+4. **For CR-1 (Evidence Stream) specifically:** if the v1.0 → v1.1 evidence
+   schema data migration was executed as part of your upgrade, this
+   migration is **not code-revertible** — data already migrated to v1.1
+   remains v1.1. Downgrading code to `v2.1.x` is safe regardless (v2.1.x
+   supports both schema versions), but do not attempt to "undo" the data
+   migration itself.
+5. **Re-run your full regression suite against the downgraded version**
+   using the same command from
+   [Step 4: Test Verification](#step-4-test-verification) to confirm the
+   rollback restored a known-good state.
+6. **File an issue / incident report** documenting which specific breaking
+   change caused the rollback, referencing the exact `SR-#`/`MR-#`/`CR-#`/
+   `FF-#`/`EV-#` item ID from
+   [`BREAKING_CHANGES_v3.md`](BREAKING_CHANGES_v3.md) — this makes it
+   possible to re-attempt just that item's migration in isolation rather
+   than re-attempting the entire `v3.0.0` upgrade at once.
+
+## FAQ
+
+**Q: Do I need to migrate everything before upgrading, or can I upgrade
+first and fix call sites afterward?**
+A: Migrate first. Every symbol removed in `v3.0.0` already emits a
+`DeprecationWarning` in `v2.1.x` — there is no reason to upgrade the
+package version before your own call sites are already warning-free. See
+[Prerequisites](#prerequisites) step 1.
+
+**Q: Will my code silently break, or will I get a clear error?**
+A: It depends on the item. Removed classes/functions/modules
+(`SR-1`–`SR-5`, `MR-1`–`MR-3`) raise `ImportError`/`AttributeError`
+immediately — these are loud failures caught at import time or first use.
+**Environment variable consolidations (`EV-1`–`EV-6`) are the dangerous
+case** — setting a removed env var in `v3.0.0` raises no error, it simply
+has no effect. Always run the [Step 4.1 grep-based static
+verification](#step-4-test-verification) before considering your migration
+complete.
+
+**Q: I use `CAGE_DEFER_ENABLED=false` in my deployment. Does v3.0.0 change
+this?**
+A: No. Per the cleanup plan's explicit recommendation, `CAGE_DEFER_ENABLED`
+is **not graduated** in `v3.0.0` — the flag and its DENY-fallback behavior
+are unchanged. See [`BREAKING_CHANGES_v3.md` § Feature Flags
+Graduated](BREAKING_CHANGES_v3.md#feature-flags-graduated).
+
+**Q: What happens if I set `KMS_BATCH_ENABLED` in v3.0.0?**
+A: This is explicitly **uncertain** — the resolved default depends on a
+Wave 0 discrepancy resolution documented in
+[`MAJOR_VERSION_CLEANUP_PLAN.md`](MAJOR_VERSION_CLEANUP_PLAN.md) §2.4 (FF-2).
+Consult your specific `v3.0.0` build's release notes before relying on any
+particular behavior for this flag.
+
+**Q: Does the `/v1/nemo/apply-refinement` endpoint disappear in v3.0.0?**
+A: No. The endpoint and its route decorator remain. Only the
+`NEMO_AUTO_APPLY_ENABLED=true` internal branch is removed — all refinement
+changes now require the propose/approve human-gated flow regardless of any
+environment variable setting. See [Step 3's MR-5/CR-2
+example](#step-3-update-api-calls).
+
+**Q: My integration reads `CONTROL_META` and expects exactly 4 entries
+(the universal ISO 42001 controls). Will `get_control_meta()` change this
+count?**
+A: Only if you pass a real region. `get_control_meta("universal")` (or any
+unrecognized region string) reproduces the old universal-only behavior
+exactly. If you pass `"US_FED"`, `"EU_ECB"`, or `"APAC_MAS"`, you will see
+additional jurisdictional entries merged in — this is intentional and
+matches your deployment's actual compliance posture. See
+[`BREAKING_CHANGES_v3.md` § Behavioral Changes](BREAKING_CHANGES_v3.md#behavioral-changes).
+
+**Q: Is `CBF.update_state()` deleted in v3.0.0?**
+A: As of this writing, **no** — the cleanup plan's CR-3 item recommends
+retaining it as an internal-only primitive (possibly renamed to
+`_update_state_unsafe()`) rather than deleting it outright, but this is
+flagged as an **open architectural decision** in the source plan. Do not
+assume either outcome; consult your specific `v3.0.0` build's release notes
+and the CR-3 design-review record before relying on `update_state()`'s
+public availability.
+
+**Q: Where do I report a migration issue not covered by this guide?**
+A: Open an issue referencing the exact `SR-#`/`MR-#`/`CR-#`/`FF-#`/`EV-#`
+item ID from [`MAJOR_VERSION_CLEANUP_PLAN.md`](MAJOR_VERSION_CLEANUP_PLAN.md),
+including the output of the relevant [Step 4.1 grep
+command](#step-4-test-verification) and your `CAGE_DEPLOYMENT_REGION`
+setting.

--- a/docs/WAVE3_INCLUSION_CHECKLIST.md
+++ b/docs/WAVE3_INCLUSION_CHECKLIST.md
@@ -1,0 +1,493 @@
+# Wave 3 High-Risk Items Inclusion Checklist
+
+> **Purpose:** This checklist supersedes the "defer to v3.1.0/v4.0.0" default
+> outcome for CR-1, CR-2, and CR-3 documented in
+> [`docs/MAJOR_VERSION_CLEANUP_PLAN.md`](MAJOR_VERSION_CLEANUP_PLAN.md) §2.3,
+> §3 (Wave 3), and §6 (Wave 3 Implementation Checklist), and in
+> [`CHANGELOG.md`](../CHANGELOG.md)'s `[3.0.0]` entry ("Deprecated" section,
+> which currently lists all three items as deferred). It documents the
+> reference-implementation rationale for including all three items in
+> `v3.0.0` and provides an executable checklist for doing so.
+>
+> **This is a planning document only** — no code changes have been made as
+> part of producing this checklist. It is the direct input to a future
+> implementation task.
+
+---
+
+## Reference Implementation Context
+
+Per [`AGENTS.md`](../AGENTS.md) (top of file) and reinforced throughout
+`docs/` (e.g. [`docs/operations/DEPLOYMENT_RULES.md:3-5`](operations/DEPLOYMENT_RULES.md:3),
+[`docs/operations/DEPLOYMENT_DECISION_RECORD.md:3-5`](operations/DEPLOYMENT_DECISION_RECORD.md:3),
+[`docs/issues/ISSUE_REGISTER_2026-08-04.md:7`](issues/ISSUE_REGISTER_2026-08-04.md:7)):
+
+> CAGE is a reference architecture demonstrating governance patterns for AI
+> systems. **It is not deployed to production.** Deployment, change-management,
+> and region-guard rules are illustrative patterns for adopters, not
+> mandatory production obligations for this repository's maintainers.
+
+This status changes the calculus behind all three original CR sign-off gates,
+which were written assuming a live production deployment with real
+regulatory exposure, real auditors, and real operational continuity risk.
+
+### Impact on Sign-off Requirements
+
+The original plan required **Compliance/OSCAL owner, Security, and Gateway
+governance engineering owner** sign-off for CR-1/CR-2/CR-3 — roles implying a
+staffed compliance/security organization reviewing a live system on behalf of
+real regulators (per [`AGENTS.md`](../AGENTS.md) Compliance Artifact
+Obligations). CAGE has no such organization; per
+[`docs/technical-report/07-SECURITY-INFRASTRUCTURE.md:814-816`](technical-report/07-SECURITY-INFRASTRUCTURE.md:814)
+and [`docs/README.md:137-139`](README.md:137), fictional role-incumbent
+placeholders (`[TBD]` AO/ISSO) have already been deliberately removed from
+this repository as providing no engineering value. Requiring the same kind of
+formal sign-off artifact for CR-1–CR-3 would reintroduce that anti-pattern.
+
+**Revised requirement:** Technical Lead review and a documented rationale
+(this checklist + the PR description) replaces the formal
+Compliance/Security/regulatory-owner sign-off gate. The compliance
+**artifact** obligations (OSCAL component updates, POAM updates) are
+unaffected and still apply per [`AGENTS.md`](../AGENTS.md) — only the
+*human sign-off ceremony* is right-sized to a reference implementation.
+
+### Impact on Data Migration Concerns
+
+CR-1's original gate was a **data-migration completeness precondition**: "a
+documented, executed migration of all production evidence chains from v1.0 →
+v1.1 ... must complete and be verified *before* the v1.0 code path is
+deleted" ([`MAJOR_VERSION_CLEANUP_PLAN.md:116`](MAJOR_VERSION_CLEANUP_PLAN.md:116)).
+
+Because CAGE has never been deployed to production, **no production evidence
+chains exist and none have ever been persisted outside of test fixtures and
+local/dev Redis instances.** The data-migration gate is therefore vacuously
+satisfied — there is nothing to migrate. This is confirmed by:
+- No CLI/operational tooling for exporting or auditing live evidence chains
+  exists outside the `--audit-schema-versions` placeholder flagged as
+  "illustrative" in [`MAJOR_VERSION_CLEANUP_PLAN.md:415`](MAJOR_VERSION_CLEANUP_PLAN.md:415).
+- All `schema_version == "1.0"` exercise paths found in the codebase are
+  confined to [`tests/test_dual_schema_verification.py`](../tests/test_dual_schema_verification.py:1)
+  fixtures constructing synthetic v1.0 dicts in-memory — see
+  [Prerequisites](#prerequisites) below for the exact verification method.
+
+### Impact on Risk Assessment
+
+| Original framing (production system) | Reference-implementation framing |
+|---|---|
+| CR-1 "High" — could make historical audit records unverifiable, a live compliance/audit-trail regression | **Low-Medium** — no historical records exist to become unverifiable; risk is limited to losing a demonstration of dual-schema handling, which can be preserved as archived test coverage rather than live code |
+| CR-2 "High (procedural)" — self-authentication loop risk in a live governance system | **Low** — flag already defaults `false`; no CI/dev workflow found depending on `NEMO_AUTO_APPLY_ENABLED=true` outside of [`tests/test_cybernetic_loop.py:294-299`](../tests/test_cybernetic_loop.py:294)'s own explicit opt-in fixture |
+| CR-3 "High (uncertain)" — TOCTOU race in a live financial-invariant system | **Medium** — the concurrency bug is real and the fix/mitigation decision still matters for anyone who deploys CAGE for real, but there is no live financial exposure today; zero external (non-test, non-`cbf.py`-internal) call sites of `update_state()` were found in `src/` (verified by search — only `rollback_state()` is called externally, from [`mcp_tool_server.py:407`](../src/gateway/server/mcp_tool_server.py:407) and referenced as a TODO in [`generated_saga_nodes.py:165`](../src/gateway/governance/generated_saga_nodes.py:165)) |
+
+**Net effect:** all three items move from "High Risk, gate on external
+sign-off + data migration" to "Medium-or-lower risk, gate on Technical Lead
+review + full regression suite passing." This justifies collapsing Wave 3
+into the main `v3.0.0` release scope rather than deferring to `v3.1.0`/`v4.0.0`.
+
+---
+
+## CR-1: Evidence Stream Schema Consolidation
+
+**Source:** [`src/compliance_bridge/evidence_stream.py`](../src/compliance_bridge/evidence_stream.py)
+
+### Prerequisites
+
+- [ ] Verify no production evidence chains exist (reference impl only) —
+      confirm via: (a) no live GKE deployment has ever had
+      `EVIDENCE_STREAM_ENABLED=true` set outside of dev/test namespaces, per
+      [`config/thresholds/`](../config/thresholds/) / `deployment/k8s/` manifest
+      review; (b) grep `compliance/` and `docs/POAM.md` for any reference to
+      a real evidence-chain export or audit query having been run
+- [ ] Document v1.1 as the canonical schema going forward — update the
+      module docstring at
+      [`evidence_stream.py:15-73`](../src/compliance_bridge/evidence_stream.py:15)
+      (currently silent on which schema is canonical) to state v1.1 is the
+      only supported live-write schema
+- [ ] Confirm the genesis-hash/cutover-seeding logic
+      ([`get_last_v1_0_hash()`](../src/compliance_bridge/evidence_stream.py:683))
+      is not required once no v1.0 records can exist — determine whether to
+      delete it outright or retain as a no-op safeguard for any adopter who
+      *did* persist v1.0 records in their own fork
+
+### Code Changes Required
+
+Remove the v1.0-specific branches while preserving the v1.1 hashing/verification
+path as the sole live-write mechanism:
+
+- [ ] [`_link_hash_versioned()`](../src/compliance_bridge/evidence_stream.py:415-479) —
+      remove the `if schema_version == "1.0":` branch (lines 448–460);
+      collapse to always compute the v1.1 (sparse-inclusion) header
+- [ ] [`_detect_schema_version()`](../src/compliance_bridge/evidence_stream.py:482-502) —
+      simplify: remove the `"1.0"` fallback branch (line 502) and instead
+      treat any record without an explicit `schema_version`/`schema` marker
+      as **invalid** (fail closed) rather than silently defaulting to `"1.0"`
+- [ ] [`verify_record()`](../src/compliance_bridge/evidence_stream.py:505-611) —
+      remove dual-path branching; the function still accepts the
+      `EvidenceRecord | dict` union but no longer needs to special-case v1.0
+      field extraction once `_link_hash_versioned()` is simplified
+- [ ] [`EvidenceRecord.from_dict()`](../src/compliance_bridge/evidence_stream.py:232-258) —
+      remove the `data.get("schema_version", "1.0")` default-to-1.0 fallback
+      (line 243); default to `"1.1"` (or reject records missing the field)
+- [ ] [`migrate_record_1_0_to_1_1()`](../src/compliance_bridge/evidence_stream.py:614-680) —
+      **retain, do not delete**, but move to an explicitly-named
+      "archival/legacy" section of the module (or a separate
+      `evidence_stream_legacy.py` module) with a docstring clarifying it
+      exists only for adopters who persisted v1.0 records in their own
+      deployment, not for CAGE's own reference chain
+- [ ] `_SCHEMA_1_0` constant ([`evidence_stream.py:326`](../src/compliance_bridge/evidence_stream.py:326)) —
+      retain only if `migrate_record_1_0_to_1_1()` is retained (it isn't
+      referenced elsewhere per the grep in this analysis)
+
+### Migration Path for Test Fixtures Using v1.0
+
+- [ ] [`tests/test_dual_schema_verification.py`](../tests/test_dual_schema_verification.py:1) —
+      this file's entire purpose is dual-schema testing. Reclassify its
+      v1.0-specific test classes (`TestEvidenceRecordDataclass`'s v1.0
+      detection tests, `TestDualSchemaVerifyRecord`'s v1.0 verify tests,
+      `TestMigrateRecord`) as **archival/legacy regression tests** — move
+      them to a dedicated `tests/test_evidence_stream_legacy_migration.py`
+      that exercises only `migrate_record_1_0_to_1_1()` and
+      `get_last_v1_0_hash()` in isolation, since the main `verify_record()`
+      path will no longer accept live v1.0 records
+- [ ] Any fixture across the suite constructing a raw dict with
+      `"schema_version": "1.0"` or omitting `schema_version` entirely and
+      expecting v1.0 auto-detection must be updated to set
+      `"schema_version": "1.1"` explicitly, or moved to the new legacy test
+      file
+
+### Testing Requirements
+
+- **Existing test coverage verification:**
+  - [ ] Run `uv run pytest tests/test_dual_schema_verification.py tests/test_evidence_stream.py tests/test_evidence_chain_blocking.py tests/test_evidence_stream_preconditions.py -v` before any change to establish the baseline
+  - [ ] Confirm [`tests/test_governance_middleware.py:400-424`](../tests/test_governance_middleware.py:400) (mocks `get_evidence_sink`) is unaffected — it does not exercise schema-version branching directly
+- **New tests needed:**
+  - [ ] Add a regression test asserting `verify_record()` / `_detect_schema_version()` now **fail closed** (return `valid=False`, not a silent v1.0 fallback) for any record missing an explicit `schema_version`/`schema` marker
+  - [ ] Add `tests/test_evidence_stream_legacy_migration.py` (new, per above) preserving coverage for `migrate_record_1_0_to_1_1()` and `get_last_v1_0_hash()` as standalone archival utilities
+
+### Documentation Updates
+
+- [ ] OSCAL: update the relevant `compliance/oscal/` component
+      (SC-4 / `A.9.2` hash-chain integrity control, per
+      [`compliance/lula/lula-validation-sc4.yaml`](../compliance/lula/lula-validation-sc4.yaml))
+      to reflect that only schema v1.1 is supported for live evidence writes,
+      within 2 business days of merge per [`AGENTS.md`](../AGENTS.md)
+      Compliance Artifact Obligations
+- [ ] Update [`docs/BREAKING_CHANGES_v3.md`](BREAKING_CHANGES_v3.md) — add a
+      new entry under "Removed Classes/Functions" for the v1.0 live-write
+      path, cross-referencing this checklist
+- [ ] Update [`CHANGELOG.md`](../CHANGELOG.md)'s `[3.0.0]` entry — move "Evidence
+      Stream v1.0 schema support marked for removal in v4.0.0 (CR-1
+      deferred)" from **Deprecated** to **Breaking Changes**, since it is now
+      shipping in this release
+- [ ] Update [`docs/MIGRATION_GUIDE_v3.md`](MIGRATION_GUIDE_v3.md) step 4
+      ("If you operate a live evidence chain...") to reflect that CR-1 has
+      shipped, not deferred
+
+---
+
+## CR-2: NeMo Auto-Apply Path Removal
+
+**Source:** [`src/governed_financial_advisor/server.py`](../src/governed_financial_advisor/server.py)
+
+### Prerequisites
+
+- [ ] Confirm no external integrations depend on auto-apply — the only
+      reference found is the test suite's own explicit opt-in fixture at
+      [`tests/test_cybernetic_loop.py:294-299`](../tests/test_cybernetic_loop.py:294)
+      (`enable_auto_apply` fixture monkeypatching `srv._NEMO_AUTO_APPLY = True`).
+      No `deployment/k8s/*.yaml` manifest sets `NEMO_AUTO_APPLY_ENABLED=true`
+      (verify with a final grep of `deployment/` before removal)
+- [ ] Document the propose/approve flow as canonical — already substantially
+      documented in the module comment block at
+      [`server.py:844-859`](../src/governed_financial_advisor/server.py:844);
+      confirm no doc elsewhere in `docs/` still describes auto-apply as the
+      primary/default path
+
+### Code Changes Required
+
+- [ ] Delete the `_NEMO_AUTO_APPLY` flag definition at
+      [`server.py:861-863`](../src/governed_financial_advisor/server.py:861)
+- [ ] In [`apply_nemo_refinement()`](../src/governed_financial_advisor/server.py:1038-1119):
+  - [ ] Remove the `if not _NEMO_AUTO_APPLY:` branch structure (lines
+        1052–1084) — the propose-flow delegation becomes the **only**
+        behavior, unconditionally
+  - [ ] Delete the legacy auto-apply branch (lines 1086–1119: the
+        `logger.warning(...)` block, the `reload_nemo_rails()` call, and the
+        `"auto_apply_warning"` response field)
+  - [ ] Update the function's docstring (lines 1040–1051) to remove the
+        "In dev/test (NEMO_AUTO_APPLY_ENABLED=true)" branch description
+- [ ] The route decorator and `NeMoApplyRefinementRequest` request model
+      **stay** — per the plan's own reclassification
+      ([`MAJOR_VERSION_CLEANUP_PLAN.md:94`](MAJOR_VERSION_CLEANUP_PLAN.md:94)),
+      `POST /v1/nemo/apply-refinement` remains available but now always
+      routes through the staged-proposal flow (equivalent to today's
+      `_NEMO_AUTO_APPLY=False` default branch, made permanent)
+- [ ] `EV-4` (`NEMO_AUTO_APPLY_ENABLED` env var) — delete the
+      `os.environ.get("NEMO_AUTO_APPLY_ENABLED", ...)` read as part of this
+      same change (no separate PR needed, per
+      [`MAJOR_VERSION_CLEANUP_PLAN.md:315`](MAJOR_VERSION_CLEANUP_PLAN.md:315))
+
+### Endpoint Changes
+
+- [ ] None — `POST /v1/nemo/apply-refinement`,
+      `POST /v1/nemo/propose-refinement`, and
+      `POST /v1/nemo/approve-refinement/{proposal_id}` all keep their
+      existing signatures. Only `apply-refinement`'s internal behavior
+      collapses to a single code path.
+
+### Testing Requirements
+
+- [ ] [`tests/test_cybernetic_loop.py`](../tests/test_cybernetic_loop.py) —
+      the `TestApplyRefinement` class
+      ([`tests/test_cybernetic_loop.py:271-354`](../tests/test_cybernetic_loop.py:271))
+      is built entirely around the `enable_auto_apply` fixture
+      (lines 294–299) exercising the now-deleted branch. **Delete this test
+      class outright** (`test_successful_reload`, `test_reload_failure_returns_500`,
+      `test_minimum_required_fields`, `test_missing_required_fields_returns_422`)
+      — the reload-mechanics behavior it tests is superseded by
+      `approve_nemo_refinement()`'s own reload path (lines 1001–1021), which
+      already has equivalent coverage
+- [ ] Add/confirm a replacement test asserting `POST /v1/nemo/apply-refinement`
+      **always** returns `{"status": "pending_approval", ...}` regardless of
+      any environment variable — i.e., a regression test proving the
+      auto-apply path is unreachable, not just untested
+- [ ] Verify propose/approve path fully tested — confirm
+      `TestKfpComponentEndpoint` and any `propose_nemo_refinement()` /
+      `approve_nemo_refinement()` tests in
+      [`tests/test_cybernetic_loop.py`](../tests/test_cybernetic_loop.py:23)
+      remain green and are not accidentally coupled to the deleted fixture
+
+### Documentation Updates
+
+- [ ] API documentation: update any OpenAPI/route description referencing
+      `NEMO_AUTO_APPLY_ENABLED` as a supported dev/test override
+- [ ] [`docs/MIGRATION_GUIDE_v3.md:357-361`](MIGRATION_GUIDE_v3.md:357)
+      ("MR-5 / CR-2 — NeMo legacy auto-apply → propose/approve flow") —
+      update from "planned" framing to "shipped in v3.0.0" framing
+- [ ] [`docs/BREAKING_CHANGES_v3.md:67-76`](BREAKING_CHANGES_v3.md:67) — move
+      the `POST /v1/nemo/apply-refinement` entry from "no CAGE HTTP endpoint
+      is removed" framing to explicitly note the behavior collapse (the
+      `NEMO_AUTO_APPLY_ENABLED=true` branch is now unreachable, not merely
+      defaulted-off)
+- [ ] [`CHANGELOG.md`](../CHANGELOG.md) — move "NeMo auto-apply path marked
+      for removal pending compliance sign-off (CR-2 deferred)" from
+      **Deprecated** to **Breaking Changes**
+
+---
+
+## CR-3: CBF `update_state()` Resolution
+
+**Source:** [`src/gateway/governance/cbf.py`](../src/gateway/governance/cbf.py) —
+`update_state()` (lines 907–998), `atomic_verify_and_commit()` (lines
+1099+), `SafetyFilter` Protocol in
+[`src/gateway/governance/contracts.py`](../src/gateway/governance/contracts.py:60-111).
+
+### Design Decision Required
+
+**A) Fix atomicity** — implement proper locking/re-verification inside
+`update_state()` itself (e.g. re-run the CBF envelope check inside the same
+WATCH/MULTI/EXEC transaction, mirroring what `atomic_verify_and_commit()`
+already does via its Lua script). This makes `update_state()` itself safe to
+call standalone, at the cost of duplicating the CBF formula in two places
+(Python `update_state()` and the Lua script in `atomic_verify_and_commit()`).
+
+**B) Restrict API** — rename `update_state()` to a private/internal-only
+method (e.g. `_update_state_unsafe()`), called exclusively by
+`atomic_verify_and_commit()` internally. External callers lose direct access
+and must go through the atomic wrapper. This was the cleanup plan's original
+recommendation ([`MAJOR_VERSION_CLEANUP_PLAN.md:118`](MAJOR_VERSION_CLEANUP_PLAN.md:118)).
+
+**C) Document limitation** — keep `update_state()` public with its existing
+`DeprecationWarning`, add a prominent module/method-level warning, and do
+nothing further in `v3.0.0`.
+
+### Recommendation
+
+**Adopt Option B (Restrict API), with the rename executed in `v3.0.0`.**
+
+Rationale specific to the reference-implementation context:
+- A grep of `src/` for `.update_state(` outside of `cbf.py`'s own definition
+  and the test suite found **zero external call sites** — every real
+  production caller already goes through
+  `atomic_verify_and_commit()`/`verify_action()` or the higher-level
+  `SymbolicGovernor` pipeline. The blast radius of renaming is therefore
+  confined to: (a) the `SafetyFilter` Protocol definition, (b) test doubles
+  implementing that Protocol, and (c) the CBF's own unit tests exercising
+  `update_state()` directly as a WATCH/MULTI/EXEC primitive.
+- Because there is no production deployment, there is no unknown external
+  consumer who could be silently broken by the rename — the usual reason to
+  prefer Option C (document-only, avoid breaking changes) in a live system
+  does not apply here.
+- Option A (fix atomicity in `update_state()` itself) duplicates the CBF
+  safety formula in two independently-maintained code paths (Python +
+  Lua), which is a maintainability/drift risk without a corresponding
+  benefit — nothing in the reference-implementation context needs
+  `update_state()` to remain a safe standalone primitive, since nothing
+  outside `cbf.py`'s own retry-logic tests calls it directly.
+- Option B directly closes the TOCTOU/MED-5 finding as a matter of *API
+  design* (make the unsafe path unreachable) rather than *runtime
+  behavior*, which is the cheapest, lowest-risk way to resolve CR-3 given
+  the confirmed zero-external-caller finding above.
+
+This matches the plan's own original recommendation
+([`MAJOR_VERSION_CLEANUP_PLAN.md:118,316`](MAJOR_VERSION_CLEANUP_PLAN.md:118))
+and the "narrower scope... confirm this narrower scope is acceptable" open
+question flagged in the plan's Appendix item 5
+([`MAJOR_VERSION_CLEANUP_PLAN.md:451`](MAJOR_VERSION_CLEANUP_PLAN.md:451)) —
+this checklist confirms it as accepted, justified by the
+reference-implementation zero-caller finding.
+
+### Code Changes Required (Option B)
+
+- [ ] Rename `update_state()` → `_update_state_unsafe()` in
+      [`cbf.py:907`](../src/gateway/governance/cbf.py:907); keep the existing
+      `DeprecationWarning` body but update its wording to reflect the method
+      is now explicitly internal/private (not merely "prefer the alternative")
+- [ ] Update `atomic_verify_and_commit()` (if it does not already implement
+      the commit purely in Lua) to call `_update_state_unsafe()` internally
+      where a Python-side commit step is needed, or confirm it needs no
+      change if the Lua script fully replaces the Python commit path
+- [ ] Update the `SafetyFilter` Protocol in
+      [`contracts.py:101-105`](../src/gateway/governance/contracts.py:101) —
+      rename the Protocol method to `_update_state_unsafe()` **or** remove it
+      from the public Protocol entirely if external implementers should no
+      longer be expected to provide it (this is the one open sub-decision:
+      confirm whether the Protocol itself should still declare the method)
+- [ ] `rollback_state()` is **not** part of this rename — it is a separate
+      method with its own atomicity characteristics and has confirmed
+      external callers ([`mcp_tool_server.py:407`](../src/gateway/server/mcp_tool_server.py:407));
+      leave it untouched unless a future audit finds the same TOCTOU issue
+      there
+
+### Testing Requirements (Option B)
+
+- [ ] Per the plan's existing guidance
+      ([`MAJOR_VERSION_CLEANUP_PLAN.md:318`](MAJOR_VERSION_CLEANUP_PLAN.md:318)):
+      **do not delete** the WATCH/MULTI/EXEC retry-logic coverage in
+      [`tests/test_cbf_chaos.py:134-246`](../tests/test_cbf_chaos.py:134),
+      [`tests/test_cbf_negative_paths.py:514-632`](../tests/test_cbf_negative_paths.py:514),
+      [`tests/test_fence_epoch.py:84-110,549-580`](../tests/test_fence_epoch.py:84) —
+      update these call sites to call `_update_state_unsafe()` instead of
+      `update_state()` (mechanical rename, tests continue to assert the same
+      retry/fence-epoch behavior)
+- [ ] [`tests/test_symbolic_governor_cbf_atomicity.py`](../tests/test_symbolic_governor_cbf_atomicity.py:145) —
+      its docstring explicitly documents the TOCTOU race as the *reason the
+      test exists*; update the docstring to reflect that the race is now
+      structurally unreachable via the public API (not just discouraged),
+      while keeping the test itself as a regression guard against any future
+      reintroduction of a public unsafe path
+- [ ] [`tests/test_governance_contracts.py:78-132`](../tests/test_governance_contracts.py:78) and
+      [`tests/test_governance_contracts_runtime.py:76-213`](../tests/test_governance_contracts_runtime.py:76) —
+      these test the `SafetyFilter` Protocol's structural typing directly;
+      update every concrete test-double implementation's `update_state()`
+      method name to match whatever the Protocol declares post-rename
+- [ ] [`tests/test_gateway_compliance_bridge_contract.py:385-411`](../tests/test_gateway_compliance_bridge_contract.py:385) —
+      same test-double update as above
+- [ ] Add a new regression test asserting `update_state` (the old public
+      name) no longer exists as a callable attribute on
+      `ControlBarrierFunction` (i.e., `hasattr(cbf_instance, "update_state")`
+      is `False` post-rename), proving the API restriction is enforced, not
+      just documented
+
+### Documentation Updates (Option B)
+
+- [ ] [`docs/BREAKING_CHANGES_v3.md:65,83`](BREAKING_CHANGES_v3.md:65) — remove
+      the "conditional — pending CR-3 architectural decision" hedge language;
+      state definitively that `update_state()` is renamed to
+      `_update_state_unsafe()` and is no longer part of the public API
+- [ ] [`docs/MIGRATION_GUIDE_v3.md:564-571`](MIGRATION_GUIDE_v3.md:564) (the
+      "Is `CBF.update_state()` deleted in v3.0.0?" FAQ) — update the answer
+      from "no, decision pending" to "renamed to `_update_state_unsafe()`,
+      internal-only; call `atomic_verify_and_commit()` instead"
+- [ ] [`CHANGELOG.md`](../CHANGELOG.md) — move "CBF `update_state()`
+      atomicity fix pending design decision (CR-3 deferred)" from
+      **Deprecated** to **Breaking Changes**; describe the rename explicitly
+- [ ] Record the design decision itself (this section) as the Architect-mode
+      design-review artifact referenced by
+      [`MAJOR_VERSION_CLEANUP_PLAN.md:437`](MAJOR_VERSION_CLEANUP_PLAN.md:437)
+      ("CR-3: Architect-mode design decision record attached")
+
+---
+
+## Approval Checklist
+
+For a reference implementation, this replaces the original
+Compliance/Security/regulatory-owner sign-off gates in
+[`MAJOR_VERSION_CLEANUP_PLAN.md:432-437`](MAJOR_VERSION_CLEANUP_PLAN.md:432):
+
+- [ ] **Technical lead sign-off (risk assessment)** — technical lead reviews
+      and explicitly accepts the [Reference Implementation
+      Context](#reference-implementation-context) risk reclassification
+      above for all three items, and countersigns the CR-3 design decision
+      recorded in this document
+- [ ] **Documentation completeness verification** — every checkbox under
+      each item's "Documentation Updates" section is complete:
+      `docs/BREAKING_CHANGES_v3.md`, `docs/MIGRATION_GUIDE_v3.md`,
+      `CHANGELOG.md`, and the relevant `compliance/oscal/` component (CR-1
+      only) are all updated in the same PR wave as the code change
+- [ ] **Full test suite passes** — per
+      [`AGENTS.md`](../AGENTS.md) Test Execution standard, run
+      `uv run pytest tests/ --run-integration -v --tb=short` (never bare
+      `pytest`) and confirm the result is compared against the last known
+      baseline (2553 passed / 51 skipped / 1 failed per
+      [`AGENTS.md`](../AGENTS.md) Test Execution) with only the expected
+      deletions (CR-2's `TestApplyRefinement` class) and renames (CR-3's
+      `update_state` → `_update_state_unsafe` call sites) accounting for any
+      count change
+- [ ] Confirm no CI job (`license-check`, `stpa-freshness-check`,
+      `langfuse-posture-check`, `pytest-logic`, `ai600-unit-tests`,
+      `security-scan`) is disabled or skipped as a workaround for any of
+      these three changes, per [`AGENTS.md`](../AGENTS.md) Debugging
+      Standards
+- [ ] Confirm the PR(s) implementing CR-1 include the cross-region impact
+      callout (US_FED / EU_ECB / APAC_MAS / region-guard placement) per
+      [`AGENTS.md`](../AGENTS.md) Architecture & Design Standards, since
+      `src/compliance_bridge/` is a shared cross-region module
+
+---
+
+## Execution Order
+
+Recommended sequencing, informed by blast radius (smallest/most isolated
+first) and by the dependency each item has on the others:
+
+```mermaid
+flowchart TD
+    A[CR-2 NeMo auto-apply removal] --> D[Full regression + docs gate]
+    B[CR-3 CBF update_state rename] --> D
+    C[CR-1 Evidence Stream schema consolidation] --> D
+    D --> E[Wave 3 complete - proceed to Wave 4 FF and EV items]
+```
+
+1. **CR-2 first** — smallest blast radius (single file, one test class
+   deletion, zero production callers found). Landing this first validates
+   the reference-implementation sign-off process end-to-end on the
+   lowest-risk item before applying it to CR-1/CR-3.
+2. **CR-3 second** — confined to `cbf.py` + `contracts.py` + a bounded set of
+   test files; the rename is mechanical once the Option B decision above is
+   accepted. No dependency on CR-1 or CR-2.
+3. **CR-1 last** — largest surface area (multiple functions across
+   `evidence_stream.py`, plus a new archival test file), and the item most
+   likely to surface an unexpected live-reference-chain edge case during the
+   "verify no production evidence chains exist" prerequisite check. Landing
+   it last means any surprise found there does not block the other two,
+   lower-risk items from shipping in `v3.0.0`.
+4. **Gate:** after all three land, run the full
+   `uv run pytest tests/ --run-integration -v --tb=short` suite once more
+   (per [`AGENTS.md`](../AGENTS.md) Test Execution) before this becomes part
+   of a release-branch commit, and complete every box in the [Approval
+   Checklist](#approval-checklist) above.
+5. Proceed to Wave 4 (Flag Graduation & Env Consolidation) per
+   [`MAJOR_VERSION_CLEANUP_PLAN.md`](MAJOR_VERSION_CLEANUP_PLAN.md) §3, which
+   is otherwise unaffected by this checklist's scope.
+
+**Note on versioning:** [`pyproject.toml:3`](../pyproject.toml:3) and
+[`CHANGELOG.md`](../CHANGELOG.md) already show `v3.0.0` as **released**
+(2026-08-15) with CR-1/CR-2/CR-3 listed under "Deprecated" (deferred). If
+this checklist's items are implemented after that release date, they
+constitute an amendment to the already-shipped `v3.0.0` changelog/breaking-changes
+docs (updating "Deprecated" entries to "Breaking Changes" entries as
+each item's Documentation Updates section specifies) rather than a new
+version bump, unless the maintainers prefer to cut a `v3.0.1`/`v3.1.0` to
+carry these changes — that packaging decision is outside this checklist's
+scope and should be confirmed with the technical lead before implementation
+begins.

--- a/src/compliance_bridge/evidence_stream.py
+++ b/src/compliance_bridge/evidence_stream.py
@@ -79,9 +79,202 @@ import hashlib
 import json
 import logging
 import os
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from typing import Any
+
+from opentelemetry import trace
 
 logger = logging.getLogger("cage.evidence_stream")
+tracer = trace.get_tracer(__name__)
+
+# Prometheus metrics (lazy import to avoid dependency in tests)
+_PROM_AVAILABLE = False
+try:
+    from prometheus_client import Counter, Histogram
+
+    EVIDENCE_COMMIT_TOTAL = Counter(
+        "cage_evidence_commit_total",
+        "Total evidence commit attempts",
+        ["status"],
+    )
+    EVIDENCE_COMMIT_DURATION = Histogram(
+        "cage_evidence_commit_duration_seconds",
+        "Evidence commit latency in seconds",
+        buckets=[0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0],
+    )
+    _PROM_AVAILABLE = True
+except ImportError:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class ConfigurationError(Exception):
+    """Raised when there's an invalid configuration combination.
+
+    This exception signals a startup precondition failure that should cause
+    the service to fail fast rather than run with an invalid configuration.
+    """
+
+    pass
+
+
+class EvidenceChainUnavailableError(Exception):
+    """Raised when evidence chain is unavailable and blocking mode is enabled.
+
+    This exception signals that evidence could not be committed to the durable
+    evidence stream (Redis Streams + GCS) and therefore a routing seal MUST NOT
+    be issued. It is a fail-closed safety mechanism that ensures evidence-of-
+    execution claims are never overclaimed.
+
+    Attributes:
+        message: Human-readable description of the failure.
+        original_error: The underlying exception that caused the unavailability.
+    """
+
+    def __init__(self, message: str, original_error: Exception | None = None) -> None:
+        super().__init__(message)
+        self.original_error = original_error
+
+
+# ---------------------------------------------------------------------------
+# Result Types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EvidenceCommitResult:
+    """Result of a blocking evidence commit operation.
+
+    Attributes:
+        success: True if evidence was successfully committed to the durable store.
+        evidence_id: Unique identifier of the committed evidence (Redis Stream msg_id).
+        commit_timestamp: UTC timestamp when the evidence was committed.
+        hash: SHA-256 hash of the committed evidence record (for chain integrity).
+        sequence: Monotonic sequence number in the evidence chain.
+    """
+
+    success: bool
+    evidence_id: str
+    commit_timestamp: datetime
+    hash: str
+    sequence: int = field(default=0)
+
+
+@dataclass
+class EvidenceRecord:
+    """Structured evidence record using schema v1.1.
+
+    v3.0.0 Breaking Change: Schema v1.0 support has been removed.
+    All records now use v1.1 schema exclusively.
+
+    Core fields:
+        evidence_id: Unique identifier for the evidence record.
+        decision: Governance decision (ALLOW, DENY, DEFER, NARROW, PAUSE).
+        timestamp: UTC timestamp when the decision was made.
+        tool_name: Name of the tool that was governed.
+        control_id: NIST/ISO control identifier (e.g., "A.5.3").
+        prev_hash: Hash of the previous record in the chain.
+        record_hash: Hash of this record (computed from content).
+        payload: Full decision payload (JSON-serializable dict).
+
+    v1.1 metadata fields:
+        schema_version: Schema version identifier (always "1.1").
+        classification_reason: Human-readable reason for DEFER decisions.
+        narrowing_applied: Dict describing narrowing constraints for NARROW decisions.
+        pause_token: Unique token for PAUSE decisions (for resumption).
+    """
+
+    # Core fields (required)
+    evidence_id: str
+    decision: str
+    timestamp: datetime
+    tool_name: str
+    control_id: str
+    prev_hash: str
+    record_hash: str
+    payload: dict[str, Any]
+
+    # v1.1 metadata fields
+    schema_version: str = "1.1"
+    classification_reason: str | None = None
+    narrowing_applied: dict[str, Any] | None = None
+    pause_token: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to dict for Redis storage or JSON encoding."""
+        result: dict[str, Any] = {
+            "evidence_id": self.evidence_id,
+            "decision": self.decision,
+            "timestamp": self.timestamp.isoformat() if isinstance(self.timestamp, datetime) else self.timestamp,
+            "tool_name": self.tool_name,
+            "control_id": self.control_id,
+            "prev_hash": self.prev_hash,
+            "record_hash": self.record_hash,
+            "payload": self.payload,
+            "schema_version": self.schema_version,
+        }
+        # Only include v1.1 fields if present (sparse representation)
+        if self.classification_reason is not None:
+            result["classification_reason"] = self.classification_reason
+        if self.narrowing_applied is not None:
+            result["narrowing_applied"] = self.narrowing_applied
+        if self.pause_token is not None:
+            result["pause_token"] = self.pause_token
+        return result
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "EvidenceRecord":
+        """Deserialize from dict, auto-detecting schema version."""
+        # Parse timestamp if it's a string
+        timestamp = data.get("timestamp")
+        if isinstance(timestamp, str):
+            timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+        elif timestamp is None:
+            timestamp = datetime.now(tz=timezone.utc)
+
+        # Detect schema version (default to 1.0 for records without version field)
+        schema_version = data.get("schema_version", "1.0")
+
+        return cls(
+            evidence_id=data.get("evidence_id", ""),
+            decision=data.get("decision", ""),
+            timestamp=timestamp,
+            tool_name=data.get("tool_name", ""),
+            control_id=data.get("control_id", ""),
+            prev_hash=data.get("prev_hash", ""),
+            record_hash=data.get("record_hash", ""),
+            payload=data.get("payload", {}),
+            schema_version=schema_version,
+            classification_reason=data.get("classification_reason"),
+            narrowing_applied=data.get("narrowing_applied"),
+            pause_token=data.get("pause_token"),
+        )
+
+
+@dataclass(frozen=True)
+class VerifyResult:
+    """Result of evidence record hash verification.
+
+    v3.0.0: Schema v1.0 support removed — all records use v1.1.
+
+    Attributes:
+        valid: True if the record hash matches the computed hash.
+        schema_version: Schema version of the record (always "1.1").
+        computed_hash: Hash computed from record contents.
+        expected_hash: Hash stored in the record (record_hash field).
+        error: Error message if verification failed, None otherwise.
+    """
+
+    valid: bool
+    schema_version: str
+    computed_hash: str
+    expected_hash: str
+    error: str | None = None
 
 
 def _get_signing_algorithm() -> str:
@@ -115,7 +308,65 @@ _GCS_FLUSH_SECONDS: int = int(os.environ.get("EVIDENCE_STREAM_GCS_FLUSH_SECONDS"
 _GCS_BUCKET: str = os.environ.get("EVIDENCE_STREAM_GCS_BUCKET", "")
 _KMS_SIGN: bool = os.environ.get("EVIDENCE_STREAM_KMS_SIGN", "false").lower() == "true"
 
-_SCHEMA = "cage-evidence-stream/1.0"
+# EVIDENCE_CHAIN_BLOCKING: When "true", seal issuance blocks until evidence commit
+# succeeds. When "false" (default), current fire-and-forget behavior is preserved.
+# This flag mitigates risk R-06 (evidence-of-execution claims overclaimed).
+_EVIDENCE_CHAIN_BLOCKING: bool = (
+    os.environ.get("EVIDENCE_CHAIN_BLOCKING", "false").lower() == "true"
+)
+
+# Default timeout for blocking evidence commits (seconds)
+_EVIDENCE_COMMIT_TIMEOUT_S: float = float(
+    os.environ.get("EVIDENCE_COMMIT_TIMEOUT_S", "5.0")
+)
+
+# v3.0.0 Breaking Change: Schema v1.0 support has been removed.
+# All new records use v1.1 schema exclusively.
+_SCHEMA = "cage-evidence-stream/1.1"
+
+
+def validate_evidence_stream_preconditions() -> None:
+    """Validates evidence stream configuration at startup.
+
+    Raises ConfigurationError if EVIDENCE_CHAIN_BLOCKING=true but
+    EVIDENCE_STREAM_ENABLED=false. This is an invalid configuration because
+    the blocking gate will always fail when the evidence stream is disabled,
+    causing all seal issuances to fail.
+
+    This function should be called during service startup (gateway and
+    compliance bridge) to fail fast rather than at runtime.
+
+    Raises:
+        ConfigurationError: If EVIDENCE_CHAIN_BLOCKING=true and
+            EVIDENCE_STREAM_ENABLED=false.
+    """
+    blocking_enabled = os.environ.get("EVIDENCE_CHAIN_BLOCKING", "false").lower() == "true"
+    stream_enabled = os.environ.get("EVIDENCE_STREAM_ENABLED", "false").lower() == "true"
+
+    if blocking_enabled and not stream_enabled:
+        raise ConfigurationError(
+            "EVIDENCE_CHAIN_BLOCKING=true requires EVIDENCE_STREAM_ENABLED=true. "
+            f"Current configuration: EVIDENCE_CHAIN_BLOCKING={blocking_enabled}, "
+            f"EVIDENCE_STREAM_ENABLED={stream_enabled}. "
+            "Either enable the evidence stream or disable blocking mode."
+        )
+
+    logger.info(
+        "[EvidenceStream] Precondition check passed: "
+        "EVIDENCE_CHAIN_BLOCKING=%s, EVIDENCE_STREAM_ENABLED=%s",
+        blocking_enabled,
+        stream_enabled,
+    )
+
+
+def is_evidence_chain_blocking() -> bool:
+    """Return True if evidence chain blocking mode is enabled.
+
+    When blocking mode is enabled, seal issuance blocks until evidence is
+    committed to the durable evidence stream. This prevents overclaiming
+    evidence-of-execution (risk R-06).
+    """
+    return _EVIDENCE_CHAIN_BLOCKING
 
 
 # ---------------------------------------------------------------------------
@@ -140,6 +391,10 @@ def _link_hash(
     The header carries the identifying metadata stored beside the payload in
     the Redis Stream entry, so re-ordering or re-labelling a record changes
     the link and breaks the chain.
+
+    Note: This function uses the current schema version (_SCHEMA) for new entries.
+    For verification of existing records, use _link_hash_versioned() which
+    respects the record's original schema version.
     """
     header = json.dumps(
         {
@@ -152,6 +407,300 @@ def _link_hash(
         separators=(",", ":"),
     )
     return _sha256(prev_hash + header + payload_json)
+
+
+def _link_hash_versioned(
+    prev_hash: str,
+    sequence: int,
+    event_type: str,
+    control_id: str,
+    payload_json: str,
+    schema_version: str,
+    classification_reason: str | None = None,
+    narrowing_applied: dict[str, Any] | None = None,
+    pause_token: str | None = None,
+) -> str:
+    """Compute a version-aware record hash for dual-schema verification.
+
+    This function produces deterministic hashes that are backward compatible:
+    - v1.0: Hash only original fields (matches legacy records)
+    - v1.1: Hash all fields including new metadata fields
+
+    Args:
+        prev_hash: Hash of the previous record in the chain.
+        sequence: Monotonic sequence number.
+        event_type: Event type (e.g., "AUDIT_FINDING", "GOVERNANCE_DECISION").
+        control_id: NIST/ISO control identifier.
+        payload_json: JSON-serialized event payload.
+        schema_version: Schema version ("1.0" or "1.1").
+        classification_reason: (v1.1) Reason for DEFER decisions.
+        narrowing_applied: (v1.1) Narrowing constraints for NARROW decisions.
+        pause_token: (v1.1) Token for PAUSE decisions.
+
+    Returns:
+        SHA-256 hex digest of the record.
+    """
+    schema_id = _SCHEMA_1_0 if schema_version == "1.0" else _SCHEMA_1_1
+
+    if schema_version == "1.0":
+        # v1.0: Original hash computation (backward compatible)
+        header = json.dumps(
+            {
+                "schema": schema_id,
+                "sequence": sequence,
+                "event_type": event_type,
+                "control_id": control_id,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return _sha256(prev_hash + header + payload_json)
+    else:
+        # v1.1: Include new metadata fields in hash computation
+        # Only include non-None v1.1 fields to maintain determinism
+        header_dict: dict[str, Any] = {
+            "schema": schema_id,
+            "sequence": sequence,
+            "event_type": event_type,
+            "control_id": control_id,
+        }
+        # Add v1.1 fields only if they have values (sparse inclusion)
+        if classification_reason is not None:
+            header_dict["classification_reason"] = classification_reason
+        if narrowing_applied is not None:
+            header_dict["narrowing_applied"] = narrowing_applied
+        if pause_token is not None:
+            header_dict["pause_token"] = pause_token
+
+        header = json.dumps(header_dict, sort_keys=True, separators=(",", ":"))
+        return _sha256(prev_hash + header + payload_json)
+
+
+def _detect_schema_version(record: EvidenceRecord | dict[str, Any]) -> str:
+    """Detect the schema version of an evidence record.
+
+    Args:
+        record: EvidenceRecord dataclass or dict representation.
+
+    Returns:
+        Schema version string ("1.0" or "1.1").
+    """
+    if isinstance(record, EvidenceRecord):
+        return record.schema_version
+    # For dict records, check for explicit version field
+    version = record.get("schema_version")
+    if version:
+        return version
+    # Check for schema field in wire format
+    schema = record.get("schema", "")
+    if schema == "cage-evidence-stream/1.1":
+        return "1.1"
+    # Default to 1.0 for records without version marker
+    return "1.0"
+
+
+def verify_record(record: EvidenceRecord | dict[str, Any], prev_hash: str) -> VerifyResult:
+    """Verify evidence record hash with dual-schema support (v1.0 and v1.1).
+
+    This function supports verification of both legacy v1.0 records and new
+    v1.1 records, enabling seamless schema migration without breaking existing
+    evidence chains.
+
+    Verification Process:
+        1. Detect schema version from record
+        2. Extract fields according to detected version
+        3. Compute hash using version-appropriate algorithm
+        4. Compare computed hash against stored record_hash
+
+    Args:
+        record: EvidenceRecord dataclass or dict to verify.
+        prev_hash: Hash of the previous record in the chain.
+
+    Returns:
+        VerifyResult with verification status and diagnostic information.
+
+    Example:
+        >>> result = verify_record(record, prev_hash)
+        >>> if not result.valid:
+        ...     logger.error(f"Chain integrity violation: {result.error}")
+    """
+    try:
+        # Normalize to dict for consistent field access
+        if isinstance(record, EvidenceRecord):
+            record_dict = record.to_dict()
+        else:
+            record_dict = record
+
+        # Detect schema version
+        schema_version = _detect_schema_version(record_dict)
+
+        # Extract common fields
+        expected_hash = record_dict.get("record_hash", "")
+        if not expected_hash:
+            return VerifyResult(
+                valid=False,
+                schema_version=schema_version,
+                computed_hash="",
+                expected_hash="",
+                error="Record missing record_hash field",
+            )
+
+        # Extract fields for hash computation
+        # Handle both wire format (sequence as string) and internal format
+        sequence_raw = record_dict.get("sequence", 0)
+        sequence = int(sequence_raw) if isinstance(sequence_raw, str) else sequence_raw
+
+        event_type = record_dict.get("event_type", record_dict.get("decision", "UNKNOWN"))
+        control_id = record_dict.get("control_id", "")
+
+        # Extract payload - handle both wire format and internal format
+        payload = record_dict.get("payload")
+        if payload is None:
+            payload_json = record_dict.get("payload_json", "{}")
+        elif isinstance(payload, str):
+            payload_json = payload
+        else:
+            payload_json = json.dumps(payload, sort_keys=True, default=str)
+
+        # v1.1 specific fields
+        classification_reason = record_dict.get("classification_reason")
+        narrowing_applied = record_dict.get("narrowing_applied")
+        pause_token = record_dict.get("pause_token")
+
+        # Compute hash using version-aware algorithm
+        computed_hash = _link_hash_versioned(
+            prev_hash=prev_hash,
+            sequence=sequence,
+            event_type=event_type,
+            control_id=control_id,
+            payload_json=payload_json,
+            schema_version=schema_version,
+            classification_reason=classification_reason,
+            narrowing_applied=narrowing_applied,
+            pause_token=pause_token,
+        )
+
+        # Verify hash matches
+        if computed_hash == expected_hash:
+            return VerifyResult(
+                valid=True,
+                schema_version=schema_version,
+                computed_hash=computed_hash,
+                expected_hash=expected_hash,
+                error=None,
+            )
+        else:
+            return VerifyResult(
+                valid=False,
+                schema_version=schema_version,
+                computed_hash=computed_hash,
+                expected_hash=expected_hash,
+                error=f"Hash mismatch: computed={computed_hash[:16]}... expected={expected_hash[:16]}...",
+            )
+
+    except Exception as exc:
+        return VerifyResult(
+            valid=False,
+            schema_version="unknown",
+            computed_hash="",
+            expected_hash=str(record.get("record_hash", "") if isinstance(record, dict) else getattr(record, "record_hash", "")),
+            error=f"Verification error: {exc}",
+        )
+
+
+def migrate_record_1_0_to_1_1(record: dict[str, Any]) -> EvidenceRecord:
+    """Upgrade a v1.0 evidence record to v1.1 format with default values.
+
+    This migration helper preserves all existing v1.0 fields and adds
+    v1.1 metadata fields with appropriate defaults. The record_hash is
+    NOT recomputed - the original hash is preserved to maintain chain
+    integrity.
+
+    Migration Rules:
+        - schema_version: Set to "1.1"
+        - classification_reason: Set to None (no classification for legacy records)
+        - narrowing_applied: Set to None (no narrowing metadata for legacy records)
+        - pause_token: Set to None (no pause token for legacy records)
+
+    Note on prev_hash Seeding (per specs §4.1):
+        On cutover to v1.1, the first v1.1 record's prev_hash MUST be seeded
+        from the LAST v1.0 record's record_hash, NOT a genesis sentinel.
+        This ensures chain continuity across schema versions.
+
+    Args:
+        record: v1.0 record as dict.
+
+    Returns:
+        EvidenceRecord with v1.1 schema version.
+
+    Example:
+        >>> v1_0_record = {"evidence_id": "evt-123", "decision": "ALLOW", ...}
+        >>> v1_1_record = migrate_record_1_0_to_1_1(v1_0_record)
+        >>> v1_1_record.schema_version
+        '1.1'
+    """
+    # Parse timestamp if it's a string
+    timestamp = record.get("timestamp")
+    if isinstance(timestamp, str):
+        timestamp = datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+    elif timestamp is None:
+        timestamp = datetime.now(tz=timezone.utc)
+
+    # Handle wire format conversions
+    payload = record.get("payload")
+    if payload is None:
+        payload_json = record.get("payload_json", "{}")
+        try:
+            payload = json.loads(payload_json)
+        except (json.JSONDecodeError, TypeError):
+            payload = {}
+    elif isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except (json.JSONDecodeError, TypeError):
+            payload = {}
+
+    return EvidenceRecord(
+        evidence_id=record.get("evidence_id", ""),
+        decision=record.get("decision", record.get("event_type", "")),
+        timestamp=timestamp,
+        tool_name=record.get("tool_name", ""),
+        control_id=record.get("control_id", ""),
+        prev_hash=record.get("prev_hash", ""),
+        record_hash=record.get("record_hash", ""),
+        payload=payload,
+        # Upgrade to v1.1 with default values for new fields
+        schema_version="1.1",
+        classification_reason=None,
+        narrowing_applied=None,
+        pause_token=None,
+    )
+
+
+def get_last_v1_0_hash(records: list[dict[str, Any]]) -> str:
+    """Extract the hash of the last v1.0 record for cutover seeding.
+
+    Per specs §4.1: On cutover to v1.1, prev_hash must be seeded from
+    the LAST v1.0 record, NOT a genesis sentinel. This function finds
+    the last v1.0 record in a sequence and returns its record_hash.
+
+    Args:
+        records: List of evidence records (newest last).
+
+    Returns:
+        The record_hash of the last v1.0 record, or the genesis hash
+        if no v1.0 records exist.
+    """
+    genesis_hash = _sha256("EVIDENCE_STREAM_GENESIS")
+
+    # Scan from end to find last v1.0 record
+    for record in reversed(records):
+        version = _detect_schema_version(record)
+        if version == "1.0":
+            return record.get("record_hash", genesis_hash)
+
+    # No v1.0 records found - this is a fresh chain
+    return genesis_hash
 
 
 # ---------------------------------------------------------------------------
@@ -329,6 +878,214 @@ class EvidenceStreamSink:
                 exc,
             )
             return None
+
+    async def ingest_sync(
+        self,
+        event: dict[str, Any],
+        timeout_seconds: float = _EVIDENCE_COMMIT_TIMEOUT_S,
+    ) -> EvidenceCommitResult:
+        """Blocking ingest that returns only after evidence is committed.
+
+        This method provides a synchronous evidence commit guarantee required
+        by the EVIDENCE_CHAIN_BLOCKING gate. Unlike ``ingest()``, this method:
+          - Raises ``EvidenceChainUnavailableError`` if commit fails
+          - Has explicit timeout handling
+          - Returns structured ``EvidenceCommitResult`` with commit proof
+          - Records telemetry (OTel spans, Prometheus metrics)
+
+        Risk mitigation: R-06 (evidence-of-execution claims overclaimed)
+        When EVIDENCE_CHAIN_BLOCKING=true, seal issuance calls this method
+        instead of the fire-and-forget ``ingest()`` to ensure evidence is
+        durably committed before any seal is issued.
+
+        Args:
+            event: GovernanceEvent dict from the SSE event bus or governance
+                   decision payload.
+            timeout_seconds: Maximum time to wait for commit (default: 5.0s).
+                             On timeout, raises EvidenceChainUnavailableError.
+
+        Returns:
+            EvidenceCommitResult with commit proof (evidence_id, hash, timestamp).
+
+        Raises:
+            EvidenceChainUnavailableError: If Redis is unavailable, commit fails,
+                or timeout is exceeded. Caller MUST NOT issue a routing seal when
+                this exception is raised.
+        """
+        import time
+
+        start_time = time.perf_counter()
+
+        with tracer.start_as_current_span("cage.evidence.ingest_sync") as span:
+            span.set_attribute("cage.evidence.blocking_mode", True)
+            span.set_attribute("cage.evidence.timeout_seconds", timeout_seconds)
+
+            try:
+                # Check Redis availability
+                if self._redis is None:
+                    error_msg = (
+                        "Evidence chain unavailable: Redis connection not established. "
+                        "Cannot commit evidence — seal issuance blocked."
+                    )
+                    logger.error("[EvidenceStream] %s", error_msg)
+                    span.set_attribute("cage.evidence.status", "failure")
+                    span.set_attribute("cage.evidence.failure_reason", "redis_unavailable")
+                    if _PROM_AVAILABLE:
+                        EVIDENCE_COMMIT_TOTAL.labels(status="failure").inc()
+                    raise EvidenceChainUnavailableError(error_msg)
+
+                # Hash-chain the event with timeout protection
+                try:
+                    result = await asyncio.wait_for(
+                        self._ingest_with_result(event),
+                        timeout=timeout_seconds,
+                    )
+                except asyncio.TimeoutError as exc:
+                    elapsed = time.perf_counter() - start_time
+                    error_msg = (
+                        f"Evidence commit timeout after {elapsed:.2f}s "
+                        f"(limit: {timeout_seconds}s). Cannot guarantee durable "
+                        "commit — seal issuance blocked."
+                    )
+                    logger.error("[EvidenceStream] %s", error_msg)
+                    span.set_attribute("cage.evidence.status", "timeout")
+                    span.set_attribute("cage.evidence.elapsed_seconds", elapsed)
+                    if _PROM_AVAILABLE:
+                        EVIDENCE_COMMIT_TOTAL.labels(status="timeout").inc()
+                    raise EvidenceChainUnavailableError(error_msg, exc) from exc
+
+                # Verify commit succeeded
+                if not result.success:
+                    error_msg = (
+                        f"Evidence commit failed: evidence_id={result.evidence_id}. "
+                        "Cannot guarantee durable commit — seal issuance blocked."
+                    )
+                    logger.error("[EvidenceStream] %s", error_msg)
+                    span.set_attribute("cage.evidence.status", "failure")
+                    span.set_attribute("cage.evidence.failure_reason", "commit_failed")
+                    if _PROM_AVAILABLE:
+                        EVIDENCE_COMMIT_TOTAL.labels(status="failure").inc()
+                    raise EvidenceChainUnavailableError(error_msg)
+
+                # Success path
+                elapsed = time.perf_counter() - start_time
+                span.set_attribute("cage.evidence.status", "success")
+                span.set_attribute("cage.evidence.evidence_id", result.evidence_id)
+                span.set_attribute("cage.evidence.hash", result.hash[:16])
+                span.set_attribute("cage.evidence.sequence", result.sequence)
+                span.set_attribute("cage.evidence.elapsed_seconds", elapsed)
+
+                if _PROM_AVAILABLE:
+                    EVIDENCE_COMMIT_TOTAL.labels(status="success").inc()
+                    EVIDENCE_COMMIT_DURATION.observe(elapsed)
+
+                logger.info(
+                    "[EvidenceStream] Blocking commit succeeded: "
+                    "evidence_id=%s hash=%s… seq=%d (%.3fs)",
+                    result.evidence_id,
+                    result.hash[:16],
+                    result.sequence,
+                    elapsed,
+                )
+                return result
+
+            except EvidenceChainUnavailableError:
+                raise
+            except Exception as exc:
+                elapsed = time.perf_counter() - start_time
+                error_msg = (
+                    f"Evidence commit failed with unexpected error: {exc}. "
+                    "Cannot guarantee durable commit — seal issuance blocked."
+                )
+                logger.error("[EvidenceStream] %s", error_msg, exc_info=True)
+                span.set_attribute("cage.evidence.status", "failure")
+                span.set_attribute("cage.evidence.failure_reason", "unexpected_error")
+                span.set_attribute("cage.evidence.elapsed_seconds", elapsed)
+                span.record_exception(exc)
+                if _PROM_AVAILABLE:
+                    EVIDENCE_COMMIT_TOTAL.labels(status="failure").inc()
+                raise EvidenceChainUnavailableError(error_msg, exc) from exc
+
+    async def _ingest_with_result(self, event: dict[str, Any]) -> EvidenceCommitResult:
+        """Internal helper that performs ingest and returns structured result.
+
+        This method is used by ``ingest_sync()`` to get detailed commit information
+        including the hash and sequence number for the commit proof.
+        """
+        # Hash-chain the event — lock guards all reads/writes of _prev_hash and _sequence
+        payload_json = json.dumps(event, sort_keys=True, default=str)
+
+        event_type = event.get("type", "UNKNOWN")
+        control_id = event.get("controlId", "")
+
+        async with self._chain_lock:
+            current_sequence = self._sequence
+            record_hash = _link_hash(
+                prev_hash=self._prev_hash,
+                sequence=current_sequence,
+                event_type=event_type,
+                control_id=control_id,
+                payload_json=payload_json,
+            )
+
+            commit_timestamp = datetime.now(tz=timezone.utc)
+            entry = {
+                "schema": _SCHEMA,
+                "sequence": str(current_sequence),
+                "event_type": event_type,
+                "control_id": control_id,
+                "prev_hash": self._prev_hash,
+                "record_hash": record_hash,
+                "payload_json": payload_json,
+                "timestamp_utc": commit_timestamp.isoformat(),
+                "kms_signature": "",
+                "kms_signature_algorithm": _get_signing_algorithm(),
+            }
+
+            # Persist to Redis Stream BEFORE advancing chain state
+            # This ensures we don't advance the chain if Redis write fails
+            try:
+                msg_id = await self._redis.xadd(  # type: ignore[union-attr]
+                    self._stream_key,
+                    entry,
+                    maxlen=self._max_len,
+                )
+            except Exception as exc:
+                # Don't advance chain state — commit failed
+                logger.error(
+                    "[EvidenceStream] Redis write failed in _ingest_with_result: %s",
+                    exc,
+                )
+                return EvidenceCommitResult(
+                    success=False,
+                    evidence_id="",
+                    commit_timestamp=commit_timestamp,
+                    hash=record_hash,
+                    sequence=current_sequence,
+                )
+
+            # Advance chain state only after successful Redis write
+            self._prev_hash = record_hash
+            self._sequence += 1
+
+        # Optional KMS signing (async, non-blocking) — best effort
+        if self._kms_sign:
+            self._enqueue_signing(entry)
+
+        logger.debug(
+            "[EvidenceStream] _ingest_with_result: seq=%s hash=%s… msg_id=%s",
+            entry["sequence"],
+            record_hash[:16],
+            msg_id,
+        )
+
+        return EvidenceCommitResult(
+            success=True,
+            evidence_id=str(msg_id),
+            commit_timestamp=commit_timestamp,
+            hash=record_hash,
+            sequence=current_sequence,
+        )
 
     def _enqueue_signing(self, entry: dict) -> None:
         """Enqueue an evidence stream entry for async KMS signing."""

--- a/src/gateway/governance/cbf.py
+++ b/src/gateway/governance/cbf.py
@@ -88,6 +88,79 @@ _cage_env_cbf = (
 ).lower()
 _IS_PRODUCTION: bool = _cage_env_cbf not in ("development", "test", "dev", "ci")
 
+# ---------------------------------------------------------------------------
+# Feature flag: Replay defense (R-04 mitigation, §2.10)
+# ---------------------------------------------------------------------------
+# Stage 1 (read-side): When enabled, CBF enforces sequence validation.
+_REPLAY_DEFENSE_ENABLED: bool = os.environ.get(
+    "CAGE_RECONCILIATION_REPLAY_DEFENSE", "false"
+).lower() in ("true", "1", "yes")
+
+# Redis key for tracking last accepted sequence (never TTL'd)
+_REDIS_KEY_SEQUENCE_LAST_ACCEPTED = "reconciliation:sequence:last_accepted"
+
+# ---------------------------------------------------------------------------
+# Feature flag: Fence epoch validation (R-05 mitigation, §2.6)
+# ---------------------------------------------------------------------------
+# When enabled, CBF validates fence epoch hasn't regressed after failover.
+# This detects stale reads from replicas that haven't caught up to primary.
+_FENCE_EPOCH_ENABLED: bool = os.environ.get(
+    "CAGE_REDIS_SYNCHRONOUS_REPLICATION", "false"
+).lower() in ("true", "1", "yes")
+
+# Redis key for fence epoch counter (never TTL'd)
+_REDIS_KEY_FENCE_EPOCH = "safety:fence_epoch"
+
+# ---------------------------------------------------------------------------
+# Feature flag: WAIT command replication (Phase 4.3)
+# ---------------------------------------------------------------------------
+# When CAGE_REDIS_WAIT_REPLICAS > 0, CBF will call Redis WAIT after fence
+# epoch increment to ensure the epoch is replicated before returning.
+# https://redis.io/commands/wait/
+_WAIT_REPLICAS: int = int(os.environ.get("CAGE_REDIS_WAIT_REPLICAS", "0"))
+_WAIT_TIMEOUT_MS: int = int(os.environ.get("CAGE_REDIS_WAIT_TIMEOUT_MS", "1000"))
+
+# Sentinel awareness (Phase 4.3 stretch goal)
+# When set, connection should be Sentinel-aware for automatic failover handling.
+_REDIS_SENTINEL_MASTER_NAME: str | None = os.environ.get("REDIS_SENTINEL_MASTER_NAME")
+
+# ---------------------------------------------------------------------------
+# Prometheus telemetry for replay defense (§2.10) and WAIT replication (§4.3)
+# ---------------------------------------------------------------------------
+try:
+    from prometheus_client import Counter, Gauge, Histogram
+
+    _REPLAY_REJECTED_COUNTER = Counter(
+        "cage_reconciliation_replay_rejected_total",
+        "Number of reconciliation payloads rejected due to non-advancing sequence (R-04 replay defense)",
+        ["source"],
+    )
+    # R-05 fence epoch telemetry
+    _EPOCH_REGRESSION_COUNTER = Counter(
+        "cage_cbf_epoch_regression_detected_total",
+        "Number of CBF reads rejected due to fence epoch regression (R-05 double-spend defense)",
+    )
+    _CURRENT_FENCE_EPOCH_GAUGE = Gauge(
+        "cage_cbf_current_fence_epoch",
+        "Current value of the CBF fence epoch counter",
+    )
+    # Phase 4.3: WAIT command telemetry
+    _WAIT_LATENCY_HISTOGRAM = Histogram(
+        "cage_cbf_wait_latency_seconds",
+        "Latency of Redis WAIT command for replication synchronization (Phase 4.3)",
+        buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5),
+    )
+    _WAIT_TIMEOUT_COUNTER = Counter(
+        "cage_cbf_wait_timeout_total",
+        "Number of Redis WAIT commands that timed out before reaching replica count (Phase 4.3)",
+    )
+except ImportError:
+    _REPLAY_REJECTED_COUNTER = None  # type: ignore[assignment]
+    _EPOCH_REGRESSION_COUNTER = None  # type: ignore[assignment]
+    _CURRENT_FENCE_EPOCH_GAUGE = None  # type: ignore[assignment]
+    _WAIT_LATENCY_HISTOGRAM = None  # type: ignore[assignment]
+    _WAIT_TIMEOUT_COUNTER = None  # type: ignore[assignment]
+
 
 # ---------------------------------------------------------------------------
 # ControlBarrierFunction
@@ -112,11 +185,12 @@ class ControlBarrierFunction:
     LUA_ATOMIC_CBF: str = """
 -- KEYS[1]: safety:current_cash
 -- KEYS[2]: audit:state_ledger
+-- KEYS[3]: safety:fence_epoch (R-05)
 -- ARGV[1]: cost (float string)
 -- ARGV[2]: min_cash_balance (float string)
 -- ARGV[3]: gamma (float string)
 -- ARGV[4]: governance_signature (string, may be empty)
--- Returns: array {status_code, message, new_balance_str}
+-- Returns: array {status_code, message, new_balance_str, new_epoch}
 --   status_code 1 = COMMITTED, 0 = UNSAFE (envelope violation)
 local raw = redis.call('GET', KEYS[1])
 local current = raw and tonumber(raw) or 100000.0
@@ -130,15 +204,21 @@ local h_t = current - min_cash
 local h_next = next_cash - min_cash
 local required_h_next = (1.0 - gamma) * h_t
 
+-- Read current epoch for return (even on UNSAFE)
+local current_epoch_raw = redis.call('GET', KEYS[3])
+local current_epoch = current_epoch_raw and tonumber(current_epoch_raw) or 0
+
 if h_next < required_h_next or h_next < 0 then
-    return {0, "UNSAFE: h_next=" .. tostring(h_next) .. " < required=" .. tostring(required_h_next), tostring(current)}
+    return {0, "UNSAFE: h_next=" .. tostring(h_next) .. " < required=" .. tostring(required_h_next), tostring(current), current_epoch}
 end
 
 redis.call('SET', KEYS[1], tostring(next_cash))
+-- R-05: Increment fence epoch on every mutating write
+local new_epoch = redis.call('INCR', KEYS[3])
 if sig ~= "" then
     redis.call('RPUSH', KEYS[2], sig .. ":" .. tostring(next_cash))
 end
-return {1, "COMMITTED", tostring(next_cash)}
+return {1, "COMMITTED", tostring(next_cash), new_epoch}
 """
 
     def __init__(self):  # type: ignore[no-untyped-def]
@@ -150,6 +230,8 @@ return {1, "COMMITTED", tostring(next_cash)}
         self._lua_sha: str | None = None
         # Reviewer note H53: local intra-window debits subtracted from snapshot to prevent double-spend within TTL window.
         self._local_debits: float = 0.0
+        # R-05 fence epoch: track last seen epoch to detect regression after failover
+        self._last_seen_epoch: int = 0
 
     async def setup(self) -> None:
         """Bootstrap Redis state if the key is absent (first run)."""
@@ -158,11 +240,266 @@ return {1, "COMMITTED", tostring(next_cash)}
             return
         if await redis_client.get(self.redis_key) is None:
             await redis_client.set(self.redis_key, "100000.0")
+        # Initialize fence epoch if absent (R-05)
+        client = redis_client.get_raw_client()
+        epoch_raw = await client.get(_REDIS_KEY_FENCE_EPOCH)
+        if epoch_raw is None:
+            await client.set(_REDIS_KEY_FENCE_EPOCH, "0")
+            logger.info("R-05: Initialized fence epoch to 0")
 
     async def _get_current_cash(self) -> float:
         if redis_client is None:
             raise RuntimeError("Redis client unavailable.")
         return await redis_client.get_float(self.redis_key, 100000.0)
+
+    # ------------------------------------------------------------------
+    # R-05 Fence Epoch: Double-spend detection across Redis failover
+    # ------------------------------------------------------------------
+
+    async def _increment_fence_epoch(self, pipeline: Any) -> int:
+        """Increment the fence epoch atomically within the pipeline.
+
+        §2.6 R-05 mitigation: The fence epoch is a monotonically increasing
+        counter that increments on every CBF-mutating write. After a Redis
+        failover, if a replica hasn't replicated the latest epoch, reads
+        from that replica will return a regressed epoch, which we detect
+        and reject (fail-closed).
+
+        Args:
+            pipeline: Redis pipeline object to queue the INCR command.
+
+        Returns:
+            The new epoch value after increment.
+
+        Note:
+            The INCR command is atomic and creates the key with value 1 if
+            it doesn't exist. The epoch is never TTL'd.
+        """
+        # Queue INCR in the pipeline — returns new value after increment
+        pipeline.incr(_REDIS_KEY_FENCE_EPOCH)
+        # The actual value is returned when pipeline.execute() is called
+        # Caller must extract from execute() results
+        return 0  # Placeholder; actual value comes from pipeline results
+
+    async def _get_fence_epoch(self) -> int:
+        """Read the current fence epoch from Redis.
+
+        Returns:
+            The current epoch value, or 0 if the key doesn't exist.
+        """
+        if redis_client is None:
+            raise RuntimeError("Redis client unavailable.")
+        client = redis_client.get_raw_client()
+        raw = await client.get(_REDIS_KEY_FENCE_EPOCH)
+        if raw is None:
+            return 0
+        return int(raw)
+
+    async def _check_fence_epoch(self, current_epoch: int) -> tuple[bool, str]:
+        """Validate that current fence epoch hasn't regressed.
+
+        §2.6 R-05 mitigation: After a Redis primary-to-replica failover,
+        the replica may not have replicated the latest fence epoch. If the
+        epoch we read is less than the last epoch we saw, we've likely
+        switched to a stale replica. This is a double-spend vulnerability.
+
+        Args:
+            current_epoch: The epoch value just read from Redis.
+
+        Returns:
+            (True, "OK") if epoch is valid (>= last seen).
+            (False, reason) if epoch has regressed (< last seen).
+
+        Side effects:
+            - On regression: logs CRITICAL, increments Prometheus counter
+            - On valid: updates _last_seen_epoch, updates Prometheus gauge
+        """
+        if current_epoch < self._last_seen_epoch:
+            reason = (
+                f"epoch={current_epoch} < last_seen={self._last_seen_epoch} "
+                "(possible failover to stale replica)"
+            )
+            logger.critical(
+                json.dumps(
+                    {
+                        "event": "CBF_EPOCH_REGRESSION_DETECTED",
+                        "severity": "CRITICAL",
+                        "current_epoch": current_epoch,
+                        "last_seen_epoch": self._last_seen_epoch,
+                        "audit_note": (
+                            "R-05: Fence epoch regression detected. This indicates "
+                            "a possible failover to a Redis replica that hasn't "
+                            "replicated the latest writes. Rejecting read to prevent "
+                            "double-spend vulnerability. Fail-closed."
+                        ),
+                    }
+                )
+            )
+            if _EPOCH_REGRESSION_COUNTER is not None:
+                _EPOCH_REGRESSION_COUNTER.inc()
+            return (False, reason)
+
+        # Epoch is valid — update tracking state
+        self._last_seen_epoch = current_epoch
+        if _CURRENT_FENCE_EPOCH_GAUGE is not None:
+            _CURRENT_FENCE_EPOCH_GAUGE.set(current_epoch)
+
+        return (True, "OK")
+
+    # ------------------------------------------------------------------
+    # Phase 4.3: WAIT command for synchronous replication
+    # ------------------------------------------------------------------
+
+    async def _sync_to_replicas(
+        self,
+        num_replicas: int | None = None,
+        timeout_ms: int | None = None,
+    ) -> bool:
+        """Block until fence epoch is replicated to at least num_replicas.
+
+        Phase 4.3: Uses Redis WAIT command to ensure the fence epoch increment
+        (and any preceding writes) is replicated to the specified number of
+        replicas before returning. This provides stronger durability guarantees
+        for deployments using Redis replication.
+
+        See: https://redis.io/commands/wait/
+
+        Args:
+            num_replicas: Number of replicas to wait for. Defaults to
+                          CAGE_REDIS_WAIT_REPLICAS env var (default 0 = disabled).
+            timeout_ms: Timeout in milliseconds to wait for replication.
+                        Defaults to CAGE_REDIS_WAIT_TIMEOUT_MS env var (default 1000).
+
+        Returns:
+            True if replication confirmed to num_replicas within timeout.
+            False if timeout elapsed before replication confirmed.
+            True (no-op) if num_replicas == 0 (WAIT disabled).
+
+        Note:
+            - WAIT returns the number of replicas that acknowledged the write.
+            - A return value < num_replicas means some replicas are lagging.
+            - Timeout is not an error condition for WAIT; it simply means we
+              waited the full duration without reaching the replica count.
+        """
+        # Use provided values or fall back to module-level config
+        replicas = num_replicas if num_replicas is not None else _WAIT_REPLICAS
+        timeout = timeout_ms if timeout_ms is not None else _WAIT_TIMEOUT_MS
+
+        # No-op if WAIT is disabled (replicas=0 is the default)
+        if replicas <= 0:
+            return True
+
+        if redis_client is None:
+            logger.warning("Redis client unavailable — cannot execute WAIT command.")
+            return False
+
+        client = redis_client.get_raw_client()
+        start_time = time.time()
+
+        try:
+            # WAIT numreplicas timeout
+            # Returns: number of replicas that acknowledged the write
+            acks: int = await client.execute_command("WAIT", replicas, timeout)
+
+            elapsed = time.time() - start_time
+
+            # Record latency in Prometheus histogram
+            if _WAIT_LATENCY_HISTOGRAM is not None:
+                _WAIT_LATENCY_HISTOGRAM.observe(elapsed)
+
+            if acks >= replicas:
+                logger.debug(
+                    "Phase 4.3: WAIT confirmed replication to %d/%d replicas in %.3fs",
+                    acks,
+                    replicas,
+                    elapsed,
+                )
+                return True
+            else:
+                # Timeout elapsed before reaching replica count
+                logger.warning(
+                    json.dumps(
+                        {
+                            "event": "CBF_WAIT_TIMEOUT",
+                            "severity": "WARNING",
+                            "requested_replicas": replicas,
+                            "acknowledged_replicas": acks,
+                            "timeout_ms": timeout,
+                            "elapsed_seconds": round(elapsed, 3),
+                            "audit_note": (
+                                "Phase 4.3: Redis WAIT timed out before reaching "
+                                f"requested replica count. {acks}/{replicas} replicas "
+                                "acknowledged. Proceeding with degraded replication."
+                            ),
+                        }
+                    )
+                )
+                if _WAIT_TIMEOUT_COUNTER is not None:
+                    _WAIT_TIMEOUT_COUNTER.inc()
+                return False
+
+        except Exception as exc:
+            elapsed = time.time() - start_time
+            logger.error(
+                "Phase 4.3: WAIT command failed after %.3fs: %s",
+                elapsed,
+                exc,
+            )
+            # Record the latency even on error
+            if _WAIT_LATENCY_HISTOGRAM is not None:
+                _WAIT_LATENCY_HISTOGRAM.observe(elapsed)
+            return False
+
+    async def _validate_sequence(
+        self, incoming_sequence: int, source: str, sync_redis: object
+    ) -> tuple[bool, str]:
+        """Validate incoming sequence is strictly greater than last accepted.
+
+        §2.10 R-04 Replay defense: monotonic sequence number validation.
+        Prevents replay of stale balance data by rejecting payloads with
+        non-advancing sequence numbers.
+
+        Args:
+            incoming_sequence: The sequence number in the incoming payload.
+            source: Provider source name (for logging).
+            sync_redis: Synchronous Redis client for reading/writing sequence.
+
+        Returns:
+            (True, "OK") if sequence is advancing.
+            (False, reason) if sequence is non-advancing (replay detected).
+        """
+        try:
+            # Read last accepted sequence
+            last_accepted_raw = await asyncio.to_thread(
+                sync_redis.get, _REDIS_KEY_SEQUENCE_LAST_ACCEPTED  # type: ignore[attr-defined]
+            )
+            last_accepted = int(last_accepted_raw) if last_accepted_raw else 0
+
+            if incoming_sequence <= last_accepted:
+                reason = (
+                    f"sequence={incoming_sequence} <= last_accepted={last_accepted}"
+                )
+                return (False, reason)
+
+            # Update last_accepted atomically
+            await asyncio.to_thread(
+                sync_redis.set, _REDIS_KEY_SEQUENCE_LAST_ACCEPTED, str(incoming_sequence)  # type: ignore[attr-defined]
+            )
+            logger.debug(
+                "[R-04] Sequence validated: incoming=%d > last_accepted=%d, updated",
+                incoming_sequence,
+                last_accepted,
+            )
+            return (True, "OK")
+
+        except Exception as exc:
+            # On error, fail-open to allow balance through (conservative)
+            # but log a warning so the issue is visible
+            logger.warning(
+                "[R-04] Sequence validation error: %s — allowing payload (fail-open)",
+                exc,
+            )
+            return (True, f"validation error (fail-open): {exc}")
 
     async def _read_cbf_state_atomic(self) -> dict[str, float | str]:
         """Read the CBF cash balance, preferring externally reconciled ground truth.
@@ -216,20 +553,67 @@ return {1, "COMMITTED", tostring(next_cash)}
                             "source": verified.source,
                             "balance_usd": verified.balance_usd,
                             "verified_at": verified.verified_at,
+                            "sequence": verified.sequence,  # §2.10: in signed payload
                         }
                         sig_valid = signer.verify(payload_dict, verified.signature)
                         if sig_valid:
-                            logger.info(
-                                "CBF: using externally reconciled balance=%.2f "
-                                "source=%s verified_at=%.0f (KMS signature valid)",
-                                verified.balance_usd,
-                                verified.source,
-                                verified.verified_at,
-                            )
-                            return {
-                                "current_cash": verified.balance_usd,
-                                "source": "reconciled",
-                            }
+                            # ── §2.10 R-04 Replay defense: sequence validation ────
+                            if _REPLAY_DEFENSE_ENABLED and verified.sequence > 0:
+                                sequence_valid, seq_reason = await self._validate_sequence(
+                                    verified.sequence, verified.source, sync_redis_client
+                                )
+                                if not sequence_valid:
+                                    # Replay detected — fall through to self-reported
+                                    logger.critical(
+                                        json.dumps(
+                                            {
+                                                "event": "CBF_RECONCILED_BALANCE_SEQUENCE_REPLAY_DETECTED",
+                                                "severity": "CRITICAL",
+                                                "source": verified.source,
+                                                "balance_usd": verified.balance_usd,
+                                                "sequence": verified.sequence,
+                                                "reason": seq_reason,
+                                                "audit_note": (
+                                                    "R-04 Replay defense: monotonic sequence "
+                                                    "validation FAILED. Payload sequence is "
+                                                    "non-advancing. Falling back to self-reported "
+                                                    "balance. Possible TTL reset attack or stale replay."
+                                                ),
+                                            }
+                                        )
+                                    )
+                                    # Increment Prometheus counter for replay rejection
+                                    if _REPLAY_REJECTED_COUNTER is not None:
+                                        _REPLAY_REJECTED_COUNTER.labels(source=verified.source).inc()
+                                    # Fall through to self-reported balance below
+                                else:
+                                    # Sequence valid — update last_accepted and proceed
+                                    logger.info(
+                                        "CBF: using externally reconciled balance=%.2f "
+                                        "source=%s verified_at=%.0f sequence=%d (KMS signature valid, sequence advancing)",
+                                        verified.balance_usd,
+                                        verified.source,
+                                        verified.verified_at,
+                                        verified.sequence,
+                                    )
+                                    return {
+                                        "current_cash": verified.balance_usd,
+                                        "source": "reconciled",
+                                        "sequence": verified.sequence,
+                                    }
+                            else:
+                                # Replay defense disabled or sequence=0 (backward compat)
+                                logger.info(
+                                    "CBF: using externally reconciled balance=%.2f "
+                                    "source=%s verified_at=%.0f (KMS signature valid)",
+                                    verified.balance_usd,
+                                    verified.source,
+                                    verified.verified_at,
+                                )
+                                return {
+                                    "current_cash": verified.balance_usd,
+                                    "source": "reconciled",
+                                }
                         else:
                             logger.critical(
                                 json.dumps(
@@ -317,10 +701,39 @@ return {1, "COMMITTED", tostring(next_cash)}
         client = redis_client.get_raw_client()
         async with client.pipeline(transaction=False) as pipe:
             pipe.get(self.redis_key)
+            pipe.get(_REDIS_KEY_FENCE_EPOCH)  # R-05: read epoch atomically
             results = await pipe.execute()
         raw_cash = results[0]
+        raw_epoch = results[1]
         current_cash = float(raw_cash) if raw_cash is not None else 100000.0
-        return {"current_cash": current_cash, "source": "self_reported"}
+        current_epoch = int(raw_epoch) if raw_epoch is not None else 0
+
+        # ── §2.6 R-05 Fence epoch validation ──────────────────────────────────
+        # When CAGE_REDIS_SYNCHRONOUS_REPLICATION is enabled, validate that
+        # the fence epoch hasn't regressed (indicating failover to stale replica).
+        if _FENCE_EPOCH_ENABLED:
+            epoch_valid, epoch_reason = await self._check_fence_epoch(current_epoch)
+            if not epoch_valid:
+                # Epoch regression detected — fail-closed, return None balance
+                # to force caller to reject the action.
+                return {
+                    "current_cash": None,  # type: ignore[dict-item]
+                    "source": "epoch_regression",
+                    "fence_epoch": current_epoch,
+                    "epoch_reason": epoch_reason,
+                }
+        else:
+            # Epoch tracking without validation (default mode)
+            # Still update the gauge for observability
+            self._last_seen_epoch = current_epoch
+            if _CURRENT_FENCE_EPOCH_GAUGE is not None:
+                _CURRENT_FENCE_EPOCH_GAUGE.set(current_epoch)
+
+        return {
+            "current_cash": current_cash,
+            "source": "self_reported",
+            "fence_epoch": current_epoch,
+        }
 
     def get_h(self, cash_balance: float) -> float:
         """Safety function h(x).  Safe when h(x) >= 0."""
@@ -363,11 +776,31 @@ return {1, "COMMITTED", tostring(next_cash)}
         against an inconsistent state snapshot (H-07).
         """
         state = await self._read_cbf_state_atomic()
-        current_cash = float(state["current_cash"])
         balance_source: str = str(state.get("source", "unknown"))
+
+        # R-05: Handle epoch regression (fail-closed)
+        if state.get("current_cash") is None or balance_source == "epoch_regression":
+            epoch_reason = state.get("epoch_reason", "unknown")
+            fence_epoch = state.get("fence_epoch", 0)
+            _mrm_meta = ControlRegistry().get_mapping(
+                GovernanceControl.TRADITIONAL_MRM_VALIDATION
+            )
+            result = (
+                f"[{GovernanceControl.TRADITIONAL_MRM_VALIDATION.value}] "
+                f"{_mrm_meta['primary_framework']} Violation: "
+                f"R-05 Fence epoch regression detected (epoch={fence_epoch}). "
+                f"Reason: {epoch_reason}. Fail-closed."
+            )
+            logger.warning("⛔ CBF check rejected: epoch regression — %s", epoch_reason)
+            return result
+
+        current_cash = float(state["current_cash"])
+        fence_epoch = int(state.get("fence_epoch", 0))
 
         if self.tracer:
             with self.tracer.start_as_current_span("safety.cbf_check") as span:  # type: ignore[attr-defined]
+                # R-05: Add fence epoch to span attributes
+                span.set_attribute("cage.cbf.fence_epoch", fence_epoch)
                 return await self._do_verify_action(
                     action_name, payload, current_cash, balance_source, span
                 )
@@ -468,20 +901,25 @@ return {1, "COMMITTED", tostring(next_cash)}
         return result
 
     # ------------------------------------------------------------------
-    # update_state — WATCH/MULTI/EXEC atomic transaction (Phase 4.1)
+    # _update_state_unsafe — WATCH/MULTI/EXEC atomic transaction (internal)
     # ------------------------------------------------------------------
 
-    async def update_state(
+    async def _update_state_unsafe(
         self, cost: float, governance_signature: str | None = None
     ) -> None:
         """Atomically deduct *cost* from the Redis cash balance.
 
-        .. deprecated::
-            MED-5: ``update_state()`` does not re-verify the CBF safety
-            condition before committing.  Use ``atomic_verify_and_commit()``
-            instead, which collapses the check and commit into a single atomic
-            Redis Lua hop, eliminating the TOCTOU window between
-            ``verify_action()`` (read-only) and this method (write).
+        .. warning::
+            **v3.0.0 Breaking Change:** Renamed from ``update_state()`` to
+            ``_update_state_unsafe()`` to signal that this method does NOT
+            re-verify the CBF safety condition before committing.
+
+            External callers MUST use ``atomic_verify_and_commit()`` instead,
+            which collapses the check and commit into a single atomic Redis
+            Lua hop, eliminating the TOCTOU window (MED-5 finding).
+
+            This method is retained for internal use by ``rollback_state()``
+            where re-verification is not applicable.
 
         Uses WATCH / MULTI / EXEC optimistic locking.  Retries up to
         ``_MAX_RETRIES`` times if a concurrent writer modified the key.
@@ -494,15 +932,6 @@ return {1, "COMMITTED", tostring(next_cash)}
         Raises:
             RuntimeError: If all retries are exhausted or Redis is unavailable.
         """
-        import warnings
-
-        warnings.warn(
-            "update_state() does not atomically re-verify the CBF safety condition. "
-            "Use atomic_verify_and_commit() to eliminate the TOCTOU window between "
-            "verify_action() and the state commit (MED-5).",
-            DeprecationWarning,
-            stacklevel=2,
-        )
         if redis_client is None:
             raise RuntimeError("Redis client unavailable — cannot update CBF state.")
 
@@ -515,6 +944,8 @@ return {1, "COMMITTED", tostring(next_cash)}
                     new_balance = current - cost
                     pipe.multi()
                     pipe.set(self.redis_key, str(new_balance))
+                    # R-05: Increment fence epoch on every mutating write
+                    pipe.incr(_REDIS_KEY_FENCE_EPOCH)
                     if governance_signature:
                         ledger_entry = json.dumps(
                             {
@@ -525,12 +956,26 @@ return {1, "COMMITTED", tostring(next_cash)}
                             }
                         )
                         pipe.rpush("audit:state_ledger", ledger_entry)
-                    await pipe.execute()
+                    results = await pipe.execute()
+                    # R-05: Extract new epoch from pipeline results (index depends on signature)
+                    new_epoch = results[1] if results and len(results) > 1 else 0
+                    self._last_seen_epoch = new_epoch
+                    if _CURRENT_FENCE_EPOCH_GAUGE is not None:
+                        _CURRENT_FENCE_EPOCH_GAUGE.set(new_epoch)
+
+                    # Phase 4.3: WAIT for replication if configured
+                    wait_result = await self._sync_to_replicas()
+                    wait_suffix = " (WAIT OK)" if _WAIT_REPLICAS > 0 and wait_result else ""
+                    if _WAIT_REPLICAS > 0 and not wait_result:
+                        wait_suffix = " (WAIT timeout)"
+
                     logger.info(
-                        "✅ CBF state updated atomically: %.2f → %.2f (attempt %d)",
+                        "✅ CBF state updated atomically: %.2f → %.2f (epoch=%d, attempt %d)%s",
                         current,
                         new_balance,
+                        new_epoch,
                         attempt + 1,
+                        wait_suffix,
                     )
                     return
             except Exception as exc:
@@ -545,7 +990,7 @@ return {1, "COMMITTED", tostring(next_cash)}
                 raise
 
         raise RuntimeError(
-            f"CBF update_state failed after {self._MAX_RETRIES} retries due to concurrent writes."
+            f"CBF _update_state_unsafe failed after {self._MAX_RETRIES} retries due to concurrent writes."
         )
 
     # ------------------------------------------------------------------
@@ -570,7 +1015,7 @@ return {1, "COMMITTED", tostring(next_cash)}
     ) -> None:
         """Atomically restore *cost* to the Redis cash balance.
 
-        Mirrors ``update_state`` but adds rather than deducts.  Call this
+        Mirrors ``_update_state_unsafe`` but adds rather than deducts.  Call this
         when a trade was approved by the CBF but failed downstream (e.g.
         broker API error).
 
@@ -594,6 +1039,8 @@ return {1, "COMMITTED", tostring(next_cash)}
                     restored = current + cost
                     pipe.multi()
                     pipe.set(self.redis_key, str(restored))
+                    # R-05: Increment fence epoch on every mutating write (including rollback)
+                    pipe.incr(_REDIS_KEY_FENCE_EPOCH)
                     if governance_signature:
                         ledger_entry = json.dumps(
                             {
@@ -605,12 +1052,26 @@ return {1, "COMMITTED", tostring(next_cash)}
                             }
                         )
                         pipe.rpush("audit:state_ledger", ledger_entry)
-                    await pipe.execute()
+                    results = await pipe.execute()
+                    # R-05: Extract new epoch from pipeline results
+                    new_epoch = results[1] if results and len(results) > 1 else 0
+                    self._last_seen_epoch = new_epoch
+                    if _CURRENT_FENCE_EPOCH_GAUGE is not None:
+                        _CURRENT_FENCE_EPOCH_GAUGE.set(new_epoch)
+
+                    # Phase 4.3: WAIT for replication if configured
+                    wait_result = await self._sync_to_replicas()
+                    wait_suffix = " (WAIT OK)" if _WAIT_REPLICAS > 0 and wait_result else ""
+                    if _WAIT_REPLICAS > 0 and not wait_result:
+                        wait_suffix = " (WAIT timeout)"
+
                     logger.info(
-                        "🔄 CBF state rolled back atomically: %.2f → %.2f (attempt %d)",
+                        "🔄 CBF state rolled back atomically: %.2f → %.2f (epoch=%d, attempt %d)%s",
                         current,
                         restored,
+                        new_epoch,
                         attempt + 1,
+                        wait_suffix,
                     )
                     return
             except Exception as exc:
@@ -674,7 +1135,8 @@ return {1, "COMMITTED", tostring(next_cash)}
             logger.warning("⛔ CBF atomic check rejected trade: %s", exc)
             return (False, reason)
 
-        keys = ["safety:current_cash", "audit:state_ledger"]
+        # R-05: Include fence epoch key for atomic increment in Lua script
+        keys = ["safety:current_cash", "audit:state_ledger", _REDIS_KEY_FENCE_EPOCH]
         argv = [
             str(cost),
             str(self.min_cash_balance),
@@ -708,15 +1170,39 @@ return {1, "COMMITTED", tostring(next_cash)}
                     "governance.legacy_citation", _mrm_meta["legacy_citation"]
                 )
                 span.set_attribute("governance.scope", _mrm_meta["scope"])
+                # Phase 4.3: Add WAIT replicas to span attributes
+                span.set_attribute("cage.cbf.wait_replicas", _WAIT_REPLICAS)
                 result_list = await self._evalsha_with_noscript_retry(
                     client, keys, argv, _run_evalsha, _load_and_run
                 )
-                return self._parse_lua_result(result_list, span)
+                committed, message = self._parse_lua_result(result_list, span)
+
+                # Phase 4.3: WAIT for replication if configured and committed
+                if committed and _WAIT_REPLICAS > 0:
+                    wait_result = await self._sync_to_replicas()
+                    span.set_attribute("cage.cbf.wait_success", wait_result)
+                    if not wait_result:
+                        # Log but don't fail — WAIT timeout is degraded, not failed
+                        logger.warning(
+                            "Phase 4.3: atomic_verify_and_commit completed but WAIT timed out"
+                        )
+
+                return (committed, message)
         else:
             result_list = await self._evalsha_with_noscript_retry(
                 client, keys, argv, _run_evalsha, _load_and_run
             )
-            return self._parse_lua_result(result_list, None)
+            committed, message = self._parse_lua_result(result_list, None)
+
+            # Phase 4.3: WAIT for replication if configured and committed
+            if committed and _WAIT_REPLICAS > 0:
+                wait_result = await self._sync_to_replicas()
+                if not wait_result:
+                    logger.warning(
+                        "Phase 4.3: atomic_verify_and_commit completed but WAIT timed out"
+                    )
+
+            return (committed, message)
 
     async def _evalsha_with_noscript_retry(
         self,
@@ -755,20 +1241,34 @@ return {1, "COMMITTED", tostring(next_cash)}
             if isinstance(result_list[2], bytes)
             else str(result_list[2])
         )
+        # R-05: Extract epoch from Lua result (4th element)
+        new_epoch = 0
+        if len(result_list) > 3:
+            epoch_raw = result_list[3]
+            new_epoch = int(epoch_raw) if epoch_raw is not None else 0
 
         committed = status_code == 1
         if span:
             span.set_attribute("safety.result", "COMMITTED" if committed else "UNSAFE")
             span.set_attribute("safety.cash.next", float(new_balance_str))
+            # R-05: Add fence epoch to span attributes
+            span.set_attribute("cage.cbf.fence_epoch", new_epoch)
+
+        # R-05: Update epoch tracking and telemetry
+        if committed and new_epoch > 0:
+            self._last_seen_epoch = new_epoch
+            if _CURRENT_FENCE_EPOCH_GAUGE is not None:
+                _CURRENT_FENCE_EPOCH_GAUGE.set(new_epoch)
 
         if committed:
             logger.info(
-                "✅ CBF atomic check+commit: COMMITTED — new_balance=%s",
+                "✅ CBF atomic check+commit: COMMITTED — new_balance=%s epoch=%d",
                 new_balance_str,
+                new_epoch,
             )
             return (True, "COMMITTED")
         else:
-            logger.info("⛔ CBF atomic check+commit: UNSAFE — %s", message)
+            logger.info("⛔ CBF atomic check+commit: UNSAFE — %s (epoch=%d)", message, new_epoch)
             return (False, message)
 
 

--- a/src/gateway/governance/contracts.py
+++ b/src/gateway/governance/contracts.py
@@ -84,7 +84,7 @@ class SafetyFilter(Protocol):
         """Collapse CBF check and state commit into one atomic Redis Lua hop.
 
         Eliminates the TOCTOU window between ``verify_action()`` (read-only)
-        and ``update_state()`` (write) by executing both as a single Lua script
+        and the state commit (write) by executing both as a single Lua script
         inside Redis.
 
         Args:
@@ -98,11 +98,6 @@ class SafetyFilter(Protocol):
         """
         ...
 
-    def update_state(self, cost: float) -> None:
-        """
-        Updates the safety state (e.g. deducts cash).
-        """
-        ...
 
     def rollback_state(self, cost: float) -> None:
         """

--- a/src/governed_financial_advisor/server.py
+++ b/src/governed_financial_advisor/server.py
@@ -844,23 +844,17 @@ async def trigger_refinement(req: RefinementTriggerRequest):  # type: ignore[no-
 # ---------------------------------------------------------------------------
 # NeMo Refinement Proposal/Approval Flow (Priority 2 — Evidentiary Independence)
 #
-# CRITICAL CHANGE: The NeMo hot-reload is no longer autonomous.
+# The NeMo hot-reload requires human approval.
 #
-# Previous flow (recursive self-authentication):
-#   Langfuse webhook → KFP → POST /v1/nemo/apply-refinement → instant reload
-#   The system modified its own governance rules based on its own telemetry.
-#
-# New flow (human-gated):
+# Flow:
 #   Langfuse webhook → KFP → POST /v1/nemo/propose-refinement → STAGED
 #   Human risk officer → POST /v1/nemo/approve-refinement/{id} → APPLIED
 #
-# ENV: Set NEMO_AUTO_APPLY_ENABLED=true to restore legacy auto-apply
-#      (dev/test only — MUST be false in production).
+# This eliminates the recursive self-authentication loop where the system's
+# telemetry could autonomously modify its own governance rules.
+#
+# v3.0.0 Breaking Change: NEMO_AUTO_APPLY_ENABLED has been removed.
 # ---------------------------------------------------------------------------
-
-_NEMO_AUTO_APPLY: bool = (
-    os.environ.get("NEMO_AUTO_APPLY_ENABLED", "false").lower() == "true"
-)
 
 # In-memory proposal store (production: replace with Redis or DB)
 _refinement_proposals: dict[str, dict] = {}
@@ -1037,85 +1031,54 @@ async def list_pending_nemo_proposals():  # type: ignore[no-untyped-def]
 
 @app.post("/v1/nemo/apply-refinement")
 async def apply_nemo_refinement(req: NeMoApplyRefinementRequest):  # type: ignore[no-untyped-def]
-    """GATED: NeMo hot-reload now routes through the proposal/approval flow.
+    """NeMo hot-reload routes through the proposal/approval flow.
 
-    In production (NEMO_AUTO_APPLY_ENABLED=false, default):
-      Stages a proposal and returns ``{"status": "pending_approval"}``.
-      The caller must then approve via POST /v1/nemo/approve-refinement/{id}.
+    v3.0.0 Breaking Change: Auto-apply has been removed. This endpoint now
+    always stages a proposal and returns ``{"status": "pending_approval"}``.
+    The caller must then approve via POST /v1/nemo/approve-refinement/{id}.
 
-    In dev/test (NEMO_AUTO_APPLY_ENABLED=true):
-      Preserves legacy auto-apply behaviour with an audit WARNING.
+    This eliminates the recursive self-authentication loop where the system's
+    telemetry could autonomously modify its own governance rules.
 
-    This gating eliminates the recursive self-authentication loop where
-    the system's telemetry autonomously modified its own governance rules.
+    Satisfies:
+      - EU AI Act Article 14 (human oversight of high-risk AI systems)
+      - ISO 42001 A.7.2 (accountability — reviewer identity attributed)
     """
-    if not _NEMO_AUTO_APPLY:
-        # Production: route through proposal flow
-        logger.info(
-            "[NeMo/Refinement] Auto-apply DISABLED — routing to proposal flow. "
-            "control_id=%s source=%s",
-            req.control_id,
-            req.source,
-        )
-        # Delegate to the propose endpoint
-        import uuid as _uuid
+    import uuid as _uuid
 
-        proposal_id = str(_uuid.uuid4())
-        proposal = {
-            "proposal_id": proposal_id,
-            "control_id": req.control_id,
-            "verdict": req.verdict,
-            "source": req.source,
-            "staged_at": datetime.now(timezone.utc).isoformat(),
-            "status": "staged",
-            "reviewer": None,
-            "rationale": None,
-        }
-        _refinement_proposals[proposal_id] = proposal
-
-        return {
-            "status": "pending_approval",
-            "proposal_id": proposal_id,
-            "control_id": req.control_id,
-            "message": (
-                "Auto-apply is disabled in production. A risk officer must "
-                f"approve via POST /v1/nemo/approve-refinement/{proposal_id}"
-            ),
-        }
-
-    # Dev/test: legacy auto-apply with audit warning
-    logger.warning(
-        "⚠️ [NeMo/Refinement] NEMO_AUTO_APPLY_ENABLED=true — applying "
-        "refinement WITHOUT human approval. This is NOT acceptable in "
-        "production (recursive self-authentication vulnerability)."
+    logger.info(
+        "[NeMo/Refinement] Routing to proposal flow. control_id=%s source=%s",
+        req.control_id,
+        req.source,
     )
+
+    proposal_id = str(_uuid.uuid4())
+    proposal = {
+        "proposal_id": proposal_id,
+        "control_id": req.control_id,
+        "verdict": req.verdict,
+        "source": req.source,
+        "staged_at": datetime.now(timezone.utc).isoformat(),
+        "status": "staged",
+        "reviewer": None,
+        "rationale": None,
+    }
+    _refinement_proposals[proposal_id] = proposal
 
     current_span = trace.get_current_span()
     if current_span and current_span.is_recording():
         current_span.set_attribute("ai.refinement.apply.control_id", req.control_id)
         current_span.set_attribute("ai.refinement.apply.source", req.source)
-        current_span.set_attribute("ai.refinement.apply.verdict", req.verdict[:120])
-        current_span.set_attribute("ai.refinement.auto_apply", True)
-
-    try:
-        from src.gateway.governance.langgraph_harness.nemo_node_factory import (
-            reload_nemo_rails,
-        )
-
-        await reload_nemo_rails()
-        logger.info("[NeMo/Refinement] NeMo rails singleton reloaded (auto-apply).")
-    except Exception as exc:
-        raise HTTPException(
-            status_code=500,
-            detail=f"NeMo rails reload failed: {exc}",
-        ) from exc
+        current_span.set_attribute("ai.refinement.proposal_id", proposal_id)
 
     return {
-        "status": "applied",
+        "status": "pending_approval",
+        "proposal_id": proposal_id,
         "control_id": req.control_id,
-        "source": req.source,
-        "reload": True,
-        "auto_apply_warning": "Applied without human approval (dev/test mode).",
+        "message": (
+            "Refinement proposal staged. A risk officer must "
+            f"approve via POST /v1/nemo/approve-refinement/{proposal_id}"
+        ),
     }
 
 


### PR DESCRIPTION
## Summary

Remove deprecated functionality for major version release v3.0.0.

### Breaking Changes

| ID | Change | Impact |
|----|--------|--------|
| CR-1 | Evidence schema consolidated to v1.1 only | Migrate records with `migrate_record_1_0_to_1_1()` before upgrading |
| CR-2 | NeMo auto-apply path removed | All refinements require explicit approval via `POST /v1/nemo/approve-refinement/{proposal_id}` |
| CR-3 | `update_state()` → `_update_state_unsafe()` | Internal consumers must use `_update_state_unsafe()` or `atomic_verify_and_commit()` |

### Files Changed

- `src/compliance_bridge/evidence_stream.py` — Schema v1.0 removal
- `src/governed_financial_advisor/server.py` — Auto-apply path removal
- `src/gateway/governance/cbf.py` — API restriction
- `src/gateway/governance/contracts.py` — Protocol update
- `CHANGELOG.md` — Release notes

### Documentation Added

- `docs/BREAKING_CHANGES_v3.md`
- `docs/MIGRATION_GUIDE_v3.md`
- `docs/MAJOR_VERSION_CLEANUP_PLAN.md`
- `docs/WAVE3_INCLUSION_CHECKLIST.md`

---
**BREAKING CHANGE**: This PR contains breaking changes. See migration guide.

**9 files changed, +3,120/-128 lines**