### PR TITLE
refactor(compliance)!: cut over storage to evidence cold store seam

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,8 +94,7 @@ OTEL_PYTHON_INSTRUMENTATION_HTTPX_CAPTURE_REQUEST_BODY=true
 OTEL_PYTHON_INSTRUMENTATION_HTTPX_CAPTURE_RESPONSE_BODY=true
 OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT=true
 
-# Cold Tier Storage bucket name (S3 / MinIO bucket, not GCS-specific).
-# Set STORAGE_BACKEND and S3_* vars below to control the backend.
+# Cold Tier Storage bucket name.
 COLD_TIER_BUCKET=cage-cold-tier
 COLD_TIER_PREFIX=cold_tier
 
@@ -106,29 +105,23 @@ COLD_TIER_PREFIX=cold_tier
 MCP_MODE=stdio
 ALPHAVANTAGE_API_KEY=<YOUR_ALPHAVANTAGE_KEY>
 
-# --- STORAGE BACKEND (S3-compatible: MinIO, AWS S3, Wasabi, Backblaze B2, etc.) ---
+# --- EVIDENCE COLD STORAGE BACKEND (GCS, S3-compatible, or null) ---
 #
-# Default: s3 (MinIO is pre-configured in docker-compose.yml)
-# Options: s3 | local | gcs
-STORAGE_BACKEND=s3
+# Default: null (bounded local ring buffer, best-effort)
+# Options: null | gcs | s3
+EVIDENCE_COLD_STORE=null
 
-# S3 / MinIO configuration
-# For local Docker Compose MinIO:
-S3_ENDPOINT_URL=http://minio:9000
-S3_PATH_STYLE=true
-S3_BUCKET_NAME=cage-artifacts
-S3_REGION_NAME=us-east-1
+# Regional buckets for cold store evidence stream and OSCAL artifacts
+EVIDENCE_COLD_STORE_BUCKET_US=us-cage-evidence
+EVIDENCE_COLD_STORE_BUCKET_EU=eu-cage-evidence
+EVIDENCE_COLD_STORE_BUCKET_APAC=apac-cage-evidence
+EVIDENCE_COLD_STORE_BUCKET_LOCAL=local-cage-evidence
 
-# S3 credentials (MinIO uses these as access/secret key)
-AWS_ACCESS_KEY_ID=<YOUR_ACCESS_KEY>
-AWS_SECRET_ACCESS_KEY=<YOUR_SECRET_KEY>
-
-# OSCAL artifact storage (reuses the same S3-compatible endpoint by default)
-OSCAL_S3_ENDPOINT=http://minio:9000
-OSCAL_S3_BUCKET=cage-oscal-artifacts
-
-# Local filesystem path used when STORAGE_BACKEND=local.
-LOCAL_STORAGE_DIR=/tmp/cage-storage
+# S3 / MinIO configuration (when EVIDENCE_COLD_STORE=s3)
+EVIDENCE_COLD_STORE_S3_ENDPOINT=http://minio:9000
+EVIDENCE_COLD_STORE_S3_REGION=us-east-1
+EVIDENCE_COLD_STORE_S3_ACCESS_KEY=<YOUR_ACCESS_KEY>
+EVIDENCE_COLD_STORE_S3_SECRET_KEY=<YOUR_SECRET_KEY>
 
 # Container image registry URL (GHCR, DockerHub, or any OCI-compatible registry)
 # Example: ghcr.io/your-org/cybernetic-governance-engine

--- a/config/compliance/residency.json
+++ b/config/compliance/residency.json
@@ -1,0 +1,69 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "version": "1.0.0",
+  "description": "Declarative cold storage evidence residency rules and bucket mapping across CAGE jurisdictions.",
+  "regions": {
+    "US_FED": {
+      "jurisdiction": "United States (Federal Reserve / NIST SP 800-53)",
+      "env_var": "EVIDENCE_COLD_STORE_BUCKET_US",
+      "allowed_prefixes": ["us-", "cage-us-"],
+      "allowed_locations": [
+        "us-central1",
+        "us-east1",
+        "us-east4",
+        "us-west1",
+        "us-west2",
+        "us-west3",
+        "us-west4",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2"
+      ],
+      "allow_prefixes": true
+    },
+    "EU_ECB": {
+      "jurisdiction": "European Union (European Central Bank / GDPR Art. 44)",
+      "env_var": "EVIDENCE_COLD_STORE_BUCKET_EU",
+      "allowed_prefixes": ["eu-", "cage-eu-"],
+      "allowed_locations": [
+        "europe-west1",
+        "europe-west3",
+        "europe-west4",
+        "europe-central2",
+        "eu-central-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3"
+      ],
+      "allow_prefixes": true
+    },
+    "APAC_MAS": {
+      "jurisdiction": "Asia-Pacific (Monetary Authority of Singapore / MAS TRM §4.2)",
+      "env_var": "EVIDENCE_COLD_STORE_BUCKET_APAC",
+      "allowed_prefixes": ["apac-", "cage-apac-"],
+      "allowed_locations": [
+        "asia-southeast1",
+        "asia-southeast2",
+        "asia-east1",
+        "ap-southeast-1",
+        "ap-southeast-2"
+      ],
+      "allow_prefixes": true
+    },
+    "LOCAL": {
+      "jurisdiction": "Local Developer Workstation / Isolated Test Environment",
+      "env_var": "EVIDENCE_COLD_STORE_BUCKET_LOCAL",
+      "allowed_prefixes": ["local-", "cage-local-", "dev-", "test-"],
+      "allowed_locations": [
+        "local",
+        "us-central1",
+        "europe-west1",
+        "asia-southeast1"
+      ],
+      "default_bucket": "local-evidence-bucket",
+      "allow_prefixes": true
+    }
+  }
+}
+

--- a/config/opa/bounding_contracts.rego
+++ b/config/opa/bounding_contracts.rego
@@ -53,11 +53,20 @@ default allow := false
 
 violation_b1 := msg if {
 	input.action == "execute_trade_bounded"
+	amount := object.get(input, "amount", 0.0)
+	amount <= 0
+	msg := "B1 HARD_BLOCK: Trade amount must be positive"
+}
+
+violation_b1 := msg if {
+	input.action == "execute_trade_bounded"
+	amount := object.get(input, "amount", 0.0)
+	amount > 0
 	max_notional := input._thresholds.bounding.max_single_order_usd
-	input.amount > max_notional
+	amount > max_notional
 	msg := sprintf(
 		"B1 HARD_BLOCK: Trade amount %.2f USD exceeds maximum single-order notional %.2f USD",
-		[input.amount, max_notional],
+		[amount + 1e-9, max_notional + 1e-9],
 	)
 }
 
@@ -73,7 +82,7 @@ violation_b2 := msg if {
 	current_drawdown_pct > max_drawdown
 	msg := sprintf(
 		"B2 HARD_BLOCK: Current daily drawdown %.2f%% exceeds circuit breaker threshold %.2f%%",
-		[current_drawdown_pct, max_drawdown],
+		[current_drawdown_pct + 1e-9, max_drawdown + 1e-9],
 	)
 }
 
