### PR TITLE
fix(governance): mark Redis EVALSHA script SHA1 as non-cryptographic

### DIFF
--- a/src/gateway/governance/routing_seal.py
+++ b/src/gateway/governance/routing_seal.py
@@ -775,7 +775,9 @@ async def _atomic_burn_nonce(
     # Note: We compute SHA1 of the script to match Redis's script SHA
     import hashlib as _hashlib
 
-    _ATOMIC_BURN_NONCE_SHA = _hashlib.sha1(_ATOMIC_BURN_NONCE_LUA.encode()).hexdigest()
+    _ATOMIC_BURN_NONCE_SHA = _hashlib.sha1(
+        _ATOMIC_BURN_NONCE_LUA.encode(), usedforsecurity=False
+    ).hexdigest()
 
     return int(result)
 


### PR DESCRIPTION
Resolves Bandit B324 (high severity) introduced in #96 (commit 24150e8).

Add `usedforsecurity=False` to `hashlib.sha1()` call used for Redis EVALSHA script caching. This SHA1 is computed to match Redis's internal script identifier mechanism, not for cryptographic security purposes.

**Changes:**
- Add `usedforsecurity=False` parameter to SHA1 computation in `routing_seal.py:778`

**Testing:**
- ✅ All 23 routing seal tests pass
- ✅ Bandit scan now reports 0 High severity issues (was 1)

**Closes:** None (this is a SAST hygiene fix)

**Compliance impact:** None — this is a clarification of non-cryptographic usage, not a security downgrade.