### PR TITLE
fix(governance): fail closed in check_approval_token when ids are absent

### DIFF
--- a/src/governed_financial_advisor/governance/nemo_actions.py
+++ b/src/governed_financial_advisor/governance/nemo_actions.py
@@ -217,12 +217,13 @@ def validate_approval_token(token: str, thread_id: str, trade_id: str) -> bool:
 def check_approval_token(context: dict[str, Any]) -> bool:
     """Return True if a valid HMAC-signed approval token is present.
 
-    Uses cryptographic HMAC-SHA256 validation. Falls back to legacy
-    non-empty check when thread_id/trade_id are not provided in context.
+    Uses cryptographic HMAC-SHA256 validation. When thread_id/trade_id are
+    not present in the context the token cannot be bound or verified, so the
+    check denies rather than trusting an unverified value.
 
     Returns:
         True  — token present and cryptographically valid.
-        False — token absent or invalid (fail-closed).
+        False — token absent, unverifiable, or invalid (fail-closed).
     """
     token = context.get("approval_token")
     if not token:
@@ -251,11 +252,12 @@ def check_approval_token(context: dict[str, Any]) -> bool:
             )
         return valid
 
-    # Legacy path: token is non-empty and not a known bad value
-    logger.debug(
-        "check_approval_token: no thread_id/trade_id — using legacy non-empty check"
+    # Without thread_id/trade_id the token's HMAC cannot be recomputed, so a
+    # non-empty string proves nothing. Deny instead of accepting it unverified.
+    logger.warning(
+        "check_approval_token: thread_id/trade_id absent — token unverifiable — DENY"
     )
-    return True
+    return False
 
 
 def check_data_latency(context: dict[str, Any]) -> bool:

--- a/tests/test_nemo_actions.py
+++ b/tests/test_nemo_actions.py
@@ -55,6 +55,33 @@ def test_check_approval_token_action_fail_closed_on_exception():
     assert result is False, "Known bad token 'bad_sig' must be rejected"
 
 
+def test_check_approval_token_denies_unverifiable_token():
+    """A non-empty token with no thread_id/trade_id cannot be verified — DENY.
+
+    The token's HMAC binds thread_id:trade_id:expiry, so without those fields
+    the signature cannot be recomputed. A forged, unsigned string must not be
+    accepted just because it is non-empty.
+    """
+    from src.governed_financial_advisor.governance.nemo_actions import (
+        generate_approval_token,
+    )
+
+    # Forged token, no identity fields — must fail-closed.
+    assert _gfa_check_approval_token({"approval_token": "forged-not-signed"}) is False
+
+    # Even a genuinely signed token is unverifiable without the bound ids.
+    token = generate_approval_token("thread-1", "trade-abc")
+    assert _gfa_check_approval_token({"approval_token": token}) is False
+
+    # With the correct bound ids present it validates.
+    assert (
+        _gfa_check_approval_token(
+            {"approval_token": token, "thread_id": "thread-1", "trade_id": "trade-abc"}
+        )
+        is True
+    )
+
+
 def test_check_drawdown_limit_action_fail_closed_on_missing_data():
     """check_drawdown_limit must return False (fail-closed) when drawdown_pct is absent."""
     # No drawdown_pct key → fail-closed


### PR DESCRIPTION
## Summary

`check_approval_token` only runs HMAC validation when both `thread_id` and `trade_id` are present in the context; when either is missing it falls through to a legacy branch that returns `True` for any non-empty token other than the literal sentinel `"bad_sig"`. The approval token's HMAC binds `thread_id:trade_id:expiry`, so a token supplied without those fields cannot be recomputed or verified, yet the guard accepts it. A forged, unsigned string therefore clears the SC-1 approval-token check, which contradicts the function's own documented fail-closed contract and the fail-closed behaviour of the sibling checks in the same module. The fix denies when the identity fields are absent so an unverifiable token is never trusted.

## Type of Change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no feature/fix, code restructuring
- [ ] `perf` — performance improvement
- [ ] `test` — test additions or corrections
- [ ] `chore` — build, deps, tooling
- [ ] `ci` — CI/CD pipeline
- [ ] `BREAKING CHANGE` — existing behaviour changes

## Related Issues / ADRs

N/A

## Changes Made

- `src/governed_financial_advisor/governance/nemo_actions.py` — `check_approval_token` now returns `False` when `thread_id`/`trade_id` are missing (the token cannot be bound or verified), replacing the legacy non-empty acceptance. Docstring updated to match.
- `tests/test_nemo_actions.py` — regression test asserting a forged token and an otherwise-valid token supplied without the bound ids are both denied, while a valid token with the correct ids still passes.

## Testing

- [x] Unit tests added / updated (`pytest tests/`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Manual smoke test performed (describe below)
- [ ] No tests needed (docs/config only — explain why)

**Manual test steps (if applicable):**
```
uv run pytest tests/test_nemo_actions.py tests/test_gateway_nemo_actions.py \
  tests/test_nemo_action_registry.py tests/test_security_medium_severity.py -o addopts="" -q
# 166 passed. The new test_check_approval_token_denies_unverifiable_token fails on the
# pre-patch tree (forged token returns True) and passes after the change.
uv run ruff check src/governed_financial_advisor/governance/nemo_actions.py tests/test_nemo_actions.py
uv run mypy src/governed_financial_advisor/governance/nemo_actions.py
```

## Compliance & Security Checklist

### 🔒 Universal — All contributors must verify (all regions affected)

- [x] No secrets, credentials, or PII in committed files
- [x] Network policy unchanged **or** reviewed by security owner
- [x] OPA policy changes reviewed for correctness (no OPA changes)
- [x] **Data residency:** no new storage path, GCS write, Langfuse sink, or telemetry export
- [x] **ISO 42001 / CSA AARM:** Lula assertions unaffected
- [x] **No region-specific behaviour introduced without a `cage_deployment_region` guard** — the change is region-agnostic and only tightens an existing approval-token guard

---

### 🎯 Region-specific depth — Check only your target deployment

**US_FED**
- [x] N/A — not targeting a single region; the fix is region-agnostic

**EU_ECB**
- [x] N/A — not targeting a single region; the fix is region-agnostic

**APAC_MAS**
- [x] N/A — not targeting a single region; the fix is region-agnostic

---

### 📋 Shared-module impact declaration

- [x] Not applicable — PR does not touch `src/gateway/governance/`, `src/compliance_bridge/`, `config/compliance/`, `config/thresholds/`, or `config/oscal/`

## Deployment Notes

N/A

## PR Title Format

`fix(governance): fail closed in check_approval_token when ids are absent`