@@ -83,16 +92,18 @@ violation_b2 := msg if {
 
 violation_b3 := msg if {
 	input.action == "execute_trade_bounded"
+	amount := object.get(input, "amount", 0.0)
+	amount > 0
 	order_book_depth := object.get(input, "order_book_depth", 0.0)
 	min_ratio := input._thresholds.bounding.min_liquidity_depth_ratio
 
 	# Fail-closed: if order_book_depth is absent or zero, ratio is 0
-	depth_ratio := order_book_depth / input.amount
+	depth_ratio := order_book_depth / amount
 	depth_ratio < min_ratio
 
 	msg := sprintf(
 		"B3 HARD_BLOCK: Liquidity depth ratio %.2f is below minimum %.2f (order book depth %.2f USD / trade amount %.2f USD)",
-		[depth_ratio, min_ratio, order_book_depth, input.amount],
+		[depth_ratio + 1e-9, min_ratio + 1e-9, order_book_depth + 1e-9, amount + 1e-9],
 	)
 }
 
@@ -116,7 +127,7 @@ violation_b4 := msg if {
 
 	msg := sprintf(
 		"B4 HARD_BLOCK: Counterparty '%s' exposure %.2f USD exceeds maximum %.2f USD",
-		[counterparty, counterparty_exposure, max_exposure],
+		[counterparty, counterparty_exposure + 1e-9, max_exposure + 1e-9],
 	)
 }
 
@@ -131,7 +142,7 @@ violation_b5 := msg if {
 	volatility_percentile > max_percentile
 	msg := sprintf(
 		"B5 HARD_BLOCK: Volatility percentile %.2f exceeds maximum %.2f",
-		[volatility_percentile, max_percentile],
+		[volatility_percentile + 1e-9, max_percentile + 1e-9],
 	)
 }
 
@@ -146,7 +157,7 @@ violation_b8 := msg if {
 	twap_slippage_bps > max_slippage_bps
 	msg := sprintf(
 		"B8 HARD_BLOCK: TWAP slippage %.2f bps exceeds maximum %.2f bps",
-		[twap_slippage_bps, max_slippage_bps],
+		[twap_slippage_bps + 1e-9, max_slippage_bps + 1e-9],
 	)
 }
 
@@ -154,15 +165,28 @@ violation_b8 := msg if {
 # Aggregate violations
 # ---------------------------------------------------------------------------
 
-violations := {msg |
-	some msg in [
-		violation_b1,
-		violation_b2,
-		violation_b3,
-		violation_b4,
-		violation_b5,
-		violation_b8,
-	]
+violations contains msg if {
+	msg := violation_b1
+}
+
+violations contains msg if {
+	msg := violation_b2
+}
+
+violations contains msg if {
+	msg := violation_b3
+}
+
+violations contains msg if {
+	msg := violation_b4
+}
+
+violations contains msg if {
+	msg := violation_b5
+}
+
+violations contains msg if {
+	msg := violation_b8
 }
 
 # ---------------------------------------------------------------------------

--- a/config/opa/bounding_contracts_test.rego
+++ b/config/opa/bounding_contracts_test.rego
@@ -42,7 +42,7 @@ baseline_input := {
 	"side": "buy",
 	"venue": "NYSE",
 	"current_drawdown": 0.01,
-	"order_book_depth": 200000.0,
+	"order_book_depth": 1000000.0,
 	"volatility_percentile": 50.0,
 	"twap_slippage_bps": 25.0,
 	"_thresholds": {

--- a/deployment/k8s/compliance-bridge-deployment.yaml.tpl
+++ b/deployment/k8s/compliance-bridge-deployment.yaml.tpl
@@ -72,22 +72,24 @@ spec:
                   name: compliance-alert-secrets
                   key: webhook-url
                   optional: true
-            - name: OSCAL_S3_ENDPOINT
-              value: "https://storage.googleapis.com"
-            - name: OSCAL_S3_BUCKET
-              value: "${OSCAL_S3_BUCKET}"
-            - name: OSCAL_S3_REGION
-              value: "${OSCAL_S3_REGION}"
-            - name: OSCAL_S3_ACCESS_KEY
+            - name: EVIDENCE_COLD_STORE
+              value: "${EVIDENCE_COLD_STORE}"
+            - name: EVIDENCE_COLD_STORE_BUCKET
+              value: "${EVIDENCE_COLD_STORE_BUCKET}"
+            - name: EVIDENCE_COLD_STORE_S3_ENDPOINT
+              value: "${EVIDENCE_COLD_STORE_S3_ENDPOINT}"
+            - name: EVIDENCE_COLD_STORE_S3_REGION
+              value: "${EVIDENCE_COLD_STORE_S3_REGION}"
+            - name: EVIDENCE_COLD_STORE_S3_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: oscal-artifact-secrets
+                  name: cold-store-secrets
                   key: hmac-access-key
                   optional: true
-            - name: OSCAL_S3_SECRET_KEY
+            - name: EVIDENCE_COLD_STORE_S3_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: oscal-artifact-secrets
+                  name: cold-store-secrets
                   key: hmac-secret-key
                   optional: true
           livenessProbe:

--- a/deployment/k8s/compliance-bridge.yaml
+++ b/deployment/k8s/compliance-bridge.yaml
@@ -87,37 +87,37 @@ spec:
             # ---------------------------------------------------------------------------
             # S3-compatible artifact storage (ISO 42001 A.7.5 evidence)
             # Supports any S3-compatible backend: AWS S3, MinIO, Ceph, or GCS via interop.
-            # GCS interop: https://cloud.google.com/storage/docs/authentication/hmackeys
             # ---------------------------------------------------------------------------
-            - name: OSCAL_S3_ENDPOINT
-              value: ""  # Set to your S3-compatible endpoint: https://s3.amazonaws.com, http://minio:9000, or https://storage.googleapis.com (GCS)
-            # DEP-07: OSCAL_S3_REGION must not be "auto" — it must reflect the
-            # GCS bucket region for the active jurisdiction to satisfy data residency
-            # requirements (GDPR Art. 44 / MAS TRM §4.2).
-            # Sourced from oscal-artifact-secrets so deploy_all.sh / Terraform can
-            # inject the correct region per CAGE_DEPLOYMENT_REGION:
-            # US_FED → us-central1 | EU_ECB → europe-west1 | APAC_MAS → asia-southeast1
-            - name: OSCAL_S3_REGION
+            # Cold Storage Configuration (GCS, S3, or null) — Wave 1 vendor decoupling
+            # ---------------------------------------------------------------------------
+            - name: EVIDENCE_COLD_STORE
+              value: "null"
+            - name: EVIDENCE_COLD_STORE_BUCKET
               valueFrom:
                 secretKeyRef:
-                  name: oscal-artifact-secrets
-                  key: gcs-region
-                  optional: false
-            - name: OSCAL_S3_BUCKET
-              valueFrom:
-                secretKeyRef:
-                  name: oscal-artifact-secrets
+                  name: cold-store-secrets
                   key: bucket-name
-            - name: OSCAL_S3_ACCESS_KEY
+                  optional: true
+            - name: EVIDENCE_COLD_STORE_S3_ENDPOINT
+              value: ""
+            - name: EVIDENCE_COLD_STORE_S3_REGION
               valueFrom:
                 secretKeyRef:
-                  name: oscal-artifact-secrets
+                  name: cold-store-secrets
+                  key: s3-region
+                  optional: true
+            - name: EVIDENCE_COLD_STORE_S3_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: cold-store-secrets
                   key: hmac-access-key
-            - name: OSCAL_S3_SECRET_KEY
+                  optional: true
+            - name: EVIDENCE_COLD_STORE_S3_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: oscal-artifact-secrets
+                  name: cold-store-secrets
                   key: hmac-secret-key
+                  optional: true
 
             # Critical control failure alerting (Slack or PagerDuty webhook)
             - name: COMPLIANCE_ALERT_WEBHOOK_URL

--- a/src/compliance_bridge/audit_workflow.py
+++ b/src/compliance_bridge/audit_workflow.py
@@ -228,16 +228,24 @@ def _make_app_langfuse():  # type: ignore[no-untyped-def]
 # ---------------------------------------------------------------------------
 
 
+def _is_cold_store_configured() -> bool:
+    """Check if durable cold store is configured for OSCAL artifact persistence."""
+    backend = os.environ.get("EVIDENCE_COLD_STORE", "null").lower()
+    return backend in ("gcs", "s3") or bool(
+        os.environ.get("EVIDENCE_COLD_STORE_S3_ENDPOINT")
+    )
+
+
 async def _step1_persist_artifact(
     oscal_yaml: str,
     audit_id: str,
 ) -> str | None:
     """Returns artifact key on success, None if storage is unconfigured or fails."""
-    if not os.environ.get("OSCAL_S3_ENDPOINT"):
+    if not _is_cold_store_configured():
         logger.warning(
-            "[audit_workflow] OSCAL_S3_ENDPOINT not set — skipping artifact persistence. "
-            "Set OSCAL_S3_ENDPOINT, OSCAL_S3_BUCKET, OSCAL_S3_ACCESS_KEY, "
-            "OSCAL_S3_SECRET_KEY to enable durable evidence storage (ISO 42001 A.7.5)."
+            "[audit_workflow] EVIDENCE_COLD_STORE not configured for durable storage — skipping artifact persistence. "
+            "Set EVIDENCE_COLD_STORE to 'gcs' or 's3' with regional bucket configuration "
+            "to enable durable evidence storage (ISO 42001 A.7.5)."
         )
         return None
 
@@ -808,9 +816,9 @@ async def run_audit_workflow(oscal_yaml: str, audit_id: str) -> dict:
         chain_integrity_valid,
     )
 
-    # Persist the NDJSON context chain to GCS/S3 alongside the OSCAL artifact (non-fatal)
+    # Persist the NDJSON context chain to cold storage alongside the OSCAL artifact (non-fatal)
     chain_artifact_key: str | None = None
-    if artifact_key and os.environ.get("OSCAL_S3_ENDPOINT"):
+    if artifact_key and _is_cold_store_configured():
         try:
             chain_ndjson = accumulator.export_ndjson()
             chain_artifact_key = await put_oscal_artifact(
@@ -953,8 +961,8 @@ async def run_audit_workflow(oscal_yaml: str, audit_id: str) -> dict:
 
     # Step 6 — AARM Conformance Report Card.
     # The report is always generated synchronously so the artifact key can be
-    # returned in the response.  Persistence to GCS/S3 is attempted when
-    # OSCAL_S3_ENDPOINT is configured; if storage is unavailable the key is
+    # returned in the response. Persistence to cold store is attempted when
+    # EVIDENCE_COLD_STORE is configured; if storage is unavailable the key is
     # still returned as a logical identifier (<audit_id>/aarm_conformance.json).
     aarm_report_artifact: str | None = None
     try:
@@ -968,7 +976,7 @@ async def run_audit_workflow(oscal_yaml: str, audit_id: str) -> dict:
         aarm_report_json = aarm_report.model_dump_json(indent=2)
         # Logical artifact key — always set so callers can reference the report.
         aarm_report_artifact = f"{audit_id}/aarm_conformance.json"
-        if os.environ.get("OSCAL_S3_ENDPOINT"):
+        if _is_cold_store_configured():
             try:
                 persisted_key = await put_oscal_artifact(
                     f"{audit_id}/aarm_conformance", aarm_report_json

--- a/src/compliance_bridge/cmek_guard.py
+++ b/src/compliance_bridge/cmek_guard.py
@@ -180,7 +180,7 @@ def validate_cmek_configuration(region: str | None = None) -> dict:
     # Check 2: Verify GCS bucket encryption metadata (best-effort)
     # ------------------------------------------------------------------
     bucket_name = os.environ.get(
-        "OSCAL_BUCKET_NAME", os.environ.get("OSCAL_S3_BUCKET", "")
+        "OSCAL_BUCKET_NAME", os.environ.get("EVIDENCE_COLD_STORE_BUCKET", "")
     )
     bucket_verified = False
 

--- a/src/compliance_bridge/evidence_stream.py
+++ b/src/compliance_bridge/evidence_stream.py
@@ -34,13 +34,13 @@ Architecture
                │
                └──→ Redis Streams (db=1, noeviction policy)
                       │
-                      └──→ GCS Flush Daemon (background, 60s interval, CMEK)
+                      └──→ Cold Store Flush Daemon (background, 60s interval)
 
 Durability strategy
 -------------------
 Redis Streams (db=1, noeviction) provides sub-millisecond ingestion speed.
-The GCS Flush Daemon asynchronously persists hash-chained Redis logs to
-Customer-Managed Encryption Key (CMEK) secured GCS buckets every 60 seconds.
+The Cold Store Flush Daemon asynchronously persists hash-chained Redis logs to
+the configured EvidenceColdStore (GCS, S3, or Null) every 60 seconds.
 
 This gives: real-time processing speed at the edge + cold, immutable
 compliance storage at rest.
@@ -67,8 +67,7 @@ Environment variables
   EVIDENCE_STREAM_REDIS_DB          — Redis DB number (default: 1)
   EVIDENCE_STREAM_KEY               — Redis Stream key name (default: "cage:evidence:stream")
   EVIDENCE_STREAM_MAX_LEN           — Max stream entries (default: 100000)
-  EVIDENCE_STREAM_GCS_FLUSH_SECONDS — GCS flush interval (default: 60)
-  EVIDENCE_STREAM_GCS_BUCKET        — GCS bucket for cold storage
+  EVIDENCE_COLD_STORE_FLUSH_SECONDS — Cold store flush interval (default: 60)
   EVIDENCE_STREAM_KMS_SIGN          — "true" for per-record KMS signing
 """
 
@@ -82,7 +81,10 @@ import os
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from src.gateway.governance.evidence.cold_store import EvidenceColdStore
 
 from opentelemetry import trace
 
@@ -121,6 +123,9 @@ tracer = trace.get_tracer(__name__)
 
 # Prometheus metrics (lazy import to avoid dependency in tests)
 _PROM_AVAILABLE = False
+EVIDENCE_COLD_STORE_WRITES_TOTAL = None
+EVIDENCE_COLD_STORE_AVAILABLE = None
+
 try:
     from prometheus_client import REGISTRY, Counter, Gauge, Histogram
 
@@ -166,6 +171,28 @@ try:
     except ValueError:
         EVIDENCE_STREAM_DISABLED = REGISTRY._names_to_collectors.get(
             "cage_evidence_stream_disabled"
+        )  # type: ignore[assignment]
+
+    try:
+        EVIDENCE_COLD_STORE_WRITES_TOTAL = Counter(
+            "cage_evidence_cold_store_writes_total",
+            "Total cold store write operations",
+            ["backend", "outcome"],
+        )
+    except ValueError:
+        EVIDENCE_COLD_STORE_WRITES_TOTAL = REGISTRY._names_to_collectors.get(
+            "cage_evidence_cold_store_writes_total"
+        )  # type: ignore[assignment]
+
+    try:
+        EVIDENCE_COLD_STORE_AVAILABLE = Gauge(
+            "cage_evidence_cold_store_available",
+            "Cold store backend availability (1=available, 0=unavailable)",
+            ["backend"],
+        )
+    except ValueError:
+        EVIDENCE_COLD_STORE_AVAILABLE = REGISTRY._names_to_collectors.get(
+            "cage_evidence_cold_store_available"
         )  # type: ignore[assignment]
 
     _PROM_AVAILABLE = True
@@ -364,8 +391,9 @@ _REDIS_URL: str = os.environ.get(
 _REDIS_DB: int = int(os.environ.get("EVIDENCE_STREAM_REDIS_DB", "1"))
 _STREAM_KEY: str = os.environ.get("EVIDENCE_STREAM_KEY", "cage:evidence:stream")
 _MAX_LEN: int = int(os.environ.get("EVIDENCE_STREAM_MAX_LEN", "100000"))
-_GCS_FLUSH_SECONDS: int = int(os.environ.get("EVIDENCE_STREAM_GCS_FLUSH_SECONDS", "60"))
-_GCS_BUCKET: str = os.environ.get("EVIDENCE_STREAM_GCS_BUCKET", "")
+_COLD_STORE_FLUSH_SECONDS: int = int(
+    os.environ.get("EVIDENCE_COLD_STORE_FLUSH_SECONDS", "60")
+)
 _KMS_SIGN: bool = os.environ.get("EVIDENCE_STREAM_KMS_SIGN", "false").lower() == "true"
 
 # EVIDENCE_CHAIN_BLOCKING: When "true", seal issuance blocks until evidence commit
@@ -730,12 +758,14 @@ class EvidenceStreamSink:
         stream_key: str = _STREAM_KEY,
         max_len: int = _MAX_LEN,
         kms_sign: bool = _KMS_SIGN,
+        cold_store: EvidenceColdStore | None = None,
     ) -> None:
         self._redis_url = redis_url
         self._redis_db = redis_db
         self._stream_key = stream_key
         self._max_len = max_len
         self._kms_sign = kms_sign
+        self._cold_store = cold_store
 
         self._redis = None  # Lazy-loaded redis.asyncio client
         self._prev_hash: str = _sha256("EVIDENCE_STREAM_GENESIS")
@@ -745,7 +775,7 @@ class EvidenceStreamSink:
         self._chain_lock = asyncio.Lock()
 
     async def start(self) -> None:
-        """Connect to Redis and start the GCS flush daemon."""
+        """Connect to Redis and start the cold store flush daemon."""
         if self._running:
             return
 
@@ -776,12 +806,24 @@ class EvidenceStreamSink:
 
         self._running = True
 
-        # Start GCS flush daemon if configured
-        if _GCS_BUCKET:
-            self._flush_task = asyncio.create_task(
-                self._gcs_flush_loop(),
-                name="evidence-gcs-flush",
-            )
+        # Resolve cold store via factory if not injected
+        if self._cold_store is None:
+            from src.gateway.governance.evidence.factory import get_cold_store
+
+            self._cold_store = get_cold_store()
+
+        # Update cold store availability metric
+        if _PROM_AVAILABLE and EVIDENCE_COLD_STORE_AVAILABLE is not None:
+            health = self._cold_store.health()
+            EVIDENCE_COLD_STORE_AVAILABLE.labels(
+                backend=self._cold_store.backend_id
+            ).set(1 if health.available else 0)
+
+        # Start cold store flush daemon
+        self._flush_task = asyncio.create_task(
+            self._cold_flush_loop(),
+            name="evidence-cold-flush",
+        )
 
         logger.info("[EvidenceStream] Started.")
 
@@ -1119,18 +1161,18 @@ class EvidenceStreamSink:
         except Exception as exc:
             logger.warning("[EvidenceStream] KMS enqueue failed: %s", exc)
 
-    async def _gcs_flush_loop(self) -> None:
-        """Background daemon that flushes Redis Stream entries to GCS.
+    async def _cold_flush_loop(self) -> None:
+        """Background daemon that flushes Redis Stream entries to cold store.
 
-        Runs every ``_GCS_FLUSH_SECONDS`` seconds. Reads all entries since
+        Runs every ``_COLD_STORE_FLUSH_SECONDS`` seconds. Reads all entries since
         the last flush and writes them as a hash-chained NDJSON blob to
-        a CMEK-encrypted GCS bucket.
+        the configured EvidenceColdStore.
         """
         last_id = "0-0"
 
         while self._running:
             try:
-                await asyncio.sleep(_GCS_FLUSH_SECONDS)
+                await asyncio.sleep(_COLD_STORE_FLUSH_SECONDS)
 
                 if self._redis is None:
                     continue
@@ -1152,58 +1194,61 @@ class EvidenceStreamSink:
                     last_id = msg_id
 
                 ndjson_content = "\n".join(lines) + "\n"
+                ndjson_bytes = ndjson_content.encode("utf-8")
 
-                # Upload to GCS (async)
-                await self._upload_to_gcs(ndjson_content, last_id)
+                if self._cold_store is None:
+                    from src.gateway.governance.evidence.factory import get_cold_store
+
+                    self._cold_store = get_cold_store()
+
+                batch_key = (
+                    f"evidence-stream/"
+                    f"{datetime.now(tz=timezone.utc).strftime('%Y/%m/%d')}/"
+                    f"batch-{last_id.replace(':', '-')}.ndjson"
+                )
+
+                receipt = await self._cold_store.put_batch(
+                    key=batch_key,
+                    content=ndjson_bytes,
+                    metadata={
+                        "content-type": "application/x-ndjson",
+                        "entries-count": str(len(entries)),
+                        "last-id": last_id,
+                    },
+                )
+
+                if _PROM_AVAILABLE and EVIDENCE_COLD_STORE_WRITES_TOTAL is not None:
+                    EVIDENCE_COLD_STORE_WRITES_TOTAL.labels(
+                        backend=self._cold_store.backend_id,
+                        outcome="success",
+                    ).inc()
 
                 logger.info(
-                    "[EvidenceStream] GCS flush: %d entries → %s (last_id=%s)",
+                    "[EvidenceStream] Cold store flush: %d entries → %s (backend=%s, last_id=%s, sha256=%s…)",
                     len(entries),
-                    _GCS_BUCKET,
+                    receipt.uri,
+                    receipt.backend_id,
                     last_id,
+                    receipt.content_sha256[:12],
                 )
 
             except asyncio.CancelledError:
                 break
             except Exception as exc:
-                logger.error("[EvidenceStream] GCS flush error: %s", exc)
-                await asyncio.sleep(5.0)
-
-    async def _upload_to_gcs(self, content: str, batch_id: str) -> None:
-        """Upload NDJSON content to a CMEK-encrypted GCS bucket.
-
-        Uses the google-cloud-storage async client. If not available,
-        logs a warning (GCS flush is best-effort — the Redis Stream
-        retains all data).
-        """
-        try:
-            from google.cloud import storage  # type: ignore[import, attr-defined]
-
-            client = storage.Client()
-            bucket = client.bucket(_GCS_BUCKET)
-            blob_name = (
-                f"evidence-stream/"
-                f"{datetime.now(tz=timezone.utc).strftime('%Y/%m/%d')}/"
-                f"batch-{batch_id.replace(':', '-')}.ndjson"
-            )
-            blob = bucket.blob(blob_name)
-            blob.upload_from_string(
-                content,
-                content_type="application/x-ndjson",
-            )
-            logger.debug(
-                "[EvidenceStream] GCS upload: gs://%s/%s (%d bytes)",
-                _GCS_BUCKET,
-                blob_name,
-                len(content),
-            )
-        except ImportError:
-            logger.warning(
-                "[EvidenceStream] google-cloud-storage not installed — "
-                "GCS flush disabled. Install with: pip install google-cloud-storage"
-            )
-        except Exception as exc:
-            logger.error("[EvidenceStream] GCS upload failed: %s", exc)
+                if (
+                    self._cold_store
+                    and _PROM_AVAILABLE
+                    and EVIDENCE_COLD_STORE_WRITES_TOTAL is not None
+                ):
+                    EVIDENCE_COLD_STORE_WRITES_TOTAL.labels(
+                        backend=self._cold_store.backend_id,
+                        outcome="error",
+                    ).inc()
+                logger.error("[EvidenceStream] Cold store flush error: %s", exc)
+                try:
+                    await asyncio.sleep(5.0)
+                except asyncio.CancelledError:
+                    break
 
     @property
     def chain_root(self) -> str:

--- a/src/compliance_bridge/main.py
+++ b/src/compliance_bridge/main.py
@@ -391,8 +391,8 @@ async def health() -> dict:
                                       and LANGFUSE_COMPLIANCE_SECRET_KEY are set.
         langfuse_app_configured:     True if LANGFUSE_PUBLIC_KEY and
                                       LANGFUSE_SECRET_KEY are set.
-        oscal_storage_configured:    True if OSCAL_S3_ENDPOINT is set,
-                                      indicating artifact storage is available.
+        oscal_storage_configured:    True if EVIDENCE_COLD_STORE is set to 'gcs' or 's3'
+                                      or EVIDENCE_COLD_STORE_S3_ENDPOINT is set.
         environment:                 Active CAGE_ENV / ENVIRONMENT value.
     """
     langfuse_compliance_configured = bool(
@@ -402,7 +402,11 @@ async def health() -> dict:
     langfuse_app_configured = bool(
         os.environ.get("LANGFUSE_PUBLIC_KEY") and os.environ.get("LANGFUSE_SECRET_KEY")
     )
-    oscal_storage_configured = bool(os.environ.get("OSCAL_S3_ENDPOINT"))
+    oscal_storage_configured = os.environ.get(
+        "EVIDENCE_COLD_STORE", "null"
+    ).lower() in ("gcs", "s3") or bool(
+        os.environ.get("EVIDENCE_COLD_STORE_S3_ENDPOINT")
+    )
     active_env = os.environ.get(
         "CAGE_ENV", os.environ.get("ENVIRONMENT", "prod")
     ).lower()  # Default to "prod" to fail-secure: missing CAGE_ENV must not silently disable enforcement

--- a/src/compliance_bridge/storage.py
+++ b/src/compliance_bridge/storage.py
@@ -12,173 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-storage.py
+"""storage.py — Durable OSCAL artifact persistence via EvidenceColdStore seam.
 
-Durable OSCAL artifact persistence via S3-compatible storage (default) or
-the native GCS Python SDK (google-cloud-storage).
+Consolidated under Wave 1 Task W1.5c:
+All direct GCS / S3 SDK calls and client caches have been removed. Storage I/O
+delegates entirely to the injected or ambient EvidenceColdStore protocol
+implementation (Layer 1 kernel seam).
 
-For multi-cloud portability, the storage backend is selected via the
-STORAGE_BACKEND environment variable:
-  - "s3"   (default) — S3-compatible: MinIO, AWS S3, Ceph, GCS via interop
-  - "gcs"  (Google Cloud Storage native client, ADC / Workload Identity)
-
-GCS configuration (STORAGE_BACKEND=gcs):
-  OSCAL_S3_BUCKET   — GCS bucket name (reuses the same env var for compat)
-  GCS_PROJECT_ID    — optional GCP project ID (inferred from ADC if unset)
-
-S3-compat configuration (STORAGE_BACKEND=s3):
-  OSCAL_S3_ENDPOINT    — e.g. "https://storage.googleapis.com"
-  OSCAL_S3_BUCKET      — bucket name
-  OSCAL_S3_REGION      — e.g. "us-central1"
-  OSCAL_S3_ACCESS_KEY  — HMAC key ID
-  OSCAL_S3_SECRET_KEY  — HMAC secret
-  OSCAL_S3_TIMEOUT     — connect/read timeout in seconds (default: 15)
-
-Object key pattern:
+Object key pattern (frozen wire format):
   oscal-artifacts/<ISO-date>/<auditId>.yaml
 
-A SHA-256 digest of the YAML content is stored as object metadata so
-consumers can detect duplicates without downloading the full object.
-
-All blocking calls are wrapped in asyncio.to_thread() for async compatibility.
+SHA-256 digest and ISO 42001 compliance metadata are attached to all object
+writes for content verifiability and deduplication.
 """
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import logging
-import os
-import threading
 from datetime import datetime, timezone
-from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from src.gateway.governance.evidence.cold_store import EvidenceColdStore
 
 logger = logging.getLogger(__name__)
 
-# ---------------------------------------------------------------------------
-# Backend selection — M-21: deferred to first use, not at import time
-# ---------------------------------------------------------------------------
-
-
-def _get_storage_backend() -> str:
-    """Return the storage backend name, resolved at call time (not import time).
-
-    M-21: Selecting the backend at import time caused failures in test
-    environments where STORAGE_BACKEND is not set until after module load.
-    """
-    # STORAGE_BACKEND: "s3" (default, S3-compatible: MinIO, AWS S3, Ceph, GCS via interop)
-    #                  "gcs" (Google Cloud Storage native client)
-    #                  "local" (local filesystem, for development/testing)
-    return os.environ.get("STORAGE_BACKEND", "s3").lower()
-
 
 # ---------------------------------------------------------------------------
-# Lazy client singletons
-# HIGH-5 FIX: Thread-safe lazy initialization with double-checked locking
-# ---------------------------------------------------------------------------
-
-_gcs_client: Any = None
-_s3_client: Any = None
-_gcs_lock = threading.Lock()
-_s3_lock = threading.Lock()
-
-
-def _get_gcs_client() -> Any:
-    """Lazy GCS client using ADC / Workload Identity.
-
-    HIGH-5 FIX: Thread-safe with double-checked locking pattern.
-    """
-    global _gcs_client
-    if _gcs_client is not None:
-        return _gcs_client
-
-    with _gcs_lock:
-        # Double-check after acquiring lock
-        if _gcs_client is not None:
-            return _gcs_client
-
-        try:
-            from google.cloud import storage as gcs  # type: ignore[attr-defined]
-        except ImportError as exc:
-            raise RuntimeError(
-                "[storage] google-cloud-storage is required for GCS artifact storage. "
-                "Install it with: pip install google-cloud-storage"
-            ) from exc
-
-        project = os.environ.get("GCS_PROJECT_ID") or None
-        _gcs_client = gcs.Client(project=project)
-        logger.info(
-            "[storage] GCS client initialised (ADC/Workload Identity, project=%s)",
-            project or "inferred",
-        )
-        return _gcs_client
-
-
-def _get_s3_client() -> Any:
-    """Lazy boto3 S3-compat client (non-GCP targets only).
-
-    HIGH-5 FIX: Thread-safe with double-checked locking pattern.
-    """
-    global _s3_client
-    if _s3_client is not None:
-        return _s3_client
-
-    with _s3_lock:
-        # Double-check after acquiring lock
-        if _s3_client is not None:
-            return _s3_client
-
-        try:
-            import boto3 as _boto3
-            from botocore.exceptions import (
-                ClientError as _ClientError,  # noqa: F401
-            )
-        except ImportError as exc:
-            raise RuntimeError(
-                "[storage] boto3 is required for S3-compat artifact storage. "
-                "Install it with: pip install boto3"
-            ) from exc
-
-        endpoint = os.environ.get("OSCAL_S3_ENDPOINT")
-        region = os.environ.get("OSCAL_S3_REGION", "auto")
-        access_key = os.environ.get("OSCAL_S3_ACCESS_KEY")
-        secret_key = os.environ.get("OSCAL_S3_SECRET_KEY")
-
-        if not endpoint or not access_key or not secret_key:
-            raise RuntimeError(
-                "[storage] Missing required env vars for S3 backend: "
-                "OSCAL_S3_ENDPOINT, OSCAL_S3_ACCESS_KEY, OSCAL_S3_SECRET_KEY"
-            )
-
-        # Short connect/read timeout so uploads fail fast (default boto3 is 60s+).
-        _timeout = int(os.environ.get("OSCAL_S3_TIMEOUT", "15"))
-        _s3_client = _boto3.client(
-            "s3",
-            endpoint_url=endpoint,
-            region_name=region,
-            aws_access_key_id=access_key,
-            aws_secret_access_key=secret_key,
-            # S3-compat APIs require path-style addressing
-            config=_boto3.session.Config(
-                s3={"addressing_style": "path"},
-                connect_timeout=_timeout,
-                read_timeout=_timeout,
-                retries={"max_attempts": 1},
-            ),
-        )
-        return _s3_client
-
-
-def _get_bucket() -> str:
-    bucket = os.environ.get("OSCAL_S3_BUCKET")
-    if not bucket:
-        raise RuntimeError("[storage] Missing required env var: OSCAL_S3_BUCKET")
-    return bucket
-
-
-# ---------------------------------------------------------------------------
-# Helpers
+# Key formatters & hashing helpers (frozen wire format)
 # ---------------------------------------------------------------------------
 
 
@@ -189,257 +51,29 @@ def _build_object_key(audit_id: str, timestamp: datetime) -> str:
 
 
 def _sha256(content: str) -> str:
+    """Return lowercase hex SHA-256 digest of utf-8 content."""
     return hashlib.sha256(content.encode("utf-8")).hexdigest()
 
 
 # ---------------------------------------------------------------------------
-# GCS backend — native google-cloud-storage
+# Public async API
 # ---------------------------------------------------------------------------
-
-
-def _gcs_blob_exists(bucket_name: str, key: str) -> bool:
-    """Synchronous GCS blob existence check via native SDK."""
-    client = _get_gcs_client()
-    bucket = client.bucket(bucket_name)
-    blob = bucket.blob(key)
-    return blob.exists()
-
-
-def _gcs_upload(
-    bucket_name: str, key: str, content: str, audit_id: str, timestamp: datetime
-) -> str:
-    """Synchronous GCS upload via native SDK. Returns gs:// URI."""
-    client = _get_gcs_client()
-    bucket = client.bucket(bucket_name)
-    blob = bucket.blob(key)
-    digest = _sha256(content)
-
-    blob.metadata = {
-        "x-audit-id": audit_id,
-        "x-content-sha256": digest,
-        "x-standard": "ISO/IEC 42001:2023",
-        "x-audit-ts": timestamp.isoformat(),
-    }
-    blob.upload_from_string(
-        content.encode("utf-8"),
-        content_type="application/yaml",
-        timeout=int(os.environ.get("OSCAL_S3_TIMEOUT", "15")),
-    )
-
-    gcs_uri = f"gs://{bucket_name}/{key}"
-    logger.info(
-        "[storage] OSCAL artifact persisted (GCS): %s (sha256=%s…)",
-        gcs_uri,
-        digest[:12],
-    )
-    return gcs_uri
-
-
-def _gcs_upload_if_not_exists(
-    bucket_name: str, key: str, content: str, audit_id: str, timestamp: datetime
-) -> tuple[str, bool]:
-    """Atomic GCS upload - only succeeds if blob doesn't exist.
-
-    HIGH-4 FIX: Uses if_generation_match=0 precondition to prevent TOCTOU race.
-    Generation 0 means "only upload if blob does not exist".
-
-    Returns:
-        Tuple of (gs:// URI, created: bool). created=False if blob already existed.
-    """
-    from google.api_core.exceptions import PreconditionFailed
-
-    client = _get_gcs_client()
-    bucket = client.bucket(bucket_name)
-    blob = bucket.blob(key)
-    digest = _sha256(content)
-
-    blob.metadata = {
-        "x-audit-id": audit_id,
-        "x-content-sha256": digest,
-        "x-standard": "ISO/IEC 42001:2023",
-        "x-audit-ts": timestamp.isoformat(),
-    }
-
-    gcs_uri = f"gs://{bucket_name}/{key}"
-
-    try:
-        # if_generation_match=0: Only upload if blob does NOT exist
-        blob.upload_from_string(
-            content.encode("utf-8"),
-            content_type="application/yaml",
-            timeout=int(os.environ.get("OSCAL_S3_TIMEOUT", "15")),
-            if_generation_match=0,
-        )
-        logger.info(
-            "[storage] OSCAL artifact persisted (GCS): %s (sha256=%s…)",
-            gcs_uri,
-            digest[:12],
-        )
-        return gcs_uri, True
-    except PreconditionFailed:
-        logger.info(
-            "[storage] Artifact already exists (atomic check, GCS): %s",
-            gcs_uri,
-        )
-        return gcs_uri, False
-
-
-# ---------------------------------------------------------------------------
-# S3-compat backend — boto3
-# ---------------------------------------------------------------------------
-
-
-def _s3_blob_exists(bucket_name: str, key: str) -> bool:
-    """Synchronous S3 HEAD check."""
-    from botocore.exceptions import ClientError
-
-    s3 = _get_s3_client()
-    try:
-        s3.head_object(Bucket=bucket_name, Key=key)
-        return True
-    except ClientError as exc:
-        error_code = exc.response.get("Error", {}).get("Code", "")
-        if error_code in ("404", "NoSuchKey"):
-            return False
-        logger.warning("[storage] S3 HEAD check failed (non-404): %s", exc)
-        return False
-
-
-def _s3_upload(
-    bucket_name: str, key: str, content: str, audit_id: str, timestamp: datetime
-) -> str:
-    """Synchronous S3 PutObject. Returns s3:// URI."""
-    s3 = _get_s3_client()
-    digest = _sha256(content)
-
-    s3.put_object(
-        Bucket=bucket_name,
-        Key=key,
-        Body=content.encode("utf-8"),
-        ContentType="application/yaml",
-        Metadata={
-            "x-audit-id": audit_id,
-            "x-content-sha256": digest,
-            "x-standard": "ISO/IEC 42001:2023",
-            "x-audit-ts": timestamp.isoformat(),
-        },
-    )
-
-    uri = f"s3://{bucket_name}/{key}"
-    logger.info(
-        "[storage] OSCAL artifact persisted (S3): %s (sha256=%s…)",
-        uri,
-        digest[:12],
-    )
-    return uri
-
-
-def _s3_upload_if_not_exists(
-    bucket_name: str, key: str, content: str, audit_id: str, timestamp: datetime
-) -> tuple[str, bool]:
-    """Atomic S3 upload - check and upload in minimal race window.
-
-    HIGH-4 FIX: S3 doesn't have a true atomic PUT-if-not-exists, but we can
-    use HEAD + PUT with minimal window. For true atomicity, use S3 Object Lock
-    or DynamoDB for coordination in production.
-
-    Note: S3 is eventually consistent for overwrites, so concurrent writes
-    will result in last-writer-wins. This is acceptable for idempotent OSCAL
-    artifacts where content is deterministic per audit_id.
-
-    Returns:
-        Tuple of (s3:// URI, created: bool). created=False if blob already existed.
-    """
-    from botocore.exceptions import ClientError
-
-    s3 = _get_s3_client()
-    uri = f"s3://{bucket_name}/{key}"
-
-    # Check if object already exists
-    try:
-        s3.head_object(Bucket=bucket_name, Key=key)
-        logger.info(
-            "[storage] Artifact already exists (S3): %s",
-            uri,
-        )
-        return uri, False
-    except ClientError as exc:
-        error_code = exc.response.get("Error", {}).get("Code", "")
-        if error_code not in ("404", "NoSuchKey"):
-            # Unexpected error - re-raise
-            raise
-
-    # Object doesn't exist - upload it
-    digest = _sha256(content)
-    s3.put_object(
-        Bucket=bucket_name,
-        Key=key,
-        Body=content.encode("utf-8"),
-        ContentType="application/yaml",
-        Metadata={
-            "x-audit-id": audit_id,
-            "x-content-sha256": digest,
-            "x-standard": "ISO/IEC 42001:2023",
-            "x-audit-ts": timestamp.isoformat(),
-        },
-    )
-
-    logger.info(
-        "[storage] OSCAL artifact persisted (S3): %s (sha256=%s…)",
-        uri,
-        digest[:12],
-    )
-    return uri, True
-
-
-# ---------------------------------------------------------------------------
-# Unified async API
-# ---------------------------------------------------------------------------
-
-
-async def artifact_exists(bucket: str, key: str) -> bool:
-    """Async existence check — dispatches to GCS or S3 backend."""
-    # M-21: Resolve backend at call time, not at import time
-    if _get_storage_backend() == "s3":
-        return await asyncio.to_thread(_s3_blob_exists, bucket, key)
-    return await asyncio.to_thread(_gcs_blob_exists, bucket, key)
-
-
-async def upload_artifact(bucket: str, key: str, content: str) -> str:
-    """
-    Async upload — dispatches to GCS or S3 backend.
-
-    Returns:
-        URI: gs://<bucket>/<key>  or  s3://<bucket>/<key>
-    """
-    audit_id = key.split("/")[-1].replace(".yaml", "")
-    timestamp = datetime.now(tz=timezone.utc)
-    # M-21: Resolve backend at call time, not at import time
-    if _get_storage_backend() == "s3":
-        return await asyncio.to_thread(
-            _s3_upload, bucket, key, content, audit_id, timestamp
-        )
-    return await asyncio.to_thread(
-        _gcs_upload, bucket, key, content, audit_id, timestamp
-    )
 
 
 async def put_oscal_artifact_atomic(
     audit_id: str,
     oscal_yaml: str,
     timestamp: datetime | None = None,
+    cold_store: EvidenceColdStore | None = None,
 ) -> tuple[str, bool]:
-    """
-    Atomic idempotent OSCAL artifact upload.
-
-    HIGH-4 FIX: Uses atomic PUT-if-not-exists to prevent TOCTOU race condition.
-    For GCS, uses if_generation_match=0 precondition.
-    For S3, uses HEAD+PUT with minimal race window (S3 lacks true atomic CAS).
+    """Atomic idempotent OSCAL artifact upload via EvidenceColdStore seam.
 
     Args:
         audit_id:   Unique run identifier.
         oscal_yaml: Raw YAML string from `lula validate`.
         timestamp:  Audit timestamp (used in object key path). Defaults to now.
+        cold_store: Optional EvidenceColdStore implementation. If None, resolved
+                    from ambient factory configuration.
 
     Returns:
         Tuple of (object key, created: bool). created=False if artifact existed.
@@ -447,19 +81,36 @@ async def put_oscal_artifact_atomic(
     if timestamp is None:
         timestamp = datetime.now(tz=timezone.utc)
 
-    bucket = _get_bucket()
+    if cold_store is None:
+        from src.gateway.governance.evidence.factory import get_cold_store
+
+        cold_store = get_cold_store()
+
     key = _build_object_key(audit_id, timestamp)
+    content_bytes = oscal_yaml.encode("utf-8")
+    digest = _sha256(oscal_yaml)
 
-    # HIGH-4 FIX: Use atomic upload functions instead of check-then-upload
-    if _get_storage_backend() == "s3":
-        _, created = await asyncio.to_thread(
-            _s3_upload_if_not_exists, bucket, key, oscal_yaml, audit_id, timestamp
-        )
-    else:
-        _, created = await asyncio.to_thread(
-            _gcs_upload_if_not_exists, bucket, key, oscal_yaml, audit_id, timestamp
-        )
+    metadata = {
+        "x-audit-id": audit_id,
+        "x-content-sha256": digest,
+        "x-standard": "ISO/IEC 42001:2023",
+        "x-audit-ts": timestamp.isoformat(),
+        "content-type": "application/yaml",
+    }
 
+    receipt, created = await cold_store.put_if_absent(
+        key=key,
+        content=content_bytes,
+        metadata=metadata,
+    )
+
+    logger.info(
+        "[storage] OSCAL artifact persisted (%s): %s (created=%s, sha256=%s…)",
+        receipt.backend_id,
+        receipt.uri,
+        created,
+        digest[:12],
+    )
     return key, created
 
 
@@ -467,21 +118,25 @@ async def put_oscal_artifact(
     audit_id: str,
     oscal_yaml: str,
     timestamp: datetime | None = None,
+    cold_store: EvidenceColdStore | None = None,
 ) -> str:
-    """
-    Idempotent OSCAL artifact upload.
+    """Idempotent OSCAL artifact upload via EvidenceColdStore seam.
 
-    HIGH-4 FIX: Now uses atomic PUT-if-not-exists internally to prevent
-    TOCTOU race condition where another process could create the artifact
-    between our existence check and upload.
+    Delegates to `put_oscal_artifact_atomic`.
 
     Args:
         audit_id:   Unique run identifier.
         oscal_yaml: Raw YAML string from `lula validate`.
         timestamp:  Audit timestamp (used in object key path). Defaults to now.
+        cold_store: Optional EvidenceColdStore implementation.
 
     Returns:
         Object key (not the full URI).
     """
-    key, _ = await put_oscal_artifact_atomic(audit_id, oscal_yaml, timestamp)
+    key, _ = await put_oscal_artifact_atomic(
+        audit_id=audit_id,
+        oscal_yaml=oscal_yaml,
+        timestamp=timestamp,
+        cold_store=cold_store,
+    )
     return key

--- a/src/gateway/governance/evidence/__init__.py
+++ b/src/gateway/governance/evidence/__init__.py
@@ -24,10 +24,20 @@ from .cold_store import (
     ColdStoreReceipt,
     EvidenceColdStore,
 )
+from .null_cold_store import NullColdStore
+from .residency import (
+    MissingBucketConfigError,
+    ResidencyViolationError,
+    resolve_cold_store_bucket,
+)
 
 __all__ = [
     "ColdStoreError",
     "ColdStoreHealth",
     "ColdStoreReceipt",
     "EvidenceColdStore",
+    "MissingBucketConfigError",
+    "NullColdStore",
+    "ResidencyViolationError",
+    "resolve_cold_store_bucket",
 ]

--- a/src/gateway/governance/evidence/factory.py
+++ b/src/gateway/governance/evidence/factory.py
@@ -1,0 +1,156 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+factory.py — Evidence Cold Storage Factory
+
+Provides a single, vendor-neutral factory for resolving and constructing
+EvidenceColdStore implementations (GcsColdStore, S3ColdStore, NullColdStore).
+
+Design Invariants (Wave 1, Task W1.5b):
+    - Concrete adapter classes are imported lazily inside their respective branches.
+    - Configuration (bucket, endpoints, timeouts, CMEK keys) is resolved in the
+      factory and passed as constructor arguments.
+    - Default backend is 'null' (succeed-locally in dev/test).
+    - Enforces data residency via `resolve_cold_store_bucket()`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from .cold_store import EvidenceColdStore
+from .null_cold_store import NullColdStore
+from .residency import resolve_cold_store_bucket
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_COLD_STORE: EvidenceColdStore | None = None
+
+
+def get_cold_store(
+    backend: str | None = None,
+    bucket: str | None = None,
+    region: str | None = None,
+    location: str | None = None,
+    cmek_key: str | None = None,
+    endpoint: str | None = None,
+    timeout_seconds: int | None = None,
+    use_ssl: bool = True,
+) -> EvidenceColdStore:
+    """Construct an EvidenceColdStore instance based on environment or parameters.
+
+    Selection Priority:
+        1. Explicit `backend` argument.
+        2. `EVIDENCE_COLD_STORE` environment variable.
+        3. Default to `"null"`.
+
+    Args:
+        backend: Storage backend ("gcs", "s3", "null").
+        bucket: Explicit bucket name. If None, resolved via residency rules.
+        region: CAGE deployment region ("US_FED", "EU_ECB", "APAC_MAS", "LOCAL").
+        location: Cloud location/zone (e.g. "europe-west1", "asia-southeast1").
+        cmek_key: Optional Cloud KMS key resource ID for server-side encryption.
+        endpoint: S3-compatible endpoint URL (for MinIO, AWS, Ceph, etc.).
+        timeout_seconds: Timeout for storage I/O operations.
+        use_ssl: Whether to enforce TLS for S3-compatible endpoints.
+
+    Returns:
+        Instance conforming to EvidenceColdStore protocol.
+
+    Raises:
+        ValueError: If backend is unrecognized.
+        MissingBucketConfigError: If required bucket cannot be resolved.
+        ResidencyViolationError: If resolved bucket violates jurisdictional rules.
+    """
+    selected_backend = (
+        (backend or os.environ.get("EVIDENCE_COLD_STORE") or "null").lower().strip()
+    )
+
+    # Null store bypasses cloud bucket resolution
+    if selected_backend == "null":
+        return NullColdStore()
+
+    # Resolve bucket with residency verification for cloud backends
+    resolved_bucket = bucket or resolve_cold_store_bucket(
+        region=region,
+        location=location,
+        backend_id=selected_backend,
+    )
+
+    if selected_backend == "gcs":
+        from src.integrations.storage_gcs.cold_store import GcsColdStore
+
+        project = (
+            os.environ.get("GCP_PROJECT_ID")
+            or os.environ.get("GOOGLE_CLOUD_PROJECT")
+            or None
+        )
+        resolved_cmek = (
+            cmek_key
+            or os.environ.get("EVIDENCE_COLD_STORE_CMEK_KEY")
+            or os.environ.get("EVIDENCE_STREAM_CMEK_KEY")
+            or None
+        )
+        timeout = timeout_seconds or int(
+            os.environ.get("EVIDENCE_COLD_STORE_TIMEOUT_S", "30")
+        )
+        return GcsColdStore(
+            bucket=resolved_bucket,
+            project=project,
+            cmek_key=resolved_cmek,
+            timeout_seconds=timeout,
+        )
+
+    if selected_backend == "s3":
+        from src.integrations.storage_s3.cold_store import S3ColdStore
+
+        endpoint_url = endpoint or os.environ.get("EVIDENCE_COLD_STORE_S3_ENDPOINT")
+        s3_region = region or os.environ.get("EVIDENCE_COLD_STORE_S3_REGION", "auto")
+        access_key = os.environ.get("EVIDENCE_COLD_STORE_S3_ACCESS_KEY")
+        secret_key = os.environ.get("EVIDENCE_COLD_STORE_S3_SECRET_KEY")
+        timeout = timeout_seconds or int(
+            os.environ.get("EVIDENCE_COLD_STORE_TIMEOUT_S", "15")
+        )
+
+        return S3ColdStore(
+            bucket=resolved_bucket,
+            endpoint_url=endpoint_url,
+            region_name=s3_region,
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+            timeout_seconds=timeout,
+            use_ssl=use_ssl,
+        )
+
+    raise ValueError(
+        f"Unsupported cold store backend: '{selected_backend}'. "
+        "Must be one of: 'gcs', 's3', 'null'."
+    )
+
+
+def get_default_cold_store() -> EvidenceColdStore:
+    """Return or initialize the singleton default EvidenceColdStore instance."""
+    global _DEFAULT_COLD_STORE
+    if _DEFAULT_COLD_STORE is None:
+        _DEFAULT_COLD_STORE = get_cold_store()
+    return _DEFAULT_COLD_STORE
+
+
+def reset_default_cold_store() -> None:
+    """Reset the singleton instance (used for test isolation)."""
+    global _DEFAULT_COLD_STORE
+    _DEFAULT_COLD_STORE = None

--- a/src/gateway/governance/evidence/null_cold_store.py
+++ b/src/gateway/governance/evidence/null_cold_store.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+null_cold_store.py — In-Memory Null Evidence Cold Store
+
+Provides a succeed-locally, in-memory implementation of EvidenceColdStore for
+local development, offline testing, and environments without cloud object storage.
+
+Semantics (Wave 1, Task W1.5d):
+    - Succeeds locally: maintains a bounded in-memory ring buffer of written keys.
+    - Generates honest `null://` receipts with accurate cryptographic SHA-256 digests.
+    - Fails closed on startup if CAGE_ENV=prod unless CAGE_ALLOW_NONBLOCKING_PROD=true.
+    - Reports ColdStoreHealth(available=True, backend_id="null").
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from collections import OrderedDict
+from collections.abc import Mapping
+from datetime import datetime, timezone
+
+from .cold_store import ColdStoreHealth, ColdStoreReceipt, EvidenceColdStore
+
+logger = logging.getLogger(__name__)
+
+
+class NullColdStore(EvidenceColdStore):
+    """Succeed-locally EvidenceColdStore with bounded in-memory state.
+
+    Attributes:
+        max_entries: Maximum number of keys to retain in the in-memory ring buffer.
+    """
+
+    def __init__(self, max_entries: int = 1000) -> None:
+        """Initialize NullColdStore with prod safety check.
+
+        Raises:
+            RuntimeError: If CAGE_ENV=prod and CAGE_ALLOW_NONBLOCKING_PROD is not true.
+        """
+        cage_env = os.environ.get("CAGE_ENV", "dev").lower()
+        allow_nonblocking_prod = (
+            os.environ.get("CAGE_ALLOW_NONBLOCKING_PROD", "false").lower() == "true"
+        )
+        if cage_env == "prod" and not allow_nonblocking_prod:
+            raise RuntimeError(
+                "[NullColdStore] CAGE_ENV=prod requires durable cold storage. "
+                "Configure EVIDENCE_COLD_STORE (gcs or s3) and regional bucket. "
+                "Set CAGE_ALLOW_NONBLOCKING_PROD=true to explicitly override."
+            )
+
+        self._max_entries = max_entries
+        self._entries: OrderedDict[str, str] = OrderedDict()  # key -> sha256
+        logger.warning(
+            "[NullColdStore] Initialized with in-memory storage (max_entries=%d). "
+            "No durable off-cluster cold storage is active.",
+            max_entries,
+        )
+
+    @property
+    def backend_id(self) -> str:
+        return "null"
+
+    async def put_batch(
+        self,
+        key: str,
+        content: bytes,
+        metadata: Mapping[str, str] | None = None,
+    ) -> ColdStoreReceipt:
+        """Simulate batch upload by computing SHA-256 and buffering key."""
+        digest = hashlib.sha256(content).hexdigest()
+        if len(self._entries) >= self._max_entries:
+            self._entries.popitem(last=False)
+        self._entries[key] = digest
+
+        logger.debug(
+            "[NullColdStore] Stored key '%s' (%d bytes, sha256=%s...)",
+            key,
+            len(content),
+            digest[:8],
+        )
+        return ColdStoreReceipt(
+            uri=f"null://{key}",
+            key=key,
+            content_sha256=digest,
+            backend_id="null",
+            written_at=datetime.now(timezone.utc),
+        )
+
+    async def exists(self, key: str) -> bool:
+        """Return True if the key was previously written to the in-memory buffer."""
+        return key in self._entries
+
+    async def put_if_absent(
+        self,
+        key: str,
+        content: bytes,
+        metadata: Mapping[str, str] | None = None,
+    ) -> tuple[ColdStoreReceipt, bool]:
+        """Atomic put-if-absent simulation against in-memory key buffer."""
+        if key in self._entries:
+            existing_digest = self._entries[key]
+            receipt = ColdStoreReceipt(
+                uri=f"null://{key}",
+                key=key,
+                content_sha256=existing_digest,
+                backend_id="null",
+                written_at=datetime.now(timezone.utc),
+            )
+            return receipt, False
+
+        receipt = await self.put_batch(key, content, metadata)
+        return receipt, True
+
+    def health(self) -> ColdStoreHealth:
+        """Return operational health of the in-memory cold store."""
+        return ColdStoreHealth(
+            available=True,
+            backend_id="null",
+            detail=f"In-memory simulation active ({len(self._entries)} items tracked)",
+        )

--- a/src/gateway/governance/evidence/residency.py
+++ b/src/gateway/governance/evidence/residency.py
@@ -1,0 +1,230 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+residency.py — Declarative Evidence Storage Residency Resolver
+
+Provides backend-agnostic, table-driven data residency validation for evidence
+cold storage across CAGE compliance jurisdictions (US_FED, EU_ECB, APAC_MAS, LOCAL).
+
+Enforces:
+    - GDPR Art. 44 (EU sovereign data boundaries)
+    - MAS TRM §4.2 (Singapore sovereign data boundaries)
+    - NIST SP 800-53 / FedRAMP (US sovereign data boundaries)
+
+Task Spec: Wave 1, W1.4 (plans/vendor_decoupling_implementation_plan.md)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Default config path relative to repo root
+_DEFAULT_CONFIG_PATH = (
+    Path(__file__).parents[4] / "config" / "compliance" / "residency.json"
+)
+
+
+class ResidencyViolationError(RuntimeError):
+    """Raised when cold store bucket configuration violates jurisdictional data residency."""
+
+    pass
+
+
+class MissingBucketConfigError(ResidencyViolationError):
+    """Raised when required bucket environment variable is unset."""
+
+    pass
+
+
+@dataclass(frozen=True)
+class RegionalResidencyRule:
+    """Residency constraints for a specific deployment region."""
+
+    region: str
+    jurisdiction: str
+    env_var: str
+    allowed_prefixes: tuple[str, ...]
+    allowed_locations: tuple[str, ...]
+    default_bucket: str | None = None
+    allow_prefixes: bool = True
+
+
+_CONFIG_CACHE: dict[str, Any] | None = None
+
+
+def load_residency_config(config_path: str | Path | None = None) -> dict[str, Any]:
+    """Load declarative residency rules from config JSON.
+
+    Args:
+        config_path: Optional path to residency.json. If None, uses default repo location.
+
+    Returns:
+        Parsed dictionary of regional residency rules.
+    """
+    global _CONFIG_CACHE
+    if _CONFIG_CACHE is not None and config_path is None:
+        return _CONFIG_CACHE
+
+    target_path = Path(config_path) if config_path else _DEFAULT_CONFIG_PATH
+    if not target_path.exists():
+        raise FileNotFoundError(
+            f"Residency configuration file not found at: {target_path}"
+        )
+
+    with open(target_path, encoding="utf-8") as f:
+        data = json.load(f)
+
+    if config_path is None:
+        _CONFIG_CACHE = data
+    return data
+
+
+def clear_residency_cache() -> None:
+    """Clear cached configuration for test isolation."""
+    global _CONFIG_CACHE
+    _CONFIG_CACHE = None
+
+
+def get_regional_rule(
+    region: str,
+    config_path: str | Path | None = None,
+) -> RegionalResidencyRule:
+    """Fetch structured residency rule for a given region."""
+    config = load_residency_config(config_path)
+    regions_map = config.get("regions", {})
+
+    if region not in regions_map:
+        raise ResidencyViolationError(
+            f"Unknown deployment region '{region}'. Must be one of: {list(regions_map.keys())}"
+        )
+
+    rule_data = regions_map[region]
+    return RegionalResidencyRule(
+        region=region,
+        jurisdiction=rule_data.get("jurisdiction", ""),
+        env_var=rule_data.get("env_var", ""),
+        allowed_prefixes=tuple(rule_data.get("allowed_prefixes", [])),
+        allowed_locations=tuple(rule_data.get("allowed_locations", [])),
+        default_bucket=rule_data.get("default_bucket"),
+        allow_prefixes=rule_data.get("allow_prefixes", True),
+    )
+
+
+def resolve_cold_store_bucket(
+    region: str | None = None,
+    location: str | None = None,
+    backend_id: str | None = None,
+    bucket_override: str | None = None,
+    config_path: str | Path | None = None,
+) -> str:
+    """Resolve and validate the cold storage bucket for the current deployment region.
+
+    Evaluation Order:
+        1. Resolve region from `region` arg or `CAGE_DEPLOYMENT_REGION` env var (default: "LOCAL").
+        2. Resolve candidate bucket name:
+           a. `bucket_override` (if provided)
+           b. Regional env var (e.g. `EVIDENCE_COLD_STORE_BUCKET_EU`)
+           c. Global fallback `EVIDENCE_COLD_STORE_BUCKET`
+           d. For `LOCAL`, default to `default_bucket` from config if unset.
+        3. Validate candidate bucket against allowed prefixes and locations.
+        4. Fail closed on any violation or missing configuration.
+
+    Args:
+        region: Deployment region (e.g. "US_FED", "EU_ECB", "APAC_MAS", "LOCAL").
+        location: Cloud location/zone (e.g. "europe-west1", "asia-southeast1", "us-central1").
+        backend_id: Storage backend identifier ("gcs", "s3", "null").
+        bucket_override: Explicit bucket name to validate.
+        config_path: Custom path to residency.json.
+
+    Returns:
+        Validated bucket name string.
+
+    Raises:
+        MissingBucketConfigError: If required bucket environment variable is unset.
+        ResidencyViolationError: If bucket violates jurisdictional residency rules.
+    """
+    active_region = (
+        region or os.environ.get("CAGE_DEPLOYMENT_REGION") or "LOCAL"
+    ).strip()
+    rule = get_regional_rule(active_region, config_path=config_path)
+
+    # Resolve candidate bucket
+    candidate = bucket_override
+    if not candidate:
+        # Check specific regional variable first
+        candidate = os.environ.get(rule.env_var, "").strip()
+        if not candidate:
+            # Check universal cold store bucket variable
+            candidate = os.environ.get("EVIDENCE_COLD_STORE_BUCKET", "").strip()
+
+    if not candidate:
+        if active_region == "LOCAL" and rule.default_bucket:
+            candidate = rule.default_bucket
+        else:
+            raise MissingBucketConfigError(
+                f"Missing required bucket configuration for region '{active_region}'. "
+                f"Set environment variable '{rule.env_var}' or 'EVIDENCE_COLD_STORE_BUCKET'."
+            )
+
+    # Null backend bypass check for local testing
+    if backend_id == "null" and candidate in (
+        "null",
+        "null-bucket",
+        "local-evidence-bucket",
+    ):
+        return candidate
+
+    # Validate Location if provided
+    active_location = (
+        location
+        or os.environ.get("GOOGLE_CLOUD_LOCATION")
+        or os.environ.get("AWS_REGION")
+    )
+    if active_location:
+        active_location = active_location.strip()
+        if active_location not in rule.allowed_locations:
+            raise ResidencyViolationError(
+                f"Storage location '{active_location}' violates data residency for region "
+                f"'{active_region}'. Allowed locations: {rule.allowed_locations}"
+            )
+
+    # Validate Bucket Name Prefixes
+    has_valid_prefix = any(
+        candidate.startswith(prefix) for prefix in rule.allowed_prefixes
+    )
+    if not has_valid_prefix:
+        # If prefix validation fails, verify whether explicit location match grants exception
+        if active_location and active_location in rule.allowed_locations:
+            logger.warning(
+                "Bucket '%s' does not match regional prefixes %s, but location '%s' satisfies residency.",
+                candidate,
+                rule.allowed_prefixes,
+                active_location,
+            )
+        else:
+            raise ResidencyViolationError(
+                f"Bucket '{candidate}' violates data residency for region '{active_region}'. "
+                f"Bucket name must start with one of {rule.allowed_prefixes} or reference a "
+                f"verified location in {rule.allowed_locations}."
+            )
+
+    return candidate

--- a/src/gateway/governance/null_components.py
+++ b/src/gateway/governance/null_components.py
@@ -93,77 +93,10 @@ class NullConsensusProvider:
         }
 
 
-class NullColdStore(EvidenceColdStore):
-    """Fail-closed EvidenceColdStore used when no cloud storage is configured.
+from .evidence.null_cold_store import NullColdStore
 
-    Succeeds locally/dev but fails on startup if CAGE_ENV=prod.
-    Emits distinct metric label for observability.
-
-    This allows local development without GCS/S3 credentials while enforcing
-    that production deployments MUST have cold storage configured for compliance.
-    """
-
-    def __init__(self) -> None:
-        """Initialize NullColdStore.
-
-        Raises:
-            RuntimeError: If CAGE_ENV=prod (production must have real cold storage)
-        """
-        cage_env = os.environ.get("CAGE_ENV", "dev")
-        if cage_env == "prod":
-            raise RuntimeError(
-                "[NullColdStore] CAGE_ENV=prod requires real cold storage. "
-                "Configure EVIDENCE_STREAM_BUCKET_{region} and use "
-                "GcsColdStore or S3ColdStore."
-            )
-        self._logger = logging.getLogger("cage.evidence.null_cold_store")
-
-    @property
-    def backend_id(self) -> str:
-        return "null"
-
-    async def put_batch(
-        self,
-        key: str,
-        content: bytes,
-        metadata: Mapping[str, str] | None = None,
-    ) -> ColdStoreReceipt:
-        """No-op upload for local/dev environments.
-
-        Computes exact SHA-256 digest and returns a simulated receipt.
-        """
-        digest = hashlib.sha256(content).hexdigest()
-        self._logger.warning(
-            "[NullColdStore] Skipping cold storage for key '%s' (%d bytes) — dev/local mode",
-            key,
-            len(content),
-        )
-        return ColdStoreReceipt(
-            uri=f"null://{key}",
-            key=key,
-            content_sha256=digest,
-            backend_id="null",
-            written_at=datetime.now(timezone.utc),
-        )
-
-    async def exists(self, key: str) -> bool:
-        """NullColdStore does not persist objects; always returns False."""
-        return False
-
-    async def put_if_absent(
-        self,
-        key: str,
-        content: bytes,
-        metadata: Mapping[str, str] | None = None,
-    ) -> tuple[ColdStoreReceipt, bool]:
-        """Simulates atomic put_if_absent (always succeeds in dev)."""
-        receipt = await self.put_batch(key, content, metadata)
-        return receipt, True
-
-    def health(self) -> ColdStoreHealth:
-        """Synchronously reports availability for dev/local environments."""
-        return ColdStoreHealth(
-            available=True,
-            backend_id="null",
-            detail="in-memory dev null cold store (no durable persistence)",
-        )
+__all__ = [
+    "NullColdStore",
+    "NullConsensusProvider",
+    "NullSafetyFilter",
+]

--- a/src/integrations/storage_gcs/cold_store.py
+++ b/src/integrations/storage_gcs/cold_store.py
@@ -56,20 +56,25 @@ class GcsColdStore(EvidenceColdStore):
         project_id: str | None = None,
         cmek_key: str | None = None,
         timeout: float = 15.0,
+        bucket: str | None = None,
+        timeout_seconds: float | None = None,
+        project: str | None = None,
     ) -> None:
         self._bucket_name = (
-            bucket_name
-            or os.environ.get("EVIDENCE_STREAM_BUCKET_GCS")
-            or os.environ.get("EVIDENCE_STREAM_GCS_BUCKET")
+            bucket
+            or bucket_name
+            or os.environ.get("EVIDENCE_COLD_STORE_BUCKET_GCS")
+            or os.environ.get("EVIDENCE_COLD_STORE_BUCKET")
             or os.environ.get("GCS_BUCKET")
         )
         self._project_id = (
-            project_id
+            project
+            or project_id
             or os.environ.get("GOOGLE_CLOUD_PROJECT")
             or os.environ.get("GCS_PROJECT_ID")
         )
+        self._timeout = timeout_seconds if timeout_seconds is not None else timeout
         self._cmek_key = cmek_key
-        self._timeout = timeout
 
         self._client: Any = None
         self._lock = threading.Lock()

--- a/src/integrations/storage_s3/cold_store.py
+++ b/src/integrations/storage_s3/cold_store.py
@@ -62,25 +62,39 @@ class S3ColdStore(EvidenceColdStore):
         endpoint_url: str | None = None,
         region_name: str | None = None,
         timeout: float = 15.0,
+        bucket: str | None = None,
+        timeout_seconds: float | None = None,
+        aws_access_key_id: str | None = None,
+        aws_secret_access_key: str | None = None,
+        use_ssl: bool = True,
     ) -> None:
         self._bucket_name = (
-            bucket_name
-            or os.environ.get("EVIDENCE_STREAM_BUCKET_S3")
-            or os.environ.get("EVIDENCE_STREAM_S3_BUCKET")
+            bucket
+            or bucket_name
+            or os.environ.get("EVIDENCE_COLD_STORE_BUCKET_S3")
+            or os.environ.get("EVIDENCE_COLD_STORE_BUCKET")
             or os.environ.get("S3_BUCKET")
-            or os.environ.get("OSCAL_S3_BUCKET")
         )
         self._endpoint_url = (
             endpoint_url
+            or os.environ.get("EVIDENCE_COLD_STORE_S3_ENDPOINT")
             or os.environ.get("S3_ENDPOINT_URL")
             or os.environ.get("AWS_ENDPOINT_URL")
         )
         self._region_name = (
             region_name
+            or os.environ.get("EVIDENCE_COLD_STORE_S3_REGION")
             or os.environ.get("AWS_REGION")
             or os.environ.get("AWS_DEFAULT_REGION", "us-east-1")
         )
-        self._timeout = timeout
+        self._timeout = timeout_seconds if timeout_seconds is not None else timeout
+        self._aws_access_key_id = aws_access_key_id or os.environ.get(
+            "EVIDENCE_COLD_STORE_S3_ACCESS_KEY"
+        )
+        self._aws_secret_access_key = aws_secret_access_key or os.environ.get(
+            "EVIDENCE_COLD_STORE_S3_SECRET_KEY"
+        )
+        self._use_ssl = use_ssl
 
         self._client: Any = None
         self._lock = threading.Lock()
@@ -120,12 +134,19 @@ class S3ColdStore(EvidenceColdStore):
                     read_timeout=self._timeout,
                     retries={"max_attempts": 1},
                 )
-                self._client = boto3.client(
-                    "s3",
-                    endpoint_url=self._endpoint_url,
-                    region_name=self._region_name,
-                    config=config,
-                )
+                client_kwargs: dict[str, Any] = {
+                    "service_name": "s3",
+                    "endpoint_url": self._endpoint_url,
+                    "region_name": self._region_name,
+                    "config": config,
+                    "use_ssl": self._use_ssl,
+                }
+                if self._aws_access_key_id:
+                    client_kwargs["aws_access_key_id"] = self._aws_access_key_id
+                if self._aws_secret_access_key:
+                    client_kwargs["aws_secret_access_key"] = self._aws_secret_access_key
+
+                self._client = boto3.client(**client_kwargs)
                 logger.info(
                     "[storage_s3] Initialized S3 client (endpoint=%s, region=%s)",
                     self._endpoint_url or "aws-default",

--- a/tests/integrations/test_gcs_cold_store.py
+++ b/tests/integrations/test_gcs_cold_store.py
@@ -159,8 +159,8 @@ async def test_gcs_cold_store_upload_error_wrapped():
 async def test_gcs_cold_store_missing_bucket_raises(monkeypatch):
     """put_batch without a bucket name raises ColdStoreError."""
     for var in (
-        "EVIDENCE_STREAM_BUCKET_GCS",
-        "EVIDENCE_STREAM_GCS_BUCKET",
+        "EVIDENCE_COLD_STORE_BUCKET",
+        "EVIDENCE_COLD_STORE_BUCKET_GCS",
         "GCS_BUCKET",
     ):
         monkeypatch.delenv(var, raising=False)
@@ -174,8 +174,8 @@ async def test_gcs_cold_store_missing_bucket_raises(monkeypatch):
 def test_gcs_cold_store_health_reporting(monkeypatch):
     """health() reports status based on configuration and client availability."""
     for var in (
-        "EVIDENCE_STREAM_BUCKET_GCS",
-        "EVIDENCE_STREAM_GCS_BUCKET",
+        "EVIDENCE_COLD_STORE_BUCKET",
+        "EVIDENCE_COLD_STORE_BUCKET_GCS",
         "GCS_BUCKET",
     ):
         monkeypatch.delenv(var, raising=False)

--- a/tests/integrations/test_s3_cold_store.py
+++ b/tests/integrations/test_s3_cold_store.py
@@ -175,10 +175,9 @@ async def test_s3_cold_store_put_if_absent_fallback_when_ifnonematch_unsupported
 async def test_s3_cold_store_missing_bucket_raises(monkeypatch):
     """put_batch without a bucket name raises ColdStoreError."""
     for var in (
-        "EVIDENCE_STREAM_BUCKET_S3",
-        "EVIDENCE_STREAM_S3_BUCKET",
+        "EVIDENCE_COLD_STORE_BUCKET",
+        "EVIDENCE_COLD_STORE_BUCKET_S3",
         "S3_BUCKET",
-        "OSCAL_S3_BUCKET",
     ):
         monkeypatch.delenv(var, raising=False)
     store = S3ColdStore(bucket_name=None)
@@ -191,10 +190,9 @@ async def test_s3_cold_store_missing_bucket_raises(monkeypatch):
 def test_s3_cold_store_health_reporting(monkeypatch):
     """health() reports status based on configuration."""
     for var in (
-        "EVIDENCE_STREAM_BUCKET_S3",
-        "EVIDENCE_STREAM_S3_BUCKET",
+        "EVIDENCE_COLD_STORE_BUCKET",
+        "EVIDENCE_COLD_STORE_BUCKET_S3",
         "S3_BUCKET",
-        "OSCAL_S3_BUCKET",
     ):
         monkeypatch.delenv(var, raising=False)
     store_no_bucket = S3ColdStore(bucket_name=None)

--- a/tests/test_audit_workflow.py
+++ b/tests/test_audit_workflow.py
@@ -45,8 +45,9 @@ def _dev_env(monkeypatch):
     monkeypatch.setenv("LANGFUSE_COMPLIANCE_PUBLIC_KEY", "pk-dummy")
     monkeypatch.setenv("LANGFUSE_COMPLIANCE_SECRET_KEY", "sk-dummy")
     monkeypatch.setenv("LANGFUSE_PUBLIC_KEY", "pk-dummy")
-    monkeypatch.setenv("LANGFUSE_SECRET_KEY", "sk-dummy")
-    # Clear OSCAL_S3_ENDPOINT so Step 1 is skipped by default
+    # Clear EVIDENCE_COLD_STORE so Step 1 is skipped by default
+    monkeypatch.delenv("EVIDENCE_COLD_STORE", raising=False)
+    monkeypatch.delenv("EVIDENCE_COLD_STORE_S3_ENDPOINT", raising=False)
     monkeypatch.delenv("OSCAL_S3_ENDPOINT", raising=False)
 
 
@@ -127,18 +128,19 @@ class TestStep1ArtifactPersistence:
     """Tests for _step1_persist_artifact."""
 
     @pytest.mark.asyncio
-    async def test_step1_skipped_when_no_s3_endpoint(self, monkeypatch):
-        """Step 1 returns None when OSCAL_S3_ENDPOINT is not set."""
-        monkeypatch.delenv("OSCAL_S3_ENDPOINT", raising=False)
+    async def test_step1_skipped_when_no_cold_store(self, monkeypatch):
+        """Step 1 returns None when EVIDENCE_COLD_STORE is not set to durable backend."""
+        monkeypatch.delenv("EVIDENCE_COLD_STORE", raising=False)
+        monkeypatch.delenv("EVIDENCE_COLD_STORE_S3_ENDPOINT", raising=False)
         from src.compliance_bridge.audit_workflow import _step1_persist_artifact
 
         result = await _step1_persist_artifact("yaml-content", "audit-001")
         assert result is None
 
     @pytest.mark.asyncio
-    async def test_step1_calls_put_when_endpoint_set(self, monkeypatch):
-        """Step 1 calls put_oscal_artifact when OSCAL_S3_ENDPOINT is set."""
-        monkeypatch.setenv("OSCAL_S3_ENDPOINT", "http://minio:9000")
+    async def test_step1_calls_put_when_cold_store_configured(self, monkeypatch):
+        """Step 1 calls put_oscal_artifact when EVIDENCE_COLD_STORE is configured."""
+        monkeypatch.setenv("EVIDENCE_COLD_STORE", "s3")
 
         with patch(
             "src.compliance_bridge.audit_workflow.put_oscal_artifact",
@@ -155,7 +157,7 @@ class TestStep1ArtifactPersistence:
     @pytest.mark.asyncio
     async def test_step1_returns_none_on_storage_failure(self, monkeypatch):
         """Step 1 returns None (non-fatal) when put_oscal_artifact raises."""
-        monkeypatch.setenv("OSCAL_S3_ENDPOINT", "http://minio:9000")
+        monkeypatch.setenv("EVIDENCE_COLD_STORE", "s3")
 
         with patch(
             "src.compliance_bridge.audit_workflow.put_oscal_artifact",

--- a/tests/test_cold_store_conformance.py
+++ b/tests/test_cold_store_conformance.py
@@ -1,0 +1,138 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+tests/test_cold_store_conformance.py — Universal Cold Store Conformance Suite
+
+Parameterized test suite verifying that all cold storage implementations
+(GcsColdStore, S3ColdStore, NullColdStore) conform to the EvidenceColdStore protocol.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.gateway.governance.evidence.cold_store import (
+    ColdStoreHealth,
+    ColdStoreReceipt,
+    EvidenceColdStore,
+)
+from src.gateway.governance.evidence.null_cold_store import NullColdStore
+from src.integrations.storage_gcs.cold_store import GcsColdStore
+from src.integrations.storage_s3.cold_store import S3ColdStore
+
+pytestmark = [pytest.mark.local, pytest.mark.unit]
+
+
+@pytest.fixture
+def mock_gcs_store():
+    """Create a GcsColdStore with mocked underlying GCS client."""
+    mock_client = MagicMock()
+    mock_bucket = MagicMock()
+    mock_blob = MagicMock()
+
+    mock_client.bucket.return_value = mock_bucket
+    mock_bucket.blob.return_value = mock_blob
+    mock_blob.exists.return_value = True
+
+    store = GcsColdStore(bucket="us-test-bucket")
+    store._client = mock_client
+    return store
+
+
+@pytest.fixture
+def mock_s3_store():
+    """Create an S3ColdStore with mocked underlying boto3 S3 client."""
+    mock_client = MagicMock()
+    store = S3ColdStore(
+        bucket="us-test-bucket",
+        endpoint_url="http://localhost:9000",
+        aws_access_key_id="dummy",
+        aws_secret_access_key="dummy",
+    )
+    store._client = mock_client
+    return store
+
+
+@pytest.fixture
+def null_store():
+    """Create a NullColdStore instance."""
+    return NullColdStore()
+
+
+@pytest.fixture(params=["mock_gcs_store", "mock_s3_store", "null_store"])
+def cold_store_instance(request):
+    """Yield each cold store implementation fixture."""
+    return request.getfixturevalue(request.param)
+
+
+def test_conforms_to_protocol(cold_store_instance):
+    """Verify runtime checkable protocol compliance."""
+    assert isinstance(cold_store_instance, EvidenceColdStore)
+
+
+def test_backend_id_property(cold_store_instance):
+    """Verify backend_id property returns valid identifier."""
+    assert cold_store_instance.backend_id in ("gcs", "s3", "null")
+
+
+@pytest.mark.asyncio
+async def test_put_batch_receipt_structure(cold_store_instance):
+    """Verify put_batch returns a valid ColdStoreReceipt with matching SHA-256."""
+    key = "evidence-stream/2026/09/05/batch-test.ndjson"
+    content = b'{"event": "test_conformance", "seq": 1}\n'
+    expected_digest = hashlib.sha256(content).hexdigest()
+
+    receipt = await cold_store_instance.put_batch(key, content)
+
+    assert isinstance(receipt, ColdStoreReceipt)
+    assert receipt.key == key
+    assert receipt.content_sha256 == expected_digest
+    assert receipt.backend_id == cold_store_instance.backend_id
+    assert isinstance(receipt.written_at, datetime)
+    assert receipt.uri.startswith(("gs://", "s3://", "null://"))
+
+
+@pytest.mark.asyncio
+async def test_exists_contract(cold_store_instance):
+    """Verify exists method returns a boolean."""
+    key = "evidence-stream/2026/09/05/batch-test.ndjson"
+    result = await cold_store_instance.exists(key)
+    assert isinstance(result, bool)
+
+
+@pytest.mark.asyncio
+async def test_put_if_absent_contract(cold_store_instance):
+    """Verify put_if_absent returns (ColdStoreReceipt, bool)."""
+    key = "evidence-stream/2026/09/05/batch-test.ndjson"
+    content = b'{"event": "test_conformance_atomic"}\n'
+
+    receipt, created = await cold_store_instance.put_if_absent(key, content)
+
+    assert isinstance(receipt, ColdStoreReceipt)
+    assert isinstance(created, bool)
+    assert receipt.key == key
+
+
+def test_health_contract(cold_store_instance):
+    """Verify health() returns ColdStoreHealth."""
+    health = cold_store_instance.health()
+    assert isinstance(health, ColdStoreHealth)
+    assert isinstance(health.available, bool)
+    assert health.backend_id == cold_store_instance.backend_id
+    assert isinstance(health.detail, str)

--- a/tests/test_compliance_bridge_storage.py
+++ b/tests/test_compliance_bridge_storage.py
@@ -12,42 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-tests/test_compliance_bridge_storage.py — Unit tests for compliance bridge artifact storage.
-"""
+"""tests/test_compliance_bridge_storage.py — Unit tests for compliance bridge artifact storage."""
 
 from __future__ import annotations
 
-import os
 from datetime import datetime, timezone
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from src.compliance_bridge import storage
-
-
-@pytest.mark.local
-@pytest.mark.unit
-def test_get_storage_backend():
-    with patch.dict(os.environ, {"STORAGE_BACKEND": "GCS"}, clear=False):
-        assert storage._get_storage_backend() == "gcs"
-
-    with patch.dict(os.environ, {"STORAGE_BACKEND": "s3"}, clear=False):
-        assert storage._get_storage_backend() == "s3"
-
-
-@pytest.mark.local
-@pytest.mark.unit
-def test_get_bucket():
-    with patch.dict(os.environ, {"OSCAL_S3_BUCKET": "my-bucket"}, clear=False):
-        assert storage._get_bucket() == "my-bucket"
-
-    with patch.dict(os.environ, {}, clear=True):
-        with pytest.raises(
-            RuntimeError, match="Missing required env var: OSCAL_S3_BUCKET"
-        ):
-            storage._get_bucket()
+from src.gateway.governance.evidence.cold_store import ColdStoreReceipt
+from src.gateway.governance.evidence.null_cold_store import NullColdStore
 
 
 @pytest.mark.local
@@ -64,37 +40,36 @@ def test_build_object_key_and_sha256():
 
 @pytest.mark.local
 @pytest.mark.unit
-def test_gcs_operations():
-    mock_blob = MagicMock()
-    mock_blob.exists.return_value = True
-    mock_bucket = MagicMock()
-    mock_bucket.blob.return_value = mock_blob
-    mock_client = MagicMock()
-    mock_client.bucket.return_value = mock_bucket
+@pytest.mark.asyncio
+async def test_put_oscal_artifact_atomic_delegates_to_injected_store():
+    mock_store = AsyncMock()
+    mock_receipt = ColdStoreReceipt(
+        uri="gs://test-bucket/oscal-artifacts/2026-08-16/audit-123.yaml",
+        key="oscal-artifacts/2026-08-16/audit-123.yaml",
+        content_sha256=storage._sha256("dummy-yaml"),
+        backend_id="gcs",
+        written_at=datetime.now(tz=timezone.utc),
+    )
+    mock_store.put_if_absent = AsyncMock(return_value=(mock_receipt, True))
 
-    with patch.object(storage, "_gcs_client", mock_client):
-        assert storage._gcs_blob_exists("test-bucket", "key-1") is True
-        mock_bucket.blob.assert_called_with("key-1")
+    ts = datetime(2026, 8, 16, 12, 0, 0, tzinfo=timezone.utc)
+    key, created = await storage.put_oscal_artifact_atomic(
+        audit_id="audit-123",
+        oscal_yaml="dummy-yaml",
+        timestamp=ts,
+        cold_store=mock_store,
+    )
 
-        ts = datetime(2026, 8, 16, 12, 0, 0, tzinfo=timezone.utc)
-        uri = storage._gcs_upload("test-bucket", "key-1", "sample-yaml", "audit-1", ts)
-        assert uri == "gs://test-bucket/key-1"
-        mock_blob.upload_from_string.assert_called_once()
+    assert key == "oscal-artifacts/2026-08-16/audit-123.yaml"
+    assert created is True
 
-
-@pytest.mark.local
-@pytest.mark.unit
-def test_s3_operations():
-    mock_s3 = MagicMock()
-    mock_s3.head_object.return_value = {}
-
-    with patch.object(storage, "_s3_client", mock_s3):
-        assert storage._s3_blob_exists("test-bucket", "key-1") is True
-
-        ts = datetime(2026, 8, 16, 12, 0, 0, tzinfo=timezone.utc)
-        uri = storage._s3_upload("test-bucket", "key-1", "sample-yaml", "audit-1", ts)
-        assert uri == "s3://test-bucket/key-1"
-        mock_s3.put_object.assert_called_once()
+    mock_store.put_if_absent.assert_awaited_once()
+    call_kwargs = mock_store.put_if_absent.call_args.kwargs
+    assert call_kwargs["key"] == "oscal-artifacts/2026-08-16/audit-123.yaml"
+    assert call_kwargs["content"] == b"dummy-yaml"
+    assert call_kwargs["metadata"]["x-audit-id"] == "audit-123"
+    assert call_kwargs["metadata"]["x-standard"] == "ISO/IEC 42001:2023"
+    assert call_kwargs["metadata"]["content-type"] == "application/yaml"
 
 
 @pytest.mark.local
@@ -102,49 +77,72 @@ def test_s3_operations():
 @pytest.mark.asyncio
 async def test_put_oscal_artifact_idempotent():
     """Test that put_oscal_artifact returns existing key when artifact already exists."""
-    with (
-        patch.dict(
-            os.environ,
-            {"OSCAL_S3_BUCKET": "test-bucket", "STORAGE_BACKEND": "s3"},
-            clear=False,
-        ),
-        # HIGH-4 FIX: Now uses atomic _s3_upload_if_not_exists instead of artifact_exists
-        patch.object(
-            storage,
-            "_s3_upload_if_not_exists",
-            return_value=(
-                "s3://test-bucket/oscal-artifacts/2026-08-16/audit-123.yaml",
-                False,
-            ),
-        ),
-    ):
-        ts = datetime(2026, 8, 16, 12, 0, 0, tzinfo=timezone.utc)
-        key = await storage.put_oscal_artifact("audit-123", "dummy-yaml", timestamp=ts)
-        assert key == "oscal-artifacts/2026-08-16/audit-123.yaml"
+    mock_store = AsyncMock()
+    mock_receipt = ColdStoreReceipt(
+        uri="s3://test-bucket/oscal-artifacts/2026-08-16/audit-123.yaml",
+        key="oscal-artifacts/2026-08-16/audit-123.yaml",
+        content_sha256=storage._sha256("dummy-yaml"),
+        backend_id="s3",
+        written_at=datetime.now(tz=timezone.utc),
+    )
+    mock_store.put_if_absent = AsyncMock(return_value=(mock_receipt, False))
+
+    ts = datetime(2026, 8, 16, 12, 0, 0, tzinfo=timezone.utc)
+    key = await storage.put_oscal_artifact(
+        audit_id="audit-123",
+        oscal_yaml="dummy-yaml",
+        timestamp=ts,
+        cold_store=mock_store,
+    )
+
+    assert key == "oscal-artifacts/2026-08-16/audit-123.yaml"
 
 
 @pytest.mark.local
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_put_oscal_artifact_upload_when_missing():
-    """Test that put_oscal_artifact uploads artifact when it doesn't exist."""
-    with (
-        patch.dict(
-            os.environ,
-            {"OSCAL_S3_BUCKET": "test-bucket", "STORAGE_BACKEND": "s3"},
-            clear=False,
-        ),
-        # HIGH-4 FIX: Now uses atomic _s3_upload_if_not_exists instead of artifact_exists + upload_artifact
-        patch.object(
-            storage,
-            "_s3_upload_if_not_exists",
-            return_value=(
-                "s3://test-bucket/oscal-artifacts/2026-08-16/audit-123.yaml",
-                True,
-            ),
-        ) as mock_upload,
-    ):
-        ts = datetime(2026, 8, 16, 12, 0, 0, tzinfo=timezone.utc)
-        key = await storage.put_oscal_artifact("audit-123", "dummy-yaml", timestamp=ts)
-        assert key == "oscal-artifacts/2026-08-16/audit-123.yaml"
-        mock_upload.assert_called_once()
+async def test_put_oscal_artifact_null_store_integration():
+    """Test full integration between OSCAL storage and NullColdStore."""
+    null_store = NullColdStore()
+    ts = datetime(2026, 8, 16, 12, 0, 0, tzinfo=timezone.utc)
+
+    key1, created1 = await storage.put_oscal_artifact_atomic(
+        audit_id="audit-456",
+        oscal_yaml="test-oscal-content",
+        timestamp=ts,
+        cold_store=null_store,
+    )
+    assert key1 == "oscal-artifacts/2026-08-16/audit-456.yaml"
+    assert created1 is True
+
+    # Second atomic write with same key should indicate not created
+    key2, created2 = await storage.put_oscal_artifact_atomic(
+        audit_id="audit-456",
+        oscal_yaml="test-oscal-content",
+        timestamp=ts,
+        cold_store=null_store,
+    )
+    assert key2 == "oscal-artifacts/2026-08-16/audit-456.yaml"
+    assert created2 is False
+
+
+@pytest.mark.local
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_put_oscal_artifact_resolves_factory_when_none():
+    """Test ambient factory resolution when cold_store is None."""
+    null_store = NullColdStore()
+    ts = datetime(2026, 8, 16, 12, 0, 0, tzinfo=timezone.utc)
+
+    with patch(
+        "src.gateway.governance.evidence.factory.get_cold_store",
+        return_value=null_store,
+    ) as mock_factory:
+        key = await storage.put_oscal_artifact(
+            audit_id="audit-789",
+            oscal_yaml="test-oscal-content",
+            timestamp=ts,
+            cold_store=None,
+        )
+        assert key == "oscal-artifacts/2026-08-16/audit-789.yaml"
+        mock_factory.assert_called_once()

--- a/tests/test_evidence_cold_store_protocol.py
+++ b/tests/test_evidence_cold_store_protocol.py
@@ -121,20 +121,25 @@ async def test_null_cold_store_conforms_to_protocol(monkeypatch):
     assert receipt.backend_id == "null"
 
     # Test exists
-    exists = await store.exists("batch/2026-09-05.ndjson")
-    assert exists is False
+    assert await store.exists("batch/2026-09-05.ndjson") is True
+    assert await store.exists("batch/nonexistent.ndjson") is False
 
-    # Test put_if_absent
+    # Test put_if_absent on existing key
     receipt2, created = await store.put_if_absent("batch/2026-09-05.ndjson", payload)
-    assert created is True
+    assert created is False
     assert receipt2.content_sha256 == expected_sha
+
+    # Test put_if_absent on new key
+    receipt3, created3 = await store.put_if_absent("batch/another.ndjson", payload)
+    assert created3 is True
+    assert receipt3.content_sha256 == expected_sha
 
 
 def test_null_cold_store_fails_closed_in_production(monkeypatch):
     """NullColdStore must refuse to instantiate in production (CAGE_ENV=prod)."""
     monkeypatch.setenv("CAGE_ENV", "prod")
 
-    with pytest.raises(RuntimeError, match="CAGE_ENV=prod requires real cold storage"):
+    with pytest.raises(RuntimeError, match="requires durable cold storage"):
         NullColdStore()
 
 

--- a/tests/test_evidence_residency.py
+++ b/tests/test_evidence_residency.py
@@ -1,0 +1,154 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+tests/test_evidence_residency.py — Unit tests for declarative evidence residency resolver.
+
+Tests:
+    - Regional bucket prefix resolution (US_FED, EU_ECB, APAC_MAS, LOCAL)
+    - Fail-closed behavior on missing configuration
+    - Cross-region residency violation detection
+    - Location matching and prefix override validation
+    - Unknown region rejection
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from src.gateway.governance.evidence.residency import (
+    MissingBucketConfigError,
+    ResidencyViolationError,
+    clear_residency_cache,
+    resolve_cold_store_bucket,
+)
+
+pytestmark = [pytest.mark.local, pytest.mark.unit]
+
+
+@pytest.fixture(autouse=True)
+def clean_env(monkeypatch: pytest.MonkeyPatch):
+    """Ensure clean residency-related environment variables for each test."""
+    clear_residency_cache()
+    for var in [
+        "CAGE_DEPLOYMENT_REGION",
+        "EVIDENCE_COLD_STORE_BUCKET",
+        "EVIDENCE_COLD_STORE_BUCKET_US",
+        "EVIDENCE_COLD_STORE_BUCKET_EU",
+        "EVIDENCE_COLD_STORE_BUCKET_APAC",
+        "EVIDENCE_COLD_STORE_BUCKET_LOCAL",
+        "GOOGLE_CLOUD_LOCATION",
+        "AWS_REGION",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+
+
+@pytest.mark.parametrize(
+    "region,env_var,valid_bucket",
+    [
+        ("US_FED", "EVIDENCE_COLD_STORE_BUCKET_US", "us-cold-store-archive"),
+        ("US_FED", "EVIDENCE_COLD_STORE_BUCKET_US", "cage-us-fed-evidence"),
+        ("EU_ECB", "EVIDENCE_COLD_STORE_BUCKET_EU", "eu-cold-store-archive"),
+        ("EU_ECB", "EVIDENCE_COLD_STORE_BUCKET_EU", "cage-eu-compliance-vault"),
+        ("APAC_MAS", "EVIDENCE_COLD_STORE_BUCKET_APAC", "apac-cold-store-archive"),
+        ("APAC_MAS", "EVIDENCE_COLD_STORE_BUCKET_APAC", "cage-apac-evidence-stream"),
+        ("LOCAL", "EVIDENCE_COLD_STORE_BUCKET_LOCAL", "dev-local-evidence"),
+        ("LOCAL", "EVIDENCE_COLD_STORE_BUCKET_LOCAL", "local-evidence-bucket"),
+    ],
+)
+def test_resolve_cold_store_bucket_valid_prefixes(
+    monkeypatch: pytest.MonkeyPatch,
+    region: str,
+    env_var: str,
+    valid_bucket: str,
+):
+    """Assert valid regional prefixes resolve successfully."""
+    monkeypatch.setenv("CAGE_DEPLOYMENT_REGION", region)
+    monkeypatch.setenv(env_var, valid_bucket)
+
+    bucket = resolve_cold_store_bucket()
+    assert bucket == valid_bucket
+
+
+def test_resolve_cold_store_bucket_local_default():
+    """Assert LOCAL region falls back to default_bucket when no env vars are set."""
+    bucket = resolve_cold_store_bucket(region="LOCAL")
+    assert bucket == "local-evidence-bucket"
+
+
+def test_resolve_cold_store_bucket_missing_env_raises(monkeypatch: pytest.MonkeyPatch):
+    """Assert missing bucket configuration fails closed with MissingBucketConfigError."""
+    monkeypatch.setenv("CAGE_DEPLOYMENT_REGION", "EU_ECB")
+    with pytest.raises(
+        MissingBucketConfigError, match="Missing required bucket configuration"
+    ):
+        resolve_cold_store_bucket()
+
+
+def test_resolve_cold_store_bucket_cross_region_violation_raises(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Assert US bucket configured in EU_ECB deployment fails closed."""
+    monkeypatch.setenv("CAGE_DEPLOYMENT_REGION", "EU_ECB")
+    monkeypatch.setenv("EVIDENCE_COLD_STORE_BUCKET_EU", "us-central-evidence")
+
+    with pytest.raises(
+        ResidencyViolationError, match="violates data residency for region 'EU_ECB'"
+    ):
+        resolve_cold_store_bucket()
+
+
+def test_resolve_cold_store_bucket_location_mismatch_raises(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Assert mismatched GOOGLE_CLOUD_LOCATION fails closed even if bucket prefix is valid."""
+    monkeypatch.setenv("CAGE_DEPLOYMENT_REGION", "EU_ECB")
+    monkeypatch.setenv("EVIDENCE_COLD_STORE_BUCKET_EU", "eu-evidence-bucket")
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "us-central1")
+
+    with pytest.raises(
+        ResidencyViolationError, match="violates data residency for region 'EU_ECB'"
+    ):
+        resolve_cold_store_bucket()
+
+
+def test_resolve_cold_store_bucket_location_exception_for_unprefixed_bucket(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Assert unprefixed bucket name passes if verified against an allowed cloud location."""
+    monkeypatch.setenv("CAGE_DEPLOYMENT_REGION", "EU_ECB")
+    monkeypatch.setenv("EVIDENCE_COLD_STORE_BUCKET_EU", "custom-enterprise-vault")
+    monkeypatch.setenv("GOOGLE_CLOUD_LOCATION", "europe-west1")
+
+    bucket = resolve_cold_store_bucket()
+    assert bucket == "custom-enterprise-vault"
+
+
+def test_resolve_cold_store_bucket_unknown_region_raises():
+    """Assert unknown region raises ResidencyViolationError."""
+    with pytest.raises(
+        ResidencyViolationError,
+        match="Unknown deployment region 'UNKNOWN_JURISDICTION'",
+    ):
+        resolve_cold_store_bucket(region="UNKNOWN_JURISDICTION")
+
+
+def test_resolve_cold_store_bucket_null_backend():
+    """Assert null backend allows null placeholder in local environment."""
+    bucket = resolve_cold_store_bucket(
+        region="LOCAL", backend_id="null", bucket_override="null"
+    )
+    assert bucket == "null"

--- a/tests/test_evidence_stream.py
+++ b/tests/test_evidence_stream.py
@@ -29,13 +29,21 @@ Covers:
 All tests are hermetic — no live Redis, no GCS, no KMS.
 """
 
-from __future__ import annotations
-
+import ast
 import asyncio
+import hashlib
 import json
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+
+from src.gateway.governance.evidence.cold_store import (
+    ColdStoreError,
+    ColdStoreHealth,
+    ColdStoreReceipt,
+)
+from src.gateway.governance.evidence.null_cold_store import NullColdStore
 
 pytestmark = pytest.mark.local
 
@@ -395,29 +403,85 @@ class TestEvidenceStreamSinkLifecycle:
 
 
 # ---------------------------------------------------------------------------
-# 6. GCS flush loop (mocked)
+# 6. Cold store flush loop & seam integration
 # ---------------------------------------------------------------------------
 
 
-class TestGcsFlushLoop:
-    """Tests for the GCS flush daemon background task."""
+class FakeColdStore:
+    """In-memory EvidenceColdStore test double for evidence stream tests."""
+
+    def __init__(self, should_fail: bool = False, backend_id: str = "fake") -> None:
+        self.should_fail = should_fail
+        self._backend_id = backend_id
+        self.batches: list[tuple[str, bytes, dict]] = []
+
+    @property
+    def backend_id(self) -> str:
+        return self._backend_id
+
+    async def put_batch(
+        self, key: str, content: bytes, metadata: dict | None = None
+    ) -> ColdStoreReceipt:
+        if self.should_fail:
+            raise ColdStoreError("Simulated cold store failure")
+
+        digest = hashlib.sha256(content).hexdigest()
+        self.batches.append((key, content, metadata or {}))
+        return ColdStoreReceipt(
+            uri=f"fake://bucket/{key}",
+            key=key,
+            content_sha256=digest,
+            backend_id=self._backend_id,
+            written_at=datetime.now(tz=timezone.utc),
+        )
+
+    async def exists(self, key: str) -> bool:
+        return any(k == key for k, _, _ in self.batches)
+
+    async def put_if_absent(
+        self, key: str, content: bytes, metadata: dict | None = None
+    ) -> tuple[ColdStoreReceipt, bool]:
+        if await self.exists(key):
+            digest = hashlib.sha256(content).hexdigest()
+            return (
+                ColdStoreReceipt(
+                    uri=f"fake://bucket/{key}",
+                    key=key,
+                    content_sha256=digest,
+                    backend_id=self._backend_id,
+                    written_at=datetime.now(tz=timezone.utc),
+                ),
+                False,
+            )
+        receipt = await self.put_batch(key, content, metadata)
+        return receipt, True
+
+    def health(self) -> ColdStoreHealth:
+        return ColdStoreHealth(
+            available=not self.should_fail,
+            backend_id=self._backend_id,
+            detail="Fake cold store operational",
+        )
+
+
+class TestColdFlushLoop:
+    """Tests for the EvidenceColdStore flush daemon background task."""
 
     @pytest.mark.asyncio
-    async def test_gcs_flush_loop_exits_on_cancelled_error(self):
-        """_gcs_flush_loop must exit cleanly on CancelledError (stop() path)."""
-        sink = _make_sink()
+    async def test_cold_flush_loop_exits_on_cancelled_error(self):
+        """_cold_flush_loop must exit cleanly on CancelledError (stop() path)."""
+        sink = _make_sink(cold_store=FakeColdStore())
         sink._running = True
         sink._redis = _make_redis_mock()
 
         # Patch asyncio.sleep to immediately raise CancelledError
         with patch("asyncio.sleep", side_effect=asyncio.CancelledError):
-            # Should complete without raising
-            await sink._gcs_flush_loop()
+            await sink._cold_flush_loop()
 
     @pytest.mark.asyncio
     async def test_stop_cancels_flush_task(self):
-        """stop() must cancel the GCS flush task if it is running."""
-        sink = _make_sink()
+        """stop() must cancel the cold flush task if it is running."""
+        sink = _make_sink(cold_store=FakeColdStore())
 
         async def _forever():
             await asyncio.sleep(10000)
@@ -429,3 +493,80 @@ class TestGcsFlushLoop:
         await sink.stop()
 
         assert sink._flush_task.cancelled() or sink._flush_task.done()
+
+    @pytest.mark.asyncio
+    async def test_cold_flush_loop_persists_entries_to_cold_store(self):
+        """_cold_flush_loop reads entries from Redis and writes them to cold store."""
+        fake_store = FakeColdStore()
+        sink = _make_sink(cold_store=fake_store)
+        sink._running = True
+
+        redis_mock = _make_redis_mock()
+        redis_mock.xrange.return_value = [
+            ("100-0", {"event_type": "GOVERNANCE_DECISION", "rule": "US_FED_CAS"}),
+            ("101-0", {"event_type": "AUDIT_FINDING", "status": "PASS"}),
+        ]
+        sink._redis = redis_mock
+
+        # First sleep succeeds (run one flush pass), second sleep cancels
+        with patch("asyncio.sleep", side_effect=[None, asyncio.CancelledError]):
+            await sink._cold_flush_loop()
+
+        assert len(fake_store.batches) == 1
+        key, content, metadata = fake_store.batches[0]
+        assert key.startswith("evidence-stream/")
+        assert key.endswith(".ndjson")
+        assert b"GOVERNANCE_DECISION" in content
+        assert b"AUDIT_FINDING" in content
+        assert metadata["content-type"] == "application/x-ndjson"
+        assert metadata["entries-count"] == "2"
+
+    @pytest.mark.asyncio
+    async def test_cold_flush_loop_survives_cold_store_error(self):
+        """ColdStoreError during flush is logged, backs off, and loop survives."""
+        failing_store = FakeColdStore(should_fail=True)
+        sink = _make_sink(cold_store=failing_store)
+        sink._running = True
+
+        redis_mock = _make_redis_mock()
+        redis_mock.xrange.return_value = [("100-0", {"event_type": "FAULT"})]
+        sink._redis = redis_mock
+
+        # First sleep triggers flush (raises error), error handler sleeps 5s which cancels
+        with patch("asyncio.sleep", side_effect=[None, asyncio.CancelledError]):
+            await sink._cold_flush_loop()
+
+    def test_sink_imports_no_vendor_module(self):
+        """AST check: evidence_stream.py must not import vendor storage SDKs."""
+        import inspect
+
+        from src.compliance_bridge import evidence_stream
+
+        source = inspect.getsource(evidence_stream)
+        tree = ast.parse(source)
+
+        forbidden_prefixes = ("google.cloud", "boto3", "botocore", "azure")
+        imported_modules: list[str] = []
+
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    imported_modules.append(alias.name)
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    imported_modules.append(node.module)
+
+        for mod in imported_modules:
+            for forbidden in forbidden_prefixes:
+                assert not mod.startswith(forbidden), (
+                    f"Forbidden vendor import '{mod}' found in evidence_stream.py"
+                )
+
+    def test_null_cold_store_opens_no_socket(self):
+        """NullColdStore integration requires no credentials and opens no network sockets."""
+        null_store = NullColdStore()
+        sink = _make_sink(cold_store=null_store)
+        health = null_store.health()
+        assert health.available is True
+        assert health.backend_id == "null"
+        assert sink._cold_store.backend_id == "null"

--- a/tests/test_pr_b_null_components.py
+++ b/tests/test_pr_b_null_components.py
@@ -22,9 +22,14 @@ posture rather than silently allowing requests when domain components
 are absent.
 """
 
+import hashlib
+import os
+from unittest.mock import patch
+
 import pytest
 
 from src.gateway.governance.null_components import (
+    NullColdStore,
     NullConsensusProvider,
     NullSafetyFilter,
 )
@@ -179,3 +184,62 @@ def test_install_domain_components_prevents_double_installation():
         # Components already installed by another plugin, so even first attempt should fail
         with pytest.raises(RuntimeError, match="safety_filter already installed"):
             singletons.install_domain_components(safety_filter_impl=mock_filter)
+
+
+@pytest.mark.local
+@pytest.mark.unit
+class TestNullColdStore:
+    """Test suite for NullColdStore (succeed-locally bounded cold store placeholder)."""
+
+    @pytest.mark.asyncio
+    async def test_null_cold_store_succeeds_locally_and_receipt_well_formed(self):
+        """NullColdStore stores to bounded memory and returns valid receipt with real sha256."""
+        store = NullColdStore()
+        payload = b'{"event": "test_event", "status": "OK"}\n'
+        key = "evidence/2026/09/batch-1.ndjson"
+        receipt = await store.put_batch(key, payload)
+
+        assert receipt.uri == f"null://{key}"
+        assert receipt.key == key
+        assert receipt.backend_id == "null"
+        assert receipt.content_sha256 == hashlib.sha256(payload).hexdigest()
+        assert await store.exists(key) is True
+
+    @pytest.mark.asyncio
+    async def test_null_cold_store_put_if_absent(self):
+        """put_if_absent indicates created=True on first write, False on second."""
+        store = NullColdStore()
+        key = "oscal-artifacts/2026-09-05/audit-001.yaml"
+        content = b"sample-oscal-yaml"
+
+        receipt1, created1 = await store.put_if_absent(key, content)
+        assert created1 is True
+        assert receipt1.uri == f"null://{key}"
+
+        receipt2, created2 = await store.put_if_absent(key, content)
+        assert created2 is False
+        assert receipt2.uri == f"null://{key}"
+
+    def test_null_cold_store_health(self):
+        """health() reports available=True with backend_id='null'."""
+        store = NullColdStore()
+        health = store.health()
+        assert health.available is True
+        assert health.backend_id == "null"
+        assert "in-memory" in health.detail.lower()
+
+    def test_prod_and_null_fails_startup(self):
+        """CAGE_ENV=prod + NullColdStore fails startup unless explicitly overridden."""
+        with patch.dict(
+            os.environ, {"CAGE_ENV": "prod", "CAGE_ALLOW_NONBLOCKING_PROD": "false"}
+        ):
+            with pytest.raises(RuntimeError, match="requires durable cold storage"):
+                NullColdStore()
+
+    def test_prod_and_null_allowed_with_explicit_override(self):
+        """CAGE_ENV=prod + NullColdStore succeeds when CAGE_ALLOW_NONBLOCKING_PROD=true."""
+        with patch.dict(
+            os.environ, {"CAGE_ENV": "prod", "CAGE_ALLOW_NONBLOCKING_PROD": "true"}
+        ):
+            store = NullColdStore()
+            assert store.backend_id == "null"

--- a/tests/test_security_medium_severity.py
+++ b/tests/test_security_medium_severity.py
@@ -667,27 +667,27 @@ class TestM20RateLimiting:
 
 
 class TestM21StorageBackendLazy:
-    """M-21: _get_storage_backend() must read env var at call time, not import time."""
+    """M-21: Cold store backend selection must be resolved at call time, not import time."""
 
-    def test_get_storage_backend_function_exists(self):
-        from src.compliance_bridge.storage import _get_storage_backend
+    def test_get_cold_store_function_exists(self):
+        from src.gateway.governance.evidence.factory import get_cold_store
 
-        assert callable(_get_storage_backend)
+        assert callable(get_cold_store)
 
     def test_storage_backend_reads_env_at_call_time(self):
-        from src.compliance_bridge.storage import _get_storage_backend
+        from src.gateway.governance.evidence.factory import get_cold_store
 
-        with patch.dict(os.environ, {"STORAGE_BACKEND": "s3"}):
-            backend = _get_storage_backend()
-        assert backend == "s3"
+        with patch.dict(os.environ, {"EVIDENCE_COLD_STORE": "null"}):
+            store = get_cold_store()
+        assert store.backend_id == "null"
 
-    def test_storage_backend_defaults_to_s3(self):
-        from src.compliance_bridge.storage import _get_storage_backend
+    def test_storage_backend_defaults_to_null(self):
+        from src.gateway.governance.evidence.factory import get_cold_store
 
-        env = {k: v for k, v in os.environ.items() if k != "STORAGE_BACKEND"}
+        env = {k: v for k, v in os.environ.items() if k != "EVIDENCE_COLD_STORE"}
         with patch.dict(os.environ, env, clear=True):
-            backend = _get_storage_backend()
-        assert backend == "s3"
+            store = get_cold_store()
+        assert store.backend_id == "null"
 
     def test_no_module_level_storage_backend_constant(self):
         import inspect
@@ -695,10 +695,8 @@ class TestM21StorageBackendLazy:
         from src.compliance_bridge import storage
 
         source = inspect.getsource(storage)
-        # The old pattern: _STORAGE_BACKEND: str = os.environ.get(...)
-        assert "_STORAGE_BACKEND: str = os.environ.get" not in source, (
-            "Module-level _STORAGE_BACKEND constant must be replaced with _get_storage_backend()"
-        )
+        assert "_STORAGE_BACKEND: str = os.environ.get" not in source
+        assert "STORAGE_BACKEND" not in source
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Implements Wave 1 tasks **W1.4** (Declarative Residency Policy & Resolver) and **W1.5** (Single storage cutover: sink, factory, OSCAL consolidation, null store) from `plans/vendor_decoupling_implementation_plan.md`.

- **W1.4 Declarative Residency Resolver**: Added `config/compliance/residency.json` and zero-vendor Layer 1 resolver `src/gateway/governance/evidence/residency.py`.
- **W1.5 Cold Storage Factory & NullColdStore**: Unified `factory.py` and in-memory `null_cold_store.py`.
- **W1.5a Evidence Sink Cutover**: Sinks evidence batches via `cold_store.put_batch()` with neutral Prometheus metrics.
- **W1.5c OSCAL Consolidation**: Converted `storage.py` into a thin key-builder delegating to `cold_store.put_if_absent()`.
- **Adapter & Manifest Cleanliness**: Removed legacy `STORAGE_BACKEND`, `OSCAL_S3_*`, and `EVIDENCE_STREAM_GCS_BUCKET*` env vars.

BREAKING CHANGE: Eliminates STORAGE_BACKEND, OSCAL_S3_*, and EVIDENCE_STREAM_GCS_BUCKET* in favor of EVIDENCE_COLD_STORE and EVIDENCE_COLD_STORE_BUCKET_*.