### PR TITLE
fix(governance): key agent catalog on full spiffe id, not last segment

### DIFF
--- a/src/gateway/governance/ingress/agent_registry_adapter.py
+++ b/src/gateway/governance/ingress/agent_registry_adapter.py
@@ -309,15 +309,29 @@ class AgentRegistryAdapter:
         agent_list = raw.get("agents", [])
 
         for agent in agent_list:
-            # Extract SPIFFE ID from the resource name (last path segment)
+            # The GEAP resource name embeds the full SPIFFE identity, e.g.
+            #   projects/.../agents/spiffe://trust-domain/ns/default/sa/trader-agent
+            # agent_catalog.rego (approved_agents[input.caller_identity.sub]) and
+            # config/agent_catalog.json both key on the FULL spiffe:// identity, so
+            # the catalog key must be that whole identity.  Taking only the final
+            # "/"-segment collapses distinct identities that share a trailing
+            # component — the same service-account name in two namespaces or trust
+            # domains — onto one key, and the later entry silently overwrites the
+            # earlier one's allowed_tools/roles (grant substitution).
             resource_name: str = agent.get("name", "")
-            spiffe_id = (
-                resource_name.rsplit("/", 1)[-1]
-                if "/" in resource_name
-                else resource_name
-            )
+            marker = resource_name.find("spiffe://")
+            spiffe_id = resource_name[marker:] if marker != -1 else resource_name
 
             if not spiffe_id:
