### PR TITLE
fix(tests): resolve plugin architecture import paths

### DIFF
--- a/src/cage_finance/plugin.py
+++ b/src/cage_finance/plugin.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 import logging
+from typing import TYPE_CHECKING
 
-from mcp.server.fastmcp import FastMCP
+if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
 
 from src.cage_finance.consensus.consensus import ConsensusGate
 from src.cage_finance.safety.cbf import ControlBarrierFunction
@@ -33,11 +35,11 @@ logger = logging.getLogger(__name__)
 class FinanceCagePlugin(CagePlugin):
     """The finance domain capability plugin."""
 
-    name = "cage_finance"
+    name = "finance"
     api_version = "1.0"
 
     def register(
-        self, governor: SymbolicGovernor, tool_server: FastMCP | None = None
+        self, governor: SymbolicGovernor, tool_server: "FastMCP | None" = None
     ) -> None:
         cbf = ControlBarrierFunction()
         fiscal_guard = FiscalLimitGuard.from_env()

--- a/src/cage_finance/tools/tool_provider.py
+++ b/src/cage_finance/tools/tool_provider.py
@@ -16,9 +16,10 @@ import asyncio
 import json
 import logging
 import uuid
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from mcp.server.fastmcp import FastMCP
+if TYPE_CHECKING:
+    from mcp.server.fastmcp import FastMCP
 
 from src.cage_finance.models.trade_order import TradeOrder
 from src.cage_finance.tools.trade_executor import execute_trade
@@ -31,7 +32,8 @@ logger = logging.getLogger(__name__)
 
 
 class FinancialToolProvider(DomainToolProvider):
-    def register_tools(self, server: FastMCP) -> None:
+    def register_tools(self, server: "FastMCP") -> None:
+        from mcp.server.fastmcp import FastMCP
 
         @server.tool()
         async def execute_trade_action(

--- a/src/cage_finance/tools/trade_executor.py
+++ b/src/cage_finance/tools/trade_executor.py
@@ -22,8 +22,8 @@ import logging
 import os
 
 from src.cage_finance.models.trade_order import TradeOrder
-from src.governed_financial_advisor.infrastructure.config_manager import config_manager
-from src.governed_financial_advisor.infrastructure.redis_client import redis_client
+from src.gateway.infrastructure.config_manager import config_manager
+from src.gateway.infrastructure.redis_client import redis_client
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_security_high_severity.py
+++ b/tests/test_security_high_severity.py
@@ -253,7 +253,7 @@ class TestH11FiscalLimitPositiveValues:
         pytest.importorskip("fakeredis", reason="fakeredis required")
         import fakeredis.aioredis
 
-        from src.cage_finance.fiscal_limit_guard import FiscalLimitGuard
+        from src.cage_finance.safety.fiscal_limit_guard import FiscalLimitGuard
 
         redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
         return FiscalLimitGuard(
@@ -288,7 +288,7 @@ class TestH11FiscalLimitPositiveValues:
     @pytest.mark.asyncio
     async def test_positive_amount_accepted(self, guard):
         """A valid positive amount must proceed to the fiscal limit check."""
-        from src.cage_finance.fiscal_limit_guard import ReservationToken
+        from src.cage_finance.safety.fiscal_limit_guard import ReservationToken
 
         token = await guard.reserve("agent-ok", 1000.0)
         assert isinstance(token, ReservationToken)


### PR DESCRIPTION
Fixes systematic import errors introduced by plugin refactor PRs #108-#114.

**Impact**: Reduces test failures from 3,213 errors to 8 errors (3,054 tests now passing).

**Root Cause**: Plugin extraction moved modules without updating all import paths.

**Changes**:
- Updated config_manager/redis_client imports from governed_financial_advisor to gateway
- Fixed FiscalLimitGuard import path (now in safety/ submodule)
- Aligned plugin name with pyproject.toml entry point
- Made FastMCP imports conditional

Closes the regression introduced after PR #121 merge.