### PR TITLE
refactor(governance)!: delete deprecated cbf compatibility shim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,7 +345,6 @@ Refactoring across v3.0.0 extracted domain mechanisms into domain plugins and mo
 |---|---|---|
 | Causal Gatekeeper | `src.gateway.governance.causal.gatekeeper` | `src.gateway.governance.causal_gatekeeper` |
 | Reconciliation Worker | `src.gateway.governance.reconciliation.worker` | `src.cage_finance.compliance.reconciliation_worker` |
-| CBF Engine | `src.gateway.governance.safety.cbf_engine` | `src.cage_finance.safety.cbf` |
 | FTRA Package | `src.gateway.governance.ftra` | Legacy flat imports in root governance |
 | Financial Tiers | `src.cage_finance.tiers` | Hardcoded blocks in `symbolic_governor.py` |
 | Healthcare Tiers | `src.cage_healthcare.tiers` | N/A (new domain plugin) |

--- a/COMPLIANCE.md
+++ b/COMPLIANCE.md
@@ -38,7 +38,7 @@ The Cybernetic Agent Governance Engine (CAGE) splits its internal control framew
 
 | System Layer | Component / Routine | Governing Framework | CAGE Control ID | Technical Artifact |
 | --- | --- | --- | --- | --- |
-| **Statistical Code** | Control Barrier Function ($h(x)$ formula & $\gamma$ decay) | **SR 26-2 §IV.B** (Model Risk Management) | `CTRL_MRM_004` | `src/gateway/governance/cbf.py` |
+| **Statistical Code** | Control Barrier Function ($h(x)$ formula & $\gamma$ decay) | **SR 26-2 §IV.B** (Model Risk Management) | `CTRL_MRM_004` | `src/gateway/governance/safety/cbf_engine.py` |
 | **Statistical Code** | DoWhy Causal Inference Model Graph & Regression Coefficients | **SR 26-2 §IV.B** (Model Risk Management) | `CTRL_MRM_004` | `src/gateway/governance/causal_gatekeeper.py` |
 | **Infrastructure** | GKE Clusters, Workload Identity, Pod Networking | **NIST RMF (SP 800-37)** · **FedRAMP HIGH** | *Out of Code Scope* | `infra/modules/gcp_gke_cluster/` |
 
@@ -60,14 +60,14 @@ The Cybernetic Agent Governance Engine (CAGE) splits its internal control framew
 
 | System Layer | Component / Routine | Governing Framework | CAGE Control ID | Technical Artifact |
 | --- | --- | --- | --- | --- |
-| **Statistical Code** | Control Barrier Function (MAS FEAT fairness boundary) | **MAS FEAT Principles** | `CTRL_MRM_004` | `src/gateway/governance/cbf.py` |
+| **Statistical Code** | Control Barrier Function (MAS FEAT fairness boundary) | **MAS FEAT Principles** | `CTRL_MRM_004` | `src/gateway/governance/safety/cbf_engine.py` |
 | **Statistical Code** | DoWhy Causal Inference (MAS FEAT accountability) | **MAS FEAT Principles** | `CTRL_MRM_004` | `src/gateway/governance/causal_gatekeeper.py` |
 
 ### 1.5 Summary Mapping for Examiners
 
 | System Layer | Component / Routine | Governing Framework | CAGE Control ID | Technical Artifact | Active Regions |
 | --- | --- | --- | --- | --- | --- |
-| **Statistical Code** | Control Barrier Function ($h(x)$ formula & $\gamma$ decay) | **SR 26-2 §IV.B** <br> (Model Risk Management) | `CTRL_MRM_004` | `src/gateway/governance/cbf.py` | `US_FED`, `APAC_MAS` *(suppressed in EU_ECB)* |
+| **Statistical Code** | Control Barrier Function ($h(x)$ formula & $\gamma$ decay) | **SR 26-2 §IV.B** <br> (Model Risk Management) | `CTRL_MRM_004` | `src/gateway/governance/safety/cbf_engine.py` | `US_FED`, `APAC_MAS` *(suppressed in EU_ECB)* |
 | **Statistical Code** | DoWhy Causal Inference Model Graph & Regression Coefficients | **SR 26-2 §IV.B** <br> (Model Risk Management) | `CTRL_MRM_004` | `src/gateway/governance/causal_gatekeeper.py` | `US_FED`, `APAC_MAS` *(suppressed in EU_ECB)* |
 | **Autonomous Engine** | LLM Routers & Execution Trust Thresholds | **ISO/IEC 42001 §A.5.2** <br> (AI Management System) | `CTRL_AGT_001` | `src/gateway/governance/symbolic_governor.py` | *All Regions* |
 | **Autonomous Engine** | LangGraph SAGA WAL Router + Atomic Rollback Patterns | **ISO/IEC 42001 §A.8.4** <br> **DORA Article 12** | `CTRL_WAL_002` | `src/gateway/governance/generated_saga_nodes.py` | *All Regions* |
