### PR TITLE
fix(compliance-bridge): honor zero balance in ledger providers

### DIFF
--- a/src/compliance_bridge/reconciliation_worker.py
+++ b/src/compliance_bridge/reconciliation_worker.py
@@ -769,10 +769,18 @@ class GcsLedgerProvider:
         #   - "balance" or "balances.{account_id}" -> balance_usd
         #   - "timestamp" -> verified_at (converted to Unix float)
         #   - "kms_signature" -> signature (if present)
+        # Resolve with explicit membership so a genuine 0.0 balance is honoured
+        # rather than treated as "absent" and overwritten by the top-level
+        # fallback — a drained account is the case the cash barrier must catch.
         balances = data.get("balances", {})
-        balance_value = balances.get(account_id, balances.get("default_account", 0.0))
-        if not balance_value and "balance" in data:
+        if account_id in balances:
+            balance_value = balances[account_id]
+        elif "default_account" in balances:
+            balance_value = balances["default_account"]
+        elif "balance" in data:
             balance_value = data["balance"]
+        else:
+            balance_value = 0.0
 
         # Parse timestamp if present, otherwise use current time
         verified_at = time.time()
@@ -892,11 +900,19 @@ class ObjectStoreLedgerProvider:
         raw = response["Body"].read().decode("utf-8")
         data = _json.loads(raw)
 
-        # Map the S3 snapshot schema to ReconciliationResult fields
+        # Map the S3 snapshot schema to ReconciliationResult fields.
+        # Resolve with explicit membership so a genuine 0.0 balance is honoured
+        # rather than treated as "absent" and overwritten by the top-level
+        # fallback — a drained account is the case the cash barrier must catch.
         balances = data.get("balances", {})
-        balance_value = balances.get(account_id, balances.get("default_account", 0.0))
-        if not balance_value and "balance" in data:
+        if account_id in balances:
+            balance_value = balances[account_id]
+        elif "default_account" in balances:
+            balance_value = balances["default_account"]
+        elif "balance" in data:
             balance_value = data["balance"]
+        else:
+            balance_value = 0.0
 
         # Parse timestamp if present, otherwise use current time
         verified_at = time.time()

--- a/tests/test_reconciliation_worker.py
+++ b/tests/test_reconciliation_worker.py
@@ -421,3 +421,78 @@ class TestReadVerifiedBalance:
 
         result = mod.read_verified_balance(mock_redis)
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# GcsLedgerProvider / ObjectStoreLedgerProvider — zero-balance mapping
+#
+# A drained (0.0) account in a multi-account snapshot must be reported as 0.0,
+# not silently replaced by the top-level "balance" fallback. The barrier the
+# reconciler feeds, h(x) = cash - min_cash, relies on the real balance; a
+# masked zero inflates it and lets trades clear against an empty account.
+# ---------------------------------------------------------------------------
+
+
+class TestLedgerProviderZeroBalanceMapping:
+    """Ledger providers must not treat a present 0.0 balance as absent."""
+
+    def _gcs_client_for(self, snapshot: dict) -> MagicMock:
+        blob = MagicMock()
+        blob.download_as_text.return_value = json.dumps(snapshot)
+        bucket = MagicMock()
+        bucket.blob.return_value = blob
+        client = MagicMock()
+        client.bucket.return_value = bucket
+        return client
+
+    def _s3_provider_with_snapshot(self, mod, monkeypatch, snapshot: dict):
+        monkeypatch.setenv("S3_RECONCILIATION_BUCKET", "cage-ledger")
+        body = MagicMock()
+        body.read.return_value = json.dumps(snapshot).encode("utf-8")
+        client = MagicMock()
+        client.get_object.return_value = {"Body": body}
+        provider = mod.ObjectStoreLedgerProvider()
+        monkeypatch.setattr(provider, "_make_client", lambda: client)
+        return provider
+
+    def test_gcs_present_zero_balance_not_masked(self, monkeypatch):
+        """A 0.0 target balance must survive even when a top-level fallback exists."""
+        mod = _get_module()
+        monkeypatch.setenv("GCS_RECONCILIATION_BUCKET", "cage-ledger")
+        snapshot = {"balances": {"acct1": 0.0}, "balance": 100_000.0}
+        client = self._gcs_client_for(snapshot)
+        provider = mod.GcsLedgerProvider()
+        with patch("google.cloud.storage.Client", return_value=client):
+            result = provider.fetch_balance("acct1")
+        assert result.balance_usd == 0.0
+
+    def test_s3_present_zero_balance_not_masked(self, monkeypatch):
+        """Same containment for the S3-compatible provider."""
+        mod = _get_module()
+        snapshot = {"balances": {"acct1": 0.0}, "balance": 100_000.0}
+        provider = self._s3_provider_with_snapshot(mod, monkeypatch, snapshot)
+
+        result = provider.fetch_balance("acct1")
+        assert result.balance_usd == 0.0
+
+    def test_gcs_nonzero_balance_preferred_over_fallback(self, monkeypatch):
+        """A real per-account balance still wins over the top-level fallback."""
+        mod = _get_module()
+        monkeypatch.setenv("GCS_RECONCILIATION_BUCKET", "cage-ledger")
+        snapshot = {"balances": {"acct1": 4_200.0}, "balance": 100_000.0}
+        client = self._gcs_client_for(snapshot)
+        provider = mod.GcsLedgerProvider()
+        with patch("google.cloud.storage.Client", return_value=client):
+            result = provider.fetch_balance("acct1")
+        assert result.balance_usd == 4_200.0
+
+    def test_gcs_absent_account_falls_back_to_top_level_balance(self, monkeypatch):
+        """When the account is absent, the top-level balance is still used."""
+        mod = _get_module()
+        monkeypatch.setenv("GCS_RECONCILIATION_BUCKET", "cage-ledger")
+        snapshot = {"balances": {}, "balance": 100_000.0}
+        client = self._gcs_client_for(snapshot)
+        provider = mod.GcsLedgerProvider()
+        with patch("google.cloud.storage.Client", return_value=client):
+            result = provider.fetch_balance("acct1")
+        assert result.balance_usd == 100_000.0


### PR DESCRIPTION
## Summary

`GcsLedgerProvider.fetch_balance` and `ObjectStoreLedgerProvider.fetch_balance` resolve a per-account balance with `balances.get(account_id, balances.get("default_account", 0.0))` and then fall back to the top-level `balance` field under `if not balance_value`. That truthiness test treats a legitimate `0.0` as missing, so a drained account in a multi-account snapshot is reported with the top-level fallback instead of its real zero. The reconciler feeds the CBF an independent cash balance for the barrier `h(x) = cash - min_cash`, so an inflated balance lets a trade clear against an empty account. Both providers now resolve the balance with explicit membership checks, so a present `0.0` is kept while the absent-account fallback is unchanged.

## Type of Change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no feature/fix, code restructuring
- [ ] `perf` — performance improvement
- [ ] `test` — test additions or corrections
- [ ] `chore` — build, deps, tooling
- [ ] `ci` — CI/CD pipeline
- [ ] `BREAKING CHANGE` — existing behaviour changes

## Related Issues / ADRs

N/A

## Changes Made

- `src/compliance_bridge/reconciliation_worker.py` — resolve the ledger balance in both cloud providers via explicit `account_id in balances` / `default_account` / top-level `balance` checks, so a real `0.0` is no longer overwritten by the fallback. Non-zero and absent-account behaviour is identical to before.
- `tests/test_reconciliation_worker.py` — regression coverage for both providers: a present `0.0` is preserved, a real per-account balance still wins over the fallback, and an absent account still uses the top-level balance.

## Testing

- [x] Unit tests added / updated (`pytest tests/`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Manual smoke test performed (describe below)
- [ ] No tests needed (docs/config only — explain why)

**Manual test steps (if applicable):**
```
uv run pytest tests/test_reconciliation_worker.py -q
# 26 passed. The two *_present_zero_balance_not_masked cases fail on the
# pre-patch tree (balance resolves to 100000.0 from the top-level fallback)
# and pass after the change (0.0 is kept).
uv run ruff check src/compliance_bridge/reconciliation_worker.py tests/test_reconciliation_worker.py
uv run mypy src/compliance_bridge/reconciliation_worker.py
```

## Compliance & Security Checklist

### 🔒 Universal — All contributors must verify (all regions affected)

- [x] No secrets, credentials, or PII in committed files
- [x] Network policy unchanged **or** reviewed by security owner
- [x] OPA policy changes reviewed for correctness (no OPA changes)
- [x] **Data residency:** no new storage path, GCS write, Langfuse sink, or telemetry export — the change only corrects balance resolution on existing ledger reads
- [x] **ISO 42001 / CSA AARM:** Lula assertions unaffected
- [x] **No region-specific behaviour introduced without a `cage_deployment_region` guard** — the fix is region-agnostic

---

### 🎯 Region-specific depth — Check only your target deployment

**US_FED**
- [x] N/A — reconciliation balance mapping is region-agnostic; no NIST control mapping or audit-retention logic changed

**EU_ECB**
- [x] N/A — not targeting EU_ECB; no new cross-border transfer or High-Risk AI behaviour, GDPR residency preserved

**APAC_MAS**
- [x] N/A — not targeting APAC_MAS; MAS TRM §4.2 residency preserved, no fairness-relevant behaviour changed

---

### 📋 Shared-module impact declaration

- [ ] Not applicable — PR does not touch shared compliance modules
- [x] **Impact assessed across all three regions**

**Cross-region impact summary (if applicable):**
```
US_FED impact:  none — balance resolution corrected identically; a real 0.0 account balance is now honoured instead of masked.
EU_ECB impact:  none — same correction; no residency or telemetry path change.
APAC_MAS impact: none — same correction; no residency or telemetry path change.
```

## Deployment Notes

N/A