+                continue
+
+            if spiffe_id in agents:
+                logger.warning(
+                    "agent_registry_adapter: duplicate agent identity '%s' in "
+                    "registry response — keeping the first entry and skipping the "
+                    "later one to avoid authorization grant substitution.",
+                    spiffe_id,
+                )
                 continue
 
             allowed_tools: list[str] = [

--- a/tests/test_agent_registry_adapter.py
+++ b/tests/test_agent_registry_adapter.py
@@ -377,11 +377,54 @@ class TestAgentRegistryAdapter:
 
         assert catalog.is_valid is True
         assert len(catalog.agents) == 1
-        # The adapter extracts the last path segment of the resource name as the key.
-        # Resource name: ".../agents/spiffe://cage/agent/foo" → last segment = "foo"
+        # The catalog key is the full spiffe:// identity, matching agent_catalog.rego
+        # (approved_agents[input.caller_identity.sub]) and config/agent_catalog.json.
+        # Resource name: ".../agents/spiffe://cage/agent/foo" → "spiffe://cage/agent/foo".
         spiffe_id = list(catalog.agents.keys())[0]
-        assert spiffe_id == "foo"
+        assert spiffe_id == "spiffe://cage/agent/foo"
         assert "execute_trade" in catalog.agents[spiffe_id]["allowed_tools"]
+
+    def test_parse_registry_response_keys_on_full_spiffe_identity(self):
+        """Distinct SPIFFE identities sharing a trailing segment must not collide.
+
+        agent_catalog.rego and config/agent_catalog.json key on the full
+        spiffe:// identity; keying on only the last path segment would collapse
+        e.g. two different-namespace service accounts named 'trader-agent' onto
+        one catalog entry, substituting one agent's tool grants for another's.
+        """
+        from src.gateway.governance.ingress.agent_registry_adapter import (
+            AgentRegistryAdapter,
+        )
+
+        raw = {
+            "agents": [
+                {
+                    "name": "projects/p/locations/l/agentRegistries/r/agents/spiffe://trust-domain/ns/default/sa/trader-agent",
+                    "labels": {"role": "trader"},
+                    "toolAuthorizations": [{"toolName": "get_market_data"}],
+                },
+                {
+                    "name": "projects/p/locations/l/agentRegistries/r/agents/spiffe://attacker-domain/ns/evil/sa/trader-agent",
+                    "labels": {"role": "admin"},
+                    "toolAuthorizations": [
+                        {"toolName": "execute_trade"},
+                        {"toolName": "wire_transfer"},
+                    ],
+                },
+            ]
+        }
+
+        agents = AgentRegistryAdapter()._parse_registry_response(raw)
+
+        # Both full identities are preserved as separate keys.
+        assert set(agents) == {
+            "spiffe://trust-domain/ns/default/sa/trader-agent",
+            "spiffe://attacker-domain/ns/evil/sa/trader-agent",
+        }
+        # The low-privilege agent did not inherit the other's grants.
+        assert agents["spiffe://trust-domain/ns/default/sa/trader-agent"][
+            "allowed_tools"
+        ] == ["get_market_data"]
 
     @pytest.mark.asyncio
     async def test_fetch_catalog_returns_error_on_http_failure(self, configured_env):


### PR DESCRIPTION
## Summary

`_parse_registry_response` keys the OPA agent catalog on the last path segment of each GEAP resource name, but that name embeds the full `spiffe://` identity and `agent_catalog.rego` (`approved_agents[input.caller_identity.sub]`) and `config/agent_catalog.json` both key on the whole identity. Two registered agents whose SPIFFE IDs share a trailing segment, such as the same service-account name in different namespaces or trust domains, collapse onto one catalog key, so the second entry overwrites the first agent's `allowed_tools` and `roles` and one identity inherits the other's grants. The parser now keys on the full `spiffe://` identity and skips a repeated identity instead of overwriting it.

## Type of Change

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `refactor` — no feature/fix, code restructuring
- [ ] `perf` — performance improvement
- [ ] `test` — test additions or corrections
- [ ] `chore` — build, deps, tooling
- [ ] `ci` — CI/CD pipeline
- [ ] `BREAKING CHANGE` — existing behaviour changes

## Related Issues / ADRs

N/A

## Changes Made

- `src/gateway/governance/ingress/agent_registry_adapter.py` — derive the catalog key from the full `spiffe://` identity in the resource name rather than the final `/`-segment, and skip a duplicate identity (log a warning) instead of silently replacing an earlier agent's grants.
- `tests/test_agent_registry_adapter.py` — update the resource-name test to expect the full `spiffe://` identity, and add a regression where two agents whose SPIFFE IDs share a trailing segment stay distinct and do not swap tool grants.

## Testing

- [x] Unit tests added / updated (`pytest tests/`)
- [ ] Integration tests pass (`make test-integration`)
- [ ] Manual smoke test performed (describe below)
- [ ] No tests needed (docs/config only — explain why)

**Manual test steps (if applicable):**
```
uv run pytest tests/test_agent_registry_adapter.py tests/test_agent_catalog.py -q --no-cov
# 58 passed. The new test_parse_registry_response_keys_on_full_spiffe_identity
# fails on the pre-patch tree (both agents collapse to key 'trader-agent') and
# passes after the change.
uv run ruff check src/gateway/governance/ingress/agent_registry_adapter.py
uv run mypy src/gateway/governance/ingress/agent_registry_adapter.py
```

## Compliance & Security Checklist

### 🔒 Universal — All contributors must verify (all regions affected)

- [x] No secrets, credentials, or PII in committed files
- [x] Network policy unchanged **or** reviewed by security owner
- [x] OPA policy changes reviewed for correctness (no `.rego` change; `agent_catalog.rego` already keys on the full identity — this aligns the data document it consumes)
- [x] **Data residency:** no new storage path, GCS write, Langfuse sink, or telemetry export introduced
- [x] **ISO 42001 / CSA AARM:** Lula assertions unaffected
- [x] **No region-specific behaviour introduced without a `cage_deployment_region` guard** — the fix is identity-keying only and behaves identically in every region

### 🎯 Region-specific depth

**US_FED**
- [x] N/A — no region-specific behaviour; the change applies uniformly

**EU_ECB**
- [x] N/A — no region-specific behaviour; the change applies uniformly

**APAC_MAS**
- [x] N/A — no region-specific behaviour; the change applies uniformly

### 📋 Shared-module impact declaration

- [ ] Not applicable — PR does not touch shared compliance modules
- [x] **Impact assessed across all three regions**

**Cross-region impact summary (if applicable):**
```
US_FED impact:  agent-catalog authorization keys now match the full SPIFFE identity used by agent_catalog.rego and config/agent_catalog.json; no posture change.
EU_ECB impact:  same identity-keying fix; no posture change.
APAC_MAS impact: same identity-keying fix; no posture change.
```

## Deployment Notes

N/A

## PR Title Format

`fix(governance): key agent catalog on full spiffe id, not last segment`