@@ -92,7 +92,7 @@ The following formal invariants are implemented directly in source code and enfo
 
 ### 2.1 Control Barrier Function (CBF)
 
-**Source:** [`src/gateway/governance/cbf.py`](src/gateway/governance/cbf.py) · **Control:** `CTRL_MRM_004`
+**Source:** [`src/gateway/governance/safety/cbf_engine.py`](src/gateway/governance/safety/cbf_engine.py) · **Control:** `CTRL_MRM_004`
 
 The safe set is `S = {x ∈ ℝⁿ : h(x) ≥ 0}` where the barrier function is:
 

--- a/tests/test_cbf_shim_guard.py
+++ b/tests/test_cbf_shim_guard.py
@@ -1,0 +1,49 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Guard test to verify permanent removal of deprecated CBF compatibility shim.
+
+Per AGENTS.md, plans/vendor_decoupling_implementation_plan.md §3 Task W1.7, and AW-5:
+The legacy shim `src/cage_finance/safety/cbf.py` is permanently deleted.
+Callers must strictly import canonical `src.gateway.governance.safety.cbf_engine`.
+This guard prevents accidental re-introduction of the compatibility shim.
+"""
+
+import importlib.util
+import pytest
+
+
+@pytest.mark.local
+@pytest.mark.unit
+def test_cbf_compatibility_shim_does_not_exist():
+    """Verify that src.cage_finance.safety.cbf cannot be found or imported."""
+    spec = importlib.util.find_spec("src.cage_finance.safety.cbf")
+    assert spec is None, (
+        "Forbidden compatibility shim 'src.cage_finance.safety.cbf' was detected! "
+        "Per AGENTS.md and W1.7, all CBF logic lives in 'src.gateway.governance.safety.cbf_engine' "
+        "and backward-compatibility shims must not exist."
+    )
+
+    with pytest.raises(ModuleNotFoundError):
+        import src.cage_finance.safety.cbf  # noqa: F401
+
+
+@pytest.mark.local
+@pytest.mark.unit
+def test_cbf_engine_canonical_import():
+    """Verify that canonical cbf_engine is importable and exports ControlBarrierFunction."""
+    from src.gateway.governance.safety.cbf_engine import ControlBarrierFunction
+
+    assert callable(ControlBarrierFunction)
+

--- a/tests/test_cbf_shim_guard.py
+++ b/tests/test_cbf_shim_guard.py
@@ -21,6 +21,7 @@ This guard prevents accidental re-introduction of the compatibility shim.
 """
 
 import importlib.util
+
 import pytest
 
 
@@ -46,4 +47,3 @@ def test_cbf_engine_canonical_import():
     from src.gateway.governance.safety.cbf_engine import ControlBarrierFunction
 
     assert callable(ControlBarrierFunction)
-


### PR DESCRIPTION
## Summary
Implements Wave 1 Task **W1.7** (`[T4.2]`) from `plans/vendor_decoupling_implementation_plan.md`:
- Removed the deprecated `src.cage_finance.safety.cbf` row from the canonical namespace table in `AGENTS.md`.
- Updated technical artifact citations for `CTRL_MRM_004` in `COMPLIANCE.md` to canonical `src/gateway/governance/safety/cbf_engine.py`.
- Added unit guard test `tests/test_cbf_shim_guard.py` asserting that `src.cage_finance.safety.cbf` does not exist and cannot be imported, preventing accidental regression.

BREAKING CHANGE: Eliminates src.cage_finance.safety.cbf compatibility shim; all callers must import canonical src.gateway.governance.safety.cbf_engine.