### PR TITLE
fix(governance): validate stpa_compiler schema fields before code generation

### DIFF
--- a/src/gateway/governance/stpa_compiler.py
+++ b/src/gateway/governance/stpa_compiler.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 import argparse
 import datetime
 import logging
+import re
 import sys
 import textwrap
 from dataclasses import dataclass, field
@@ -58,7 +59,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import yaml
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 
 logger = logging.getLogger("stpa_compiler")
 
@@ -93,6 +94,48 @@ UcaType = Literal["not_provided", "unsafe_action", "wrong_timing", "stopped_too_
 EnforcementTarget = Literal["opa", "nemo", "python", "langgraph", "ftra", "all"]
 OpaDecision = Literal["DENY", "GOVERNANCE_VIOLATION", "MANUAL_REVIEW", "ALLOW"]
 
+# ---------------------------------------------------------------------------
+# Input hardening for fields that reach the code generators.
+#
+# generate_python() and generate_langgraph() interpolate control-structure
+# string fields directly into Python source that write_artifacts() writes to
+# generated_stpa_validator.py / generated_saga_nodes.py, which singletons.py,
+# symbolic_governor.py and auditor.py import at process start; generate_opa()
+# and generate_nemo() do the same for Rego / Colang.  A field that carries a
+# quote, brace, or newline can break out of a generated string literal,
+# f-string, or comment and inject executable code into the compiled artifact.
+# Identifier-typed fields (action names, param keys, threshold paths) are held
+# to identifier grammars; free-text fields (descriptions, messages) may not
+# carry the characters that escape a generated literal.  Both are enforced here
+# at parse time so no generator has to remember to escape.
+# ---------------------------------------------------------------------------
+
+_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+_ACTION_RE = re.compile(r"^(?:\*|[A-Za-z_][A-Za-z0-9_.-]*)$")
+_DOTTED_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*$")
+_TEXT_FORBIDDEN = ('"', "\\", "{", "}", "\n", "\r")
+
+
+def _require_pattern(value: str, pattern: re.Pattern[str], field: str) -> str:
+    if not pattern.match(value):
+        raise ValueError(
+            f"{field} must match {pattern.pattern!r}; got {value!r} — this value is "
+            "compiled into generated enforcement code and may not contain other characters"
+        )
+    return value
+
+
+def _reject_source_breaking(value: str, field: str) -> str:
+    for ch in _TEXT_FORBIDDEN:
+        if ch in value:
+            raise ValueError(
+                f"{field} may not contain {ch!r} — it is interpolated into generated "
+                "enforcement code (string literals, f-strings, and comments)"
+            )
+    return value
+
+
 # FTRA terminal classification — used by the Forward-Looking Trajectory Reachability Analyzer.
 # Fail-closed: any action not present in the compiled registry is treated as
 # IRREVERSIBLE_TERMINAL by IrreversibilityClassifier at runtime.
@@ -116,15 +159,53 @@ class ConditionModel(BaseModel):
     semantic_pattern: str | None = None
     composite: str | None = None  # free-form expression for complex conditions
 
+    @field_validator("param")
+    @classmethod
+    def _v_param(cls, v: str | None) -> str | None:
+        return v if v is None else _require_pattern(v, _IDENT_RE, "condition.param")
+
+    @field_validator("threshold_ref")
+    @classmethod
+    def _v_threshold_ref(cls, v: str | None) -> str | None:
+        return (
+            v
+            if v is None
+            else _require_pattern(v, _DOTTED_IDENT_RE, "condition.threshold_ref")
+        )
+
+    @field_validator("semantic_pattern", "composite")
+    @classmethod
+    def _v_free_text(cls, v: str | None, info: ValidationInfo) -> str | None:
+        return (
+            v
+            if v is None
+            else _reject_source_breaking(v, f"condition.{info.field_name}")
+        )
+
 
 class OpaRuleModel(BaseModel):
     decision: OpaDecision = "DENY"
     message: str
 
+    @field_validator("message")
+    @classmethod
+    def _v_message(cls, v: str) -> str:
+        return _reject_source_breaking(v, "opa_rule.message")
+
 
 class NemoRailModel(BaseModel):
     flow_name: str
     message: str
+
+    @field_validator("flow_name")
+    @classmethod
+    def _v_flow_name(cls, v: str) -> str:
+        return _require_pattern(v, _IDENT_RE, "nemo_rail.flow_name")
+
+    @field_validator("message")
+    @classmethod
+    def _v_message(cls, v: str) -> str:
+        return _reject_source_breaking(v, "nemo_rail.message")
 
 
 class ParameterMappingModel(BaseModel):
@@ -140,6 +221,11 @@ class ParameterMappingModel(BaseModel):
 
     forward_key: str  # e.g. "transaction_id" from the forward action's context_data
     compensating_key: str  # e.g. "target_tx_id" expected by the compensating API call
+
+    @field_validator("forward_key", "compensating_key")
+    @classmethod
+    def _v_key(cls, v: str) -> str:
+        return _require_pattern(v, _IDENT_RE, "parameter_mapping key")
 
     @classmethod
     def from_yaml_dict(cls, raw: dict[str, str]) -> list[ParameterMappingModel]:
@@ -179,6 +265,20 @@ class SagaModel(BaseModel):
     execution_type: ExecutionType = "local"
     mcp_tool_name: str | None = None
 
+    @field_validator("forward_action", "compensating_action")
+    @classmethod
+    def _v_saga_action(cls, v: str) -> str:
+        return _require_pattern(v, _IDENT_RE, "langgraph_saga action")
+
+    @field_validator("mcp_tool_name")
+    @classmethod
+    def _v_mcp_tool_name(cls, v: str | None) -> str | None:
+        return (
+            v
+            if v is None
+            else _require_pattern(v, _IDENT_RE, "langgraph_saga.mcp_tool_name")
+        )
+
     @model_validator(mode="before")
     @classmethod
     def _parse_parameter_mapping(cls, data: Any) -> Any:
@@ -211,6 +311,21 @@ class UCAModel(BaseModel):
     # FTRA: commencement-time worst-case reachability classification.
     # Fail-closed: IrreversibilityClassifier treats absent entries as IRREVERSIBLE_TERMINAL.
     terminal_classification: TerminalClassification | None = None
+
+    @field_validator("id")
+    @classmethod
+    def _v_id(cls, v: str) -> str:
+        return _require_pattern(v, _ID_RE, "uca.id")
+
+    @field_validator("action")
+    @classmethod
+    def _v_action(cls, v: str) -> str:
+        return _require_pattern(v, _ACTION_RE, "uca.action")
+
+    @field_validator("description")
+    @classmethod
+    def _v_description(cls, v: str) -> str:
+        return _reject_source_breaking(v, "uca.description")
 
     @model_validator(mode="after")
     def _validate_enforcement_deps(self) -> UCAModel:
@@ -258,6 +373,13 @@ class SystemModel(BaseModel):
     controller: str
     controlled_process: str
     sensors: list[str] = Field(default_factory=list)
+
+    @field_validator("name", "version")
+    @classmethod
+    def _v_banner_field(cls, v: str) -> str:
+        # name and version are interpolated into the `# System: ...` header
+        # comment of every generated artifact, including the Python ones.
+        return _reject_source_breaking(v, "system field")
 
 
 class ControlStructureModel(BaseModel):

--- a/tests/test_stpa_compiler.py
+++ b/tests/test_stpa_compiler.py
@@ -191,6 +191,89 @@ class TestSchemaValidation:
 
 
 # ---------------------------------------------------------------------------
+# Generated-code injection guards
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestGeneratedCodeInjection:
+    """Control-structure string fields are compiled into the generated Python
+    validator / saga nodes (imported at runtime) and the Rego / Colang policies.
+    Fields carrying a quote, brace, or newline could break out of a generated
+    literal or comment and inject code, so the schema rejects them at parse.
+    """
+
+    def test_threshold_ref_bare_code_injection_rejected(self) -> None:
+        # threshold_ref lands in bare code (`threshold = THRESHOLDS.<ref>`); a
+        # newline injects arbitrary statements into the generated validator.
+        raw = yaml.safe_load(_MINIMAL_YAML)
+        cond = raw["unsafe_control_actions"][0]["condition"]
+        cond["operator"] = "greater_than"
+        cond["threshold_ref"] = "drawdown\n    __import__('os').system('id')  #"
+        with pytest.raises(Exception, match="threshold_ref"):
+            ControlStructureModel(**raw)
+
+    def test_param_non_identifier_rejected(self) -> None:
+        raw = yaml.safe_load(_MINIMAL_YAML)
+        raw["unsafe_control_actions"][0]["condition"]["param"] = 'x") or exec("1'
+        with pytest.raises(Exception, match="condition.param"):
+            ControlStructureModel(**raw)
+
+    def test_description_fstring_injection_rejected(self) -> None:
+        # description is baked into a generated f-string; a brace is evaluated.
+        raw = yaml.safe_load(_MINIMAL_YAML)
+        raw["unsafe_control_actions"][0]["description"] = "{__import__('os').getpid()}"
+        with pytest.raises(Exception, match="uca.description"):
+            ControlStructureModel(**raw)
+
+    def test_uca_action_non_identifier_rejected(self) -> None:
+        raw = yaml.safe_load(_MINIMAL_YAML)
+        raw["unsafe_control_actions"][0]["action"] = 'do_thing"\n    import os  #'
+        with pytest.raises(Exception, match="uca.action"):
+            ControlStructureModel(**raw)
+
+    def test_system_name_newline_rejected(self) -> None:
+        # name/version reach the `# System: ...` header of every artifact.
+        raw = yaml.safe_load(_MINIMAL_YAML)
+        raw["system"]["name"] = "X\n_PWNED = 1"
+        with pytest.raises(Exception, match="system field"):
+            ControlStructureModel(**raw)
+
+    def test_opa_rule_message_quote_rejected(self) -> None:
+        raw = yaml.safe_load(_MINIMAL_YAML)
+        raw["unsafe_control_actions"][0]["opa_rule"]["message"] = 'a" ; allow := true #'
+        with pytest.raises(Exception, match="opa_rule.message"):
+            ControlStructureModel(**raw)
+
+    def test_nemo_flow_name_non_identifier_rejected(self) -> None:
+        raw = yaml.safe_load(_NEMO_YAML)
+        raw["unsafe_control_actions"][0]["nemo_rail"]["flow_name"] = "bad name"
+        with pytest.raises(Exception, match="nemo_rail.flow_name"):
+            ControlStructureModel(**raw)
+
+    def test_saga_action_non_identifier_rejected(self) -> None:
+        raw = yaml.safe_load(_MINIMAL_YAML)
+        uca = raw["unsafe_control_actions"][0]
+        uca["enforcement"] = ["langgraph"]
+        uca.pop("opa_rule", None)
+        uca["langgraph_saga"] = {
+            "forward_action": "execute_trade\n    import os  #",
+            "compensating_action": "reverse_trade",
+        }
+        with pytest.raises(Exception, match="langgraph_saga action"):
+            ControlStructureModel(**raw)
+
+    def test_valid_fields_still_generate_clean_python(self) -> None:
+        # Positive control: legitimate values compile and the generated Python
+        # holds no injected import.
+        raw = yaml.safe_load(_MINIMAL_YAML)
+        cs = ControlStructureModel(**raw)
+        gen = generate_python(cs)
+        assert "GeneratedSTPAValidator" in gen
+        assert "__import__" not in gen
+
+
+# ---------------------------------------------------------------------------
 # OPA generation tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

`generate_python` and `generate_langgraph` in `stpa_compiler.py` interpolate control-structure string fields straight into the Python source that `write_artifacts` writes to `generated_stpa_validator.py` and `generated_saga_nodes.py` (imported at process start by `singletons.py` / `symbolic_governor.py` / `auditor.py`), and `generate_opa` / `generate_nemo` do the same for Rego and Colang. Several fields land in bare-code, f-string, or comment context with no escaping: `condition.threshold_ref` becomes `threshold = THRESHOLDS.<ref>` after a `threshold_ref.replace(".", ".")` that changes nothing, and `uca.description` is baked into a generated f-string. A control-structure document reaching the compiler through the OSCAL / AAIF / ACS / lula ingress adapters can therefore inject Python that runs when the generated validator is imported. The fix constrains these fields at the schema parse boundary so no generator has to remember to escape: identifier-typed fields must be identifiers, and free-text fields cannot carry the quotes, braces, or newlines that break out of a generated literal.

## Type of Change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no feature/fix, code restructuring
- [ ] `perf` — performance improvement
- [ ] `test` — test additions or corrections
- [ ] `chore` — build, deps, tooling
- [ ] `ci` — CI/CD pipeline
- [ ] `BREAKING CHANGE` — existing behaviour changes

## Related Issues / ADRs

N/A

## Changes Made

- `src/gateway/governance/stpa_compiler.py` — pydantic field validators on the STPA schema models (`ConditionModel`, `UCAModel`, `SystemModel`, `SagaModel`, `ParameterMappingModel`, `NemoRailModel`, `OpaRuleModel`). Identifier-typed fields (`id`, `action`, `param`, `threshold_ref`, `flow_name`, saga action/tool/key names) must match an identifier grammar; free-text fields (descriptions, messages, `system.name`/`version`) may not contain `"` `\` `{` `}` or newlines. Every generator reads the validated models, so all output formats are covered at the single parse boundary.
- `tests/test_stpa_compiler.py` — `TestGeneratedCodeInjection` exercising the `threshold_ref` bare-code, `description` f-string, `param`/`action`/`flow_name`/saga identifier, `system.name` newline, and `opa_rule.message` quote vectors, plus a positive control that a valid control structure still compiles to clean Python.

## Testing

- [x] Unit tests added / updated (`pytest tests/`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Manual smoke test performed (describe below)
- [ ] No tests needed (docs/config only — explain why)

**Manual test steps (if applicable):**
```
uv run pytest tests/test_stpa_compiler.py -q          # 48 passed (9 new)
uv run ruff check src/gateway/governance/stpa_compiler.py
uv run ruff format --check src/gateway/governance/stpa_compiler.py
uv run mypy src/gateway/governance/stpa_compiler.py
# The real config/stpa_control_structure.yaml still parses and compiles to
# byte-identical artifacts; the new tests fail on the pre-patch tree.
```

## Compliance & Security Checklist

### 🔒 Universal — All contributors must verify (all regions affected)

- [x] No secrets, credentials, or PII in committed files
- [x] Network policy unchanged **or** reviewed by security owner
- [x] OPA policy changes reviewed for correctness (no OPA policy changed — this hardens the compiler that generates the policy; generated output for valid input is unchanged)
- [x] **Data residency:** no new storage path, GCS write, Langfuse sink, or telemetry export
- [x] **ISO 42001 / CSA AARM:** Lula assertions unaffected
- [x] **No region-specific behaviour introduced without a `cage_deployment_region` guard** — this is region-agnostic input validation; valid configs behave identically in every region

---

### 🎯 Region-specific depth — Check only your target deployment

**US_FED**
- [x] N/A — region-agnostic input validation, no control-mapping or behaviour change

**EU_ECB**
- [x] N/A — region-agnostic input validation, no control-mapping or behaviour change

**APAC_MAS**
- [x] N/A — region-agnostic input validation, no control-mapping or behaviour change

---

### 📋 Shared-module impact declaration

- [ ] Not applicable — PR does not touch shared compliance modules
- [x] **Impact assessed across all three regions**

**Cross-region impact summary (if applicable):**
```
US_FED impact:  none for valid inputs — generated artifacts are unchanged; a malformed
                control-structure document is now rejected at parse.
EU_ECB impact:  same as US_FED — region-agnostic parse-time validation.
APAC_MAS impact: same as US_FED — region-agnostic parse-time validation.
```

## Deployment Notes

N/A

## PR Title Format

`fix(governance): validate stpa_compiler schema fields before code generation`
