### PR TITLE
fix(infra): contain LocalStorage paths within the storage root

### DIFF
--- a/src/governed_financial_advisor/infrastructure/storage.py
+++ b/src/governed_financial_advisor/infrastructure/storage.py
@@ -145,7 +145,17 @@ class LocalStorage(StorageInterface):
         logger.info("LocalStorage initialised at %s", self.base_dir)
 
     def _resolve(self, remote_path: str) -> Path:
-        return self.base_dir / remote_path
+        # Contain the join within base_dir. A remote_path with ".." segments
+        # (``../../etc/passwd``) or an absolute component (``/etc/passwd`` — which
+        # makes ``base_dir / remote_path`` discard base_dir entirely) would escape
+        # the storage root and let a caller read or write arbitrary filesystem
+        # locations through read_text/write_text/upload/download/exists.
+        dest = self.base_dir / remote_path
+        if not dest.resolve().is_relative_to(self.base_dir.resolve()):
+            raise ValueError(
+                f"LocalStorage: remote_path {remote_path!r} escapes the storage root"
+            )
+        return dest
 
     def upload(self, local_path: str, remote_path: str) -> str:
         import shutil

--- a/tests/test_security_high_severity.py
+++ b/tests/test_security_high_severity.py
@@ -413,4 +413,43 @@ class TestH12PolicySchemaValidation:
                 loader.load_stamp_hazards(blob_name)
 
 
+# =============================================================================
+# LocalStorage path containment: _resolve() must keep caller paths under base_dir
+# =============================================================================
+
+
+class TestLocalStoragePathContainment:
+    """LocalStorage._resolve rejects paths that escape the storage root."""
+
+    def _backend(self, tmp_path: Path):
+        from src.governed_financial_advisor.infrastructure.storage import LocalStorage
+
+        return LocalStorage(base_dir=str(tmp_path / "store"))
+
+    def test_relative_traversal_rejected(self, tmp_path):
+        backend = self._backend(tmp_path)
+        with pytest.raises(ValueError):
+            backend.write_text("../escaped.txt", "pwned")
+        assert not (tmp_path / "escaped.txt").exists()
+
+    def test_absolute_path_rejected(self, tmp_path):
+        backend = self._backend(tmp_path)
+        outside = tmp_path / "outside.txt"
+        # An absolute component makes ``base_dir / remote_path`` discard base_dir.
+        with pytest.raises(ValueError):
+            backend.write_text(str(outside), "pwned")
+        assert not outside.exists()
+
+    def test_nested_traversal_rejected(self, tmp_path):
+        backend = self._backend(tmp_path)
+        with pytest.raises(ValueError):
+            backend.read_text("a/b/../../../../etc/hostname")
+
+    def test_legitimate_nested_path_roundtrips(self, tmp_path):
+        backend = self._backend(tmp_path)
+        backend.write_text("oscal/2026/report.txt", "ok")
+        assert backend.read_text("oscal/2026/report.txt") == "ok"
+        assert backend.exists("oscal/2026/report.txt")
+
+
 pytestmark = [pytest.mark.unit, pytest.mark.local]


### PR DESCRIPTION
## Summary

`LocalStorage._resolve` builds `self.base_dir / remote_path` with no containment, so a `remote_path` that carries `..` segments (`../../etc/passwd`) or an absolute component (`/etc/passwd`, which makes `base_dir / remote_path` discard `base_dir` entirely) resolves outside the storage root. Every LocalStorage operation — `read_text`, `write_text`, `upload`, `download`, `exists` — routes through `_resolve`, so the escape reaches an arbitrary filesystem path for both reads and writes. The join is now rejected when the resolved path is not inside `base_dir`.

## Type of Change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no feature/fix, code restructuring
- [ ] `perf` — performance improvement
- [ ] `test` — test additions or corrections
- [ ] `chore` — build, deps, tooling
- [ ] `ci` — CI/CD pipeline
- [ ] `BREAKING CHANGE` — existing behaviour changes

## Related Issues / ADRs

N/A

## Changes Made

- `src/governed_financial_advisor/infrastructure/storage.py` — `LocalStorage._resolve` now raises `ValueError` when `(base_dir / remote_path).resolve()` is not relative to `base_dir.resolve()`. Valid keys (including nested prefixes) are unchanged; only escaping paths are rejected. The GCS/S3 backends are unaffected — they address flat object keys, not the filesystem.
- `tests/test_security_high_severity.py` — regression coverage for relative traversal, absolute-component escape, nested traversal, and an unchanged legitimate nested round-trip.

## Testing

- [x] Unit tests added / updated (`pytest tests/`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Manual smoke test performed (describe below)
- [ ] No tests needed (docs/config only — explain why)

**Manual test steps (if applicable):**
```
python3.12 -m pytest tests/test_security_high_severity.py::TestLocalStoragePathContainment -q
# 4 passed. The three traversal cases fail on the pre-patch tree and pass after the change.
python3.12 -m ruff check src/governed_financial_advisor/infrastructure/storage.py tests/test_security_high_severity.py
python3.12 -m mypy src/governed_financial_advisor/infrastructure/storage.py
```

## Compliance & Security Checklist

### 🔒 Universal — All contributors must verify (all regions affected)

- [x] No secrets, credentials, or PII in committed files
- [x] Network policy unchanged **or** reviewed by security owner
- [x] OPA policy changes reviewed for correctness (no OPA changes)
- [x] **Data residency:** no new storage path, GCS write, Langfuse sink, or telemetry export is introduced — the change constrains an existing local filesystem helper to its configured root
- [x] **ISO 42001 / CSA AARM:** Lula assertions unaffected
- [x] **No region-specific behaviour introduced without a `cage_deployment_region` guard** — the change is region-agnostic and does not touch `src/gateway/governance/`, `src/compliance_bridge/`, or `config/`

---

### 🎯 Region-specific depth — Check only your target deployment

**US_FED**
- [x] N/A — not region-specific; the fix constrains a filesystem helper equally in all regions

**EU_ECB**
- [x] N/A — not targeting EU_ECB

**APAC_MAS**
- [x] N/A — not targeting APAC_MAS

---

### 📋 Shared-module impact declaration

- [x] Not applicable — PR does not touch shared compliance modules (`src/governed_financial_advisor/infrastructure/storage.py` is not under `src/gateway/governance/`, `src/compliance_bridge/`, or `config/`)

## Deployment Notes

N/A

## PR Title Format

`fix(infra): contain LocalStorage paths within the storage root`