### PR TITLE
ci(ci): disable broken nightly workflows

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -22,8 +22,15 @@ concurrency:
 
 
 on:
-  schedule:
-    - cron: '0 3 * * *'   # 03:00 UTC daily
+  # DISABLED: 25/25 nightly runs failed at "Set up job" before any test ran.
+  # Root cause: required secrets do not exist (only MIRROR_SECRET is configured).
+  # Needs: GOOGLE_CREDENTIALS, GKE_CLUSTER_NAME, GKE_CLUSTER_LOCATION
+  # Per AGENTS.md, live-GKE validation is a deliberate manual activity via
+  # port_forward_dev.sh + --run-integration, not an unattended nightly against
+  # a cluster this repo has no credentials for. Keep workflow_dispatch for
+  # manual runs once secrets are configured.
+  # schedule:
+  #   - cron: '0 3 * * *'   # 03:00 UTC daily (disabled)
   workflow_dispatch:
     inputs:
       namespace:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -487,8 +487,13 @@ jobs:
   locust-load-test:
     name: "Nightly Load Test (Locust)"
     runs-on: ubuntu-latest
-    # Run only on the nightly schedule — not on every push or pull_request.
-    if: github.event_name == 'schedule'
+    # DISABLED: cannot start the gateway. Three defects must be fixed first:
+    #  1. vllm_client.py:76 reads VLLM_BASE_URL but the job sets VLLM_GATEWAY_URL
+    #  2. no services: containers for Redis (6379) or OPA (8181) that the env points at
+    #  3. the health loop prints "Gateway ready" even after 30 failed curl attempts,
+    #     so Locust would silently hammer a dead port with no early failure signal
+    # Verified by execution: gateway crashes with "VLLM_BASE_URL must be set"
+    if: false  # was: github.event_name == 'schedule'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/poam-drift.yml
+++ b/.github/workflows/poam-drift.yml
@@ -22,8 +22,11 @@ concurrency:
 
 
 on:
-  schedule:
-    - cron: '0 4 * * *'   # 04:00 UTC daily
+  # REMOVED SCHEDULE: this is a deterministic function of repo content
+  # (check_poam_lula_divergence.py reads docs/POAM.md and compliance/lula/).
+  # The pull_request trigger already runs on changes to those exact paths,
+  # so the nightly cron re-computed an identical answer on an unchanged tree.
+  # Verified offline: 36 covered, 14 skipped, 0 uncovered, exit 0.
   pull_request:
     paths:
       - 'docs/POAM.md'


### PR DESCRIPTION
## Summary

A nightly job audit found that **3 of the 4 scheduled runs either cannot succeed or duplicate existing PR triggers**. Only the security scan nightly provides unique value.

## Analysis Results

| Nightly | Cron | Historical Outcome | Action Taken |
|---|---|---|---|
| **Security Scanning** | 02:00 | 32 pass / 18 fail | ✅ **UNCHANGED — keep** |
| **POAM Drift Check** | 04:00 | 15 pass / 10 fail | ⚠️ **Removed cron** (kept PR trigger) |
| **Integration Tests** | 03:00 | **0 pass / 25 fail** | ❌ **Disabled cron** (kept workflow_dispatch) |
| **Locust Load Test** | 02:00 | never ran | ❌ **Re-disabled with defect comments** |

## Changes Made

### 1. Locust (re-disabled with detailed defect documentation)

**Status before:** I had re-enabled this in PR #145, removing `if: false` under the assumption the disablement was accidental.

**Verification by execution proved that wrong:** Launched the gateway with the job's exact env block and it crashes:
```
RuntimeError: VLLM_BASE_URL must be set — no localhost fallback in production
ERROR:    Application startup failed. Exiting.
```

**Root causes** (added as inline comments):
1. The job sets `VLLM_GATEWAY_URL` but vllm_client.py:76 reads `VLLM_BASE_URL` (wrong variable name)
2. No `services:` containers for the Redis (6379) or OPA (8181) endpoints the env points at
3. The health loop prints "Gateway ready" even after 30 failed curl attempts, so Locust would silently hammer a dead port

### 2. Integration Tests (disabled nightly cron, kept workflow_dispatch)

**Historical record:** 25 runs, 25 failures, all at "Set up job" before any test executed.

**Root cause:**
```bash
$ gh api repos/:owner/:repo/actions/secrets --jq '.total_count, (.secrets[]?.name)'
1
MIRROR_SECRET
```

The job requires `GOOGLE_CREDENTIALS`, `GKE_CLUSTER_NAME`, `GKE_CLUSTER_LOCATION` — **none exist**.

Per AGENTS.md, live-GKE validation is meant to be a deliberate manual activity (`port_forward_dev.sh` + `--run-integration`), not an unattended nightly against a cluster this repo has no credentials for.

**Change:** Commented out the `schedule:` cron, kept `workflow_dispatch:` for manual runs once secrets are configured.

### 3. POAM Drift (removed redundant cron)

**Verification:** Ran locally — `36 covered, 14 skipped, 0 uncovered`, exit 0.

**Analysis:** This is a **deterministic function of repo content**. `check_poam_lula_divergence.py` reads `docs/POAM.md` and `compliance/lula/`, touches no network. Its result cannot change between commits.

**The workflow already has:**
```yaml
pull_request:
  paths:
    - 'docs/POAM.md'
    - 'compliance/lula/**'
```

The 04:00 cron re-computes an identical answer on an unchanged tree.

**Change:** Removed the `schedule:` cron, kept the PR trigger.

### 4. Security Scan (unchanged — the only one earning its slot)

**Proof of value:** The **2026-08-22** nightly run failed on `Python Dependency Vulnerability Scan` — a **newly disclosed CVE against unchanged code**. No push-triggered job can structurally detect that, because nothing was pushed.

Its recent Sept 1–5 failures correctly detected the broken OPA tests on `main` that I later traced and fixed. A 64% pass rate here reflects real signal, not flakiness.

## Net Effect

**Before:** 4 nightlies producing ~25 false alarms per month  
**After:** 1 nightly that works

## Verification

- All 3 modified workflows parse cleanly
- Inline comments document the specific defects preventing Locust and Integration from succeeding
- Security Scanning workflow untouched