### PR TITLE
refactor(integrations): retire provider_04 naming residue after actuator_01 migration

### DIFF
--- a/plans/cage_internal_blockers_implementation_plan.md
+++ b/plans/cage_internal_blockers_implementation_plan.md
@@ -1,0 +1,683 @@
+# CAGE Internal Blockers — Implementation Plan
+
+> **Reference Architecture Note (per [`AGENTS.md`](../AGENTS.md)).**
+> CAGE is a reference architecture, not a deployed production service. This plan
+> optimizes for **clean architecture and structural clarity over operational
+> continuity and backward compatibility**. Breaking changes are acceptable and
+> desirable. No deprecation window is owed. The partner is referred to
+> throughout by the anonymized slot name `actuator_01`; the raw vendor name
+> appears only in gitignored `local/` material.
+
+**Status:** Ready for implementation — all three work items are unblocked and have
+**zero partner dependency**.
+
+**Scope:** The three CAGE-internal blocking items:
+
+1. **Stream B** — dual-control mechanism (B-1 + B-2)
+2. **`provider_04` retirement** — remove the architecturally-wrong legacy artifact
+3. **Import boundary CI** — add the `src/gateway` → `src.integrations` rule
+
+**Governing sources:**
+[`IMPLEMENTATION_PLAN_v2.md`](../local/integrations/archytan/IMPLEMENTATION_PLAN_v2.md) §4, §5.3, §6,
+[`Secure Plugin & Adapter Architecture Specification.md`](../local/analysis/Secure%20Plugin%20%26%20Adapter%20Architecture%20Specification.md)
+
+---
+
+## 0. Critical Finding — The Plan v2 Baseline Is Stale
+
+Codebase inspection shows that **the bulk of Stream B has already been
+implemented**, and `src/integrations/provider_04/` **has already been deleted**.
+Plan v2's premise — "CAGE has no multi-approver quorum mechanism" — is no longer
+accurate. Implementing it again would be wasted work.
+
+However, inspection surfaced a **different and more dangerous problem**: the
+dual-control mechanism that exists is **forgeable by an unauthenticated caller**,
+and the quorum escalation table is **dead code**. The residual work is therefore
+smaller in volume but higher in severity than plan v2 anticipated.
+
+### 0.1 What has already landed
+
+| Plan v2 deliverable | Status | Evidence |
+|---|---|---|
+| `ApprovalRecord` model | ✅ Landed | [`defer_queue.py:124`](../src/gateway/governance/defer_queue.py:124) |
+| `DeferToken.approvals` list | ✅ Landed | [`defer_queue.py:212`](../src/gateway/governance/defer_queue.py:212) |
+| `DeferToken.required_quorum` field | ✅ Landed | [`defer_queue.py:213`](../src/gateway/governance/defer_queue.py:213) |
+| `schema_version = 2` | ✅ Landed | [`defer_queue.py:211`](../src/gateway/governance/defer_queue.py:211) |
+| **B-2** `correlation_id` + uuid5 legacy derivation | ✅ Landed | [`defer_queue.py:216`](../src/gateway/governance/defer_queue.py:216) |
+| `ApprovalStatus` enum | ✅ Landed | [`defer_queue.py:229`](../src/gateway/governance/defer_queue.py:229) |
+| `DeferReason` → quorum table, total over 7 values | ✅ Landed | [`defer_queue.py:251`](../src/gateway/governance/defer_queue.py:251) |
+| `DeferQueue.approve()` under WATCH/MULTI/EXEC | ✅ Landed | [`defer_queue.py:436`](../src/gateway/governance/defer_queue.py:436) |
+| `PARTIALLY_APPROVED` state | ✅ Landed | [`defer_queue.py:520`](../src/gateway/governance/defer_queue.py:520) |
+| `defer_escalate()` takes an operator-bearing body | ✅ Landed | [`main.py:1480`](../src/compliance_bridge/main.py:1480) |
+| `src/integrations/provider_04/` package deleted | ✅ Landed | Directory does not exist |
+| `actuator_01` package — 8 modules | ✅ Landed | [`src/integrations/actuator_01/`](../src/integrations/actuator_01/) |
+| WebAuthn optional fields on `ApprovalRecord` | ✅ Landed | [`defer_queue.py:149`](../src/gateway/governance/defer_queue.py:149) |
+
+### 0.2 What actually remains — the real residual
+
+| ID | Residual gap | Severity |
+|---|---|---|
+| **R-B1a** | [`defer_escalate()`](../src/compliance_bridge/main.py:1480) has **no authentication dependency**. Compare [`main.py:672`](../src/compliance_bridge/main.py:672) and [`main.py:1003`](../src/compliance_bridge/main.py:1003), which both carry `Depends(require_internal_token)`. | **P0** |
+| **R-B1b** | `operator_urn` is **self-asserted in the request body**. Two POSTs with two invented URNs satisfy quorum. Dual control is forgeable by one actor. | **P0** |
+| **R-B1c** | `auth_principal_hash` is `sha256(body.session_id)` — a hash of **attacker-supplied input**, not of an authenticated principal. See [`main.py:1526`](../src/compliance_bridge/main.py:1526). | **P0** |
+| **R-B1d** | [`get_required_quorum()`](../src/gateway/governance/defer_queue.py:262) is **dead code** — zero call sites in `src/`. `required_quorum` always defaults to `2`, so `FTRA_IRREVERSIBLE_TERMINAL`, `EXTERNAL_VALIDATION`, and `FLOWSIGNAL_ESCALATION` silently get **2 instead of the mandated 3**. | **P1** |
+| **R-B1e** | [`defer_inject()`](../src/compliance_bridge/main.py:1323) resolves tokens on the data-hydration path with **no quorum check**, providing a bypass around dual control. | **P1** |
+| **R-P04a** | Dangling `"p04"` and `"p05"` entries remain in the `alias_map` at [`normative_provider.py:921`](../src/gateway/governance/normative_provider.py:921) — they resolve to names with no factory branch, falling through to `ValueError`. | P2 |
+| **R-P04b** | `provider_04` referenced in three docstrings and three test modules. | P2 |
+| **R-P04c** | [`scratch/archytan_test.py`](../scratch/archytan_test.py) leaks the raw vendor name and the `urn:archytan:op:` namespace. | P2 |
+| **R-IB** | No `src/gateway` → `src.integrations` import boundary rule exists in [`check_import_boundaries.py`](../scripts/check_import_boundaries.py). | P1 |
+
+### 0.3 The honest restatement of B-1
+
+Plan v2 §1.2 said CAGE's dual control was *"one unauthenticated POST."* After the
+schema work, it is now **two unauthenticated POSTs with caller-chosen operator
+names**. The state machine is correct; the **identity binding underneath it is
+absent**. Until R-B1a/b/c close, the `≥2 distinct operators` property CAGE would
+assert to the partner — and any ISO 42001 human-oversight control mapping built on
+it — remains an **inaccurate control assertion**. The publication gate from plan
+v2 §6.4 stays shut.
+
+---
+
+## 1. Work Item 1 — Retire `provider_04`
+
+**Branch:** `refactor/retire-provider-04`
+**Depends on:** nothing
+**Rationale:** `provider_04` was an `EnvelopeMapper`/`AttestationProvider` framing
+of what is architecturally a **downstream execution actuator**. That framing is
+wrong: CAGE is the *issuer*, not the consumer. The package is already gone; this
+item removes the residue so no future contributor rebuilds against it.
+
+### 1.1 Kernel changes
+
+| Target | Change |
+|---|---|
+| [`normative_provider.py:921`](../src/gateway/governance/normative_provider.py:921) | Delete the `"p04": "provider_04"` alias. It resolves to a name with no factory branch. |
+| [`normative_provider.py:922`](../src/gateway/governance/normative_provider.py:922) | Evaluate `"p05": "provider_05"` in the same pass — `provider_05` also has no branch in `get_normative_provider`. Either remove the alias or add the missing branch. **Recommendation: remove**, since `provider_05` implements `EnvelopeMapper`, not `NormativeProvider`. |
+| [`normative_provider.py:902`](../src/gateway/governance/normative_provider.py:902) | Rewrite the docstring note. Replace the `provider_04 and provider_05` sentence with an `actuator_01` pointer describing the `ExecutionActuator` seam. |
+| [`src/integrations/__init__.py:27`](../src/integrations/__init__.py:27) | Replace the `provider_04/ — Attestation provider + envelope mapper` line with an `actuator_01/ — Downstream execution actuator` entry. |
+
+### 1.2 Test changes
+
+| Target | Change |
+|---|---|
+| [`test_normative_provider_conformance.py:49`](../tests/test_normative_provider_conformance.py:49) | Remove `"provider_04"` from `ATTESTATION_PROVIDERS`. Confirm whether the list is referenced at all — `test_attestation_providers_exist` imports `provider_02` and `provider_05` directly and never reads it. If unused, delete the constant. |
+| [`test_jcs_canonicalizer.py:77`](../tests/test_jcs_canonicalizer.py:77), [`:117`](../tests/test_jcs_canonicalizer.py:117) | Rename `test_jcs_provider_04_reference_vector_1/2` to `..._actuator_01_...`. Update the `envelope_version` literal from `provider_04.envelope/v1` to `actuator_01.envelope/v1` and the `operator_urn` from `urn:provider_04:op:` to `urn:actuator01:op:`. **Recompute the expected canonical bytes and SHA-256** — these are byte-exact assertions and the literals change. |
+| [`test_actuator_01_envelope.py:382`](../tests/test_actuator_01_envelope.py:382) | Update the comment pointing at the old vector test name. |
+| [`test_provider_05_warrant_contract.py:99`](../tests/test_provider_05_warrant_contract.py:99) | Change the `urn:provider_04:op:test_operator` actor literal to `urn:actuator01:op:test_operator`. |
+
+> **Note on the byte-exact vectors.** These two vectors are the partner's published
+> reference vectors and are the strongest evidence that CAGE's JCS canonicalizer
+> is wire-correct. Do **not** weaken the assertions. Recompute the digests from the
+> renamed inputs and keep the byte-exact comparison intact. Preserve a comment
+> recording that the vector *structure* is the partner's, with only the anonymized
+> slot names substituted.
+
+### 1.3 Hygiene
+
+- Delete [`scratch/archytan_test.py`](../scratch/archytan_test.py). It is gitignored,
+  so it is not a committed leak, but it contains the raw vendor name and the
+  `urn:archytan:op:` namespace and should not persist in a working tree.
+- Grep for any remaining `provider_04` / `Provider04` occurrence in committed
+  paths and confirm zero results before opening the PR.
+
+### 1.4 Acceptance criteria
+
+- `rg -n 'provider_04|Provider04' src/ tests/ scripts/ docs/ compliance/` returns **zero** results.
+- `get_normative_provider("p04")` raises `ValueError` with a message listing only live providers.
+- Both JCS reference vectors still pass byte-exact under the new naming.
+- `make test-fast` is green.
+
+---
+
+## 2. Work Item 2 — Stream B Residual: Bind Dual Control to Real Identity
+
+**Branch:** `feat/defer-dual-control-auth`
+**Depends on:** nothing
+**This is the true critical path.** It is a **breaking change** to the escalate
+endpoint contract, which per [`AGENTS.md`](../AGENTS.md) is acceptable and desirable.
+
+### 2.1 The design problem
+
+The current flow trusts the caller for the one thing that must not be caller-controlled:
+
+```mermaid
+graph LR
+    A[Unauthenticated POST] --> B[body.operator_urn<br/>self-asserted]
+    B --> C[ApprovalRecord]
+    C --> D[approve]
+    D --> E[distinct-URN check<br/>passes trivially]
+    E --> F[QUORUM_REACHED]
+```
+
+`DeferQueue.approve()` correctly enforces *distinctness of `approver_urn`*, but
+`approver_urn` is a **string the caller chose**. Distinctness of attacker-chosen
+strings is not dual control.
+
+The fix inverts the trust direction: the approver identity must be **derived from
+the authenticated principal**, and the request body's claim must be either
+dropped entirely or validated as a cross-check that cannot widen authority.
+
+```mermaid
+graph LR
+    A[Authenticated POST] --> B[Auth dependency<br/>resolves principal]
+    B --> C[Derive approver_urn<br/>from principal]
+    C --> D[ApprovalRecord]
+    D --> E[approve]
+    E --> F[distinct principals<br/>genuinely enforced]
+    F --> G[QUORUM_REACHED]
+```
+
+### 2.2 Task B-2.1 — Authenticate the escalate endpoint
+
+Add the existing dependency to [`defer_escalate()`](../src/compliance_bridge/main.py:1480),
+matching the pattern already used at [`main.py:1003`](../src/compliance_bridge/main.py:1003):
+
+- Add `_auth: str = Depends(require_internal_token)` to the signature.
+- Apply the same treatment to [`defer_inject()`](../src/compliance_bridge/main.py:1323),
+  which is likewise unauthenticated today.
+
+**Caveat to record in the PR description.** [`require_internal_token`](../src/compliance_bridge/auth.py:40)
+is a **shared service token**, not a per-operator identity. It authenticates *the
+caller is an internal service*, not *which human approved*. It is a necessary
+first step and it closes the anonymous-access hole, but on its own it does **not**
+deliver dual control — a single holder of the service token can still mint two
+approvals. Task B-2.2 is what actually closes B-1.
+
+### 2.3 Task B-2.2 — The Operator Identity Seam (expanded design)
+
+This is the substantive piece and the one that actually closes B-1. It is
+specified in depth below because `defer_escalate()` is the **highest-consequence
+override path in the engine**: it is the mechanism by which a human overrides a
+governance decision the machine already declined to make autonomously.
+
+#### 2.3.1 The governing invariant
+
+> **CAGE's core architectural invariant: execution and authorization integrity
+> must never rely on self-attestation from the domain being governed.**
+
+Every other authorization surface in CAGE already honours this. The
+[`AgentGatewayAdapter`](../src/gateway/server/agent_gateway_adapter.py:1133)
+derives `caller_principal` from `request.attributes.source.principal` — the SPIFFE
+ID the service mesh extracted from the verified client certificate SAN — and
+explicitly **fails closed** when extraction fails
+([`:1134`](../src/gateway/server/agent_gateway_adapter.py:1134)). The agent
+catalog at [`config/agent_catalog.json`](../config/agent_catalog.json) keys
+authorization on the **full `spiffe://` identity**, and
+[`agent_registry_adapter.py`](../src/gateway/governance/ingress/agent_registry_adapter.py:314)
+takes pains to preserve the whole identity string rather than a suffix,
+specifically to prevent authorization grant substitution.
+
+The DEFER escalation path is the **one place that does not follow this pattern**.
+It accepts the principal as a JSON string field. That is a split-brain trust
+model: the same deployment verifies agent identity cryptographically at the
+transport layer while accepting operator identity as a self-declared parameter on
+the path that can override the verifier. Closing this is not about adding an auth
+check — it is about restoring architectural symmetry.
+
+#### 2.3.2 Identity provenance — SPIFFE/SVID as the substrate
+
+> **ADR — Operator Identity Provenance**
+> **Status:** Accepted · **Supersedes:** the self-asserted `operator_urn` in
+> [`DeferEscalateRequest`](../src/compliance_bridge/main.py:1460)
+> **Decision:** Operator identity for dual-control approval is derived from the
+> **SPIFFE/SVID mTLS substrate**, with a configuration-gated OIDC JWT fallback for
+> TLS-terminating topologies. Identity is never accepted from the request body.
+> **Consequence:** Dual control rests on the same verified transport identity as
+> the rest of the engine. Deployments that cannot surface a client certificate
+> must explicitly opt into the weaker channel rather than silently degrading.
+
+**Decision (accepted): mTLS/SPIFFE SVID is the identity substrate; OIDC JWT is a
+constrained fallback.**
+
+CAGE already runs a SPIFFE trust domain. [`linkerd-mtls-policy.yaml`](../deployment/k8s/linkerd-mtls-policy.yaml:154)
+establishes that identity strings are *"derived deterministically from the
+ServiceAccount"*, defines `cage-compliance-bridge-sa`
+([`:83`](../deployment/k8s/linkerd-mtls-policy.yaml:83)), and enforces
+`MeshTLSAuthentication` + `AuthorizationPolicy` such that a pod without a valid
+SPIFFE certificate is rejected **at the proxy sidecar before any byte reaches the
+application port** ([`:205`](../deployment/k8s/linkerd-mtls-policy.yaml:205)).
+The OSCAL SSP already asserts SVID-derived workload identity with in-memory-only
+private keys ([`oscal_ssp_exporter.py:319`](../src/gateway/governance/oscal_ssp_exporter.py:319)).
+
+Binding operator identity to this substrate means the dual-control property rests
+on the same cryptographic foundation as the rest of the engine, verified per call,
+with no new trust root introduced.
+
+| Source | Precedence | `auth_method` | Provenance |
+|---|---|---|---|
+| SPIFFE SVID / mTLS client certificate | **Primary** | `"MTLS"` | Transport-layer, verified by the mesh proxy before the request reaches the app |
+| OIDC bearer JWT | Fallback | `"OIDC"` | Application-layer, verified against [`jwks.py`](../src/gateway/governance/jwks.py) |
+| WebAuthn assertion | Phase 5 | `"WEBAUTHN"` | Gated on partner Q1/Q6; `ApprovalRecord` fields already exist and stay `None` |
+
+**Precedence is evaluated, not negotiated.** If a verified SVID is present it wins
+unconditionally. A caller must not be able to suppress the certificate channel in
+favour of a JWT channel it finds easier to control.
+
+**Disagreement fails closed.** If both an SVID and an OIDC `sub` resolve, and they
+map to **different** operator URNs, return `403`. A conflict between two identity
+channels is a signal, never a tiebreak.
+
+**The OIDC fallback is deliberately constrained.** It exists only for deployments
+that terminate TLS at an ingress proxy and therefore cannot surface a client
+certificate to the application. Two rules govern it:
+
+- It must be **explicitly enabled** by configuration (e.g.
+  `CAGE_OPERATOR_IDENTITY_ALLOW_OIDC`). It must not be reachable by default, so a
+  misconfigured mesh silently degrades to the weaker channel.
+- Where a proxy forwards the verified subject in a header (XFCC-style), that
+  header is trustworthy **only** when the proxy→app connection is itself
+  authenticated and the app strips any inbound copy of that header from
+  untrusted sources. An unstripped forwarded-subject header is caller-controlled
+  input and reintroduces R-B1b verbatim. State this explicitly in the deployment
+  notes; it is the most likely way this design gets silently defeated in practice.
+
+**Never fall back to the service token as an identity.**
+[`require_internal_token`](../src/compliance_bridge/auth.py:40) authenticates
+*a service*, not *an operator*. Using it as a principal would let one token holder
+mint both approvals — the exact defect being closed.
+
+#### 2.3.3 Human operator vs. workload identity
+
+A genuine wrinkle deserves stating plainly. A SPIFFE SVID in a Kubernetes mesh
+identifies a **workload** (a ServiceAccount), not a **human**. If two human
+operators both approve through the same web console pod, they present the *same*
+SVID. The distinctness check in
+[`DeferQueue.approve()`](../src/gateway/governance/defer_queue.py:436) would then
+reject the second approval as `ALREADY_APPROVED` — correct behaviour, but it means
+**SVID alone cannot express two-human quorum through a shared front end**.
+
+This yields a two-tier model that must be documented rather than glossed:
+
+| Caller shape | Identity binding | Dual control genuinely satisfied? |
+|---|---|---|
+| Operator with an individually-issued client certificate | SVID/DN maps 1:1 to a human operator URN | **Yes** |
+| Operator via a shared console workload, with OIDC user token | Workload SVID authenticates the *channel*; OIDC `sub` identifies the *human* | **Yes**, provided both are verified and the `sub` supplies `operator_urn` |
+| Operator via a shared console workload, no user token | Only a workload identity is available | **No** — must fail closed |
+
+In the second row the two channels are **complementary, not redundant**: the SVID
+proves the request came from the sanctioned console, and the OIDC `sub` proves
+which human sat behind it. The conflict rule in §2.3.2 applies to the *operator
+URN* dimension only; a workload SVID and a human `sub` are not "in conflict"
+because they answer different questions. Implement this as an explicit resolution
+order rather than an implicit one:
+
+1. If an individually-issued operator certificate is present → `operator_urn` from
+   its subject, `auth_method="MTLS"`.
+2. Else if a workload SVID is present **and** OIDC is enabled **and** a verified
+   `sub` is present → `operator_urn` from the `sub`, `auth_method="OIDC"`, and
+   record the workload SVID alongside as channel provenance.
+3. Else → fail closed.
+
+The distinction between an individual operator certificate and a workload SVID
+must itself be explicit — for example a dedicated trust-domain path prefix — and
+not inferred by string heuristics on the DN.
+
+#### 2.3.4 The `OperatorPrincipal` contract
+
+A new `require_operator_identity` dependency in
+[`src/compliance_bridge/auth.py`](../src/compliance_bridge/auth.py), returning:
+
+| Field | Source | Notes |
+|---|---|---|
+| `operator_urn` | Verified credential subject per §2.3.3 | **Never** read from the request body |
+| `auth_method` | `"MTLS"` \| `"OIDC"` \| `"WEBAUTHN"` \| `"DEV_SYNTHETIC"` | Set by the dependency, not the caller |
+| `principal_hash` | `sha256` of the verified subject | Replaces `sha256(session_id)` at [`main.py:1526`](../src/compliance_bridge/main.py:1526) |
+| `channel_provenance` | Workload SVID when distinct from `operator_urn` | Audit-only; never participates in the distinctness check |
+
+`ApprovalRecord` already carries `approver_urn`, `auth_method`, and
+`auth_principal_hash` ([`defer_queue.py:136`](../src/gateway/governance/defer_queue.py:136)),
+so this maps onto the existing schema with **no model change** — the fields simply
+start being populated from a verified source. `channel_provenance` is the only
+candidate addition, and it can live in the audit event rather than the token if a
+schema change is undesirable.
+
+#### 2.3.5 Body contract change (breaking)
+
+Remove `operator_urn`, `session_id`, and `auth_method` from
+[`DeferEscalateRequest`](../src/compliance_bridge/main.py:1460). All three become
+server-derived. Any retained body field (e.g. justification text) must be
+non-authoritative and must never reach `ApprovalRecord.approver_urn`.
+
+Reject rather than ignore: if the body asserts an `operator_urn` at all, return
+`400`. Silently ignoring a field a caller believes is load-bearing is how this
+class of defect returns. Per [`AGENTS.md`](../AGENTS.md), this breaking change is
+desirable and owed no deprecation shim.
+
+#### 2.3.6 Dev-mode boundary — the leak risk
+
+[`require_internal_token`](../src/compliance_bridge/auth.py:59) **degrades open**
+in `CAGE_ENV=dev`, returning the literal `"dev-unauthenticated"`. Note also that
+it defaults `CAGE_ENV` to `"prod"` precisely to fail secure — the right instinct,
+and the operator dependency must inherit it.
+
+The operator dependency must **not** replicate the degrade-open behaviour, because
+a loose dev toggle here does not merely ease local development — it produces
+**approval records that are indistinguishable in the audit trail from genuine
+ones**. That is the specific failure this section exists to prevent.
+
+Required dev-mode properties:
+
+| Property | Requirement |
+|---|---|
+| Enablement | Only when `CAGE_ENV` is explicitly `dev`/`development` **and** an explicit `CAGE_ALLOW_DEV_OPERATOR_IDENTITY` opt-in is set. Two independent conditions, never one. |
+| Labelling | `auth_method="DEV_SYNTHETIC"` — a value that has no production meaning and is trivially greppable in evidence |
+| Distinctness | Each synthetic principal is **distinct per request**, so multi-operator flows are exercisable locally |
+| Honesty | Synthetic principals must be distinct **and** obviously synthetic — e.g. a reserved `urn:cage:dev:` prefix that production URN mapping can never emit |
+| Evidence | Any `DeferToken` containing a `DEV_SYNTHETIC` approval is marked as non-evidentiary; the compliance narrative must state that such tokens are excluded from control assertions |
+| Guard | A test asserts that with `CAGE_ENV=prod`, no configuration produces a `DEV_SYNTHETIC` principal |
+
+The reserved-prefix rule is what makes the exclusion mechanically checkable later:
+a Lula or OSCAL assertion can scan for `urn:cage:dev:` in approval records and fail
+if any reaches a production evidence set.
+
+### 2.4 Task B-2.3 — Wire the quorum table into the park path
+
+[`get_required_quorum()`](../src/gateway/governance/defer_queue.py:262) exists,
+is total over all seven `DeferReason` values, and is **never called**. Consequently
+the three high-consequence reasons that the table assigns `3` are running at the
+field default of `2`.
+
+- Set `required_quorum` from `get_required_quorum(token.defer_reason)` at token
+  construction. The cleanest placement is inside
+  [`DeferToken.model_post_init`](../src/gateway/governance/defer_queue.py:216),
+  alongside the existing `correlation_id` derivation — but **only when the caller
+  did not explicitly supply a value**, so that an explicit override remains possible.
+- Alternatively enforce it in [`DeferQueue.park()`](../src/gateway/governance/defer_queue.py:323).
+  `model_post_init` is preferred: it makes the invariant hold for every
+  `DeferToken` regardless of construction path, including tokens rehydrated in tests.
+- Add a test asserting the mapping is **total** — parametrize over
+  `list(DeferReason)` and assert `get_required_quorum` raises no `KeyError`, so a
+  future eighth enum value fails loudly rather than defaulting.
+
+### 2.5 Task B-2.4 — Close the `defer_inject` bypass
+
+[`defer_inject()`](../src/compliance_bridge/main.py:1323) resolves a parked token
+through the data-hydration path. It is semantically distinct from human approval —
+it re-evaluates confidence via `replay_evaluate()` — but it still **transitions the
+token to resolved without consulting `approvals` or `required_quorum`**.
+
+Decide and document the intended semantics:
+
+- **Option A — reason-gated.** `defer_inject` may resolve only tokens whose
+  `defer_reason` is a data-starvation class (`INSUFFICIENT_CONTEXT`,
+  `DATA_STARVATION`, `AMBIGUOUS_SEMANTIC_DISTANCE`). For
+  `FTRA_IRREVERSIBLE_TERMINAL`, `EXTERNAL_VALIDATION`, and `FLOWSIGNAL_ESCALATION`
+  it returns `409` and directs the caller to the approval path.
+  **Recommended** — it matches the original DEFER design intent, where injection
+  serves the automated hydration loop and escalation serves human oversight.
+- **Option B — state-gated.** `defer_inject` refuses any token already in
+  `PARTIALLY_APPROVED`, on the grounds that a human ceremony is underway.
+
+Implement Option A, and additionally refuse when the token is
+`PARTIALLY_APPROVED` (the Option B condition) since both guards are cheap and
+independent. Record the chosen semantics in the endpoint docstring.
+
+### 2.6 Task B-2.5 — T2 dual-control test suite
+
+Extend [`tests/test_defer_queue_quorum.py`](../tests/test_defer_queue_quorum.py)
+and add endpoint-level tests. The suite must include **adversarial** cases, not
+just happy-path quorum accumulation:
+
+| Test | Asserts |
+|---|---|
+| `test_escalate_requires_authentication` | Unauthenticated POST → `401`, and **no** `ApprovalRecord` is written |
+| `test_body_asserting_operator_urn_is_rejected` | A body carrying `operator_urn` at all → `400`, never silently ignored |
+| `test_svid_wins_over_oidc_when_both_present` | Precedence is evaluated, not caller-negotiated |
+| `test_conflicting_svid_and_oidc_urn_fails_closed` | An individual operator cert and an OIDC `sub` mapping to different URNs → `403` |
+| `test_oidc_fallback_disabled_by_default` | Without the explicit opt-in, an OIDC-only request fails closed |
+| `test_forwarded_subject_header_from_untrusted_source_ignored` | An inbound XFCC-style header on an unauthenticated connection cannot supply a principal |
+| `test_workload_svid_alone_cannot_approve` | A shared-console workload SVID with no human `sub` → fails closed (§2.3.3 row 3) |
+| `test_workload_svid_plus_oidc_sub_yields_human_urn` | `operator_urn` comes from the `sub`; the SVID is recorded only as `channel_provenance` |
+| `test_channel_provenance_excluded_from_distinctness` | Two humans behind the same console SVID can both approve |
+| `test_single_principal_cannot_reach_quorum` | Two POSTs from the **same** authenticated principal → `409 ALREADY_APPROVED`, token stays `PARTIALLY_APPROVED` |
+| `test_quorum_three_for_irreversible_terminal` | `FTRA_IRREVERSIBLE_TERMINAL` parks with `required_quorum == 3`; two approvals leave it `PARTIALLY_APPROVED` |
+| `test_quorum_three_for_external_validation` | Same for `EXTERNAL_VALIDATION` |
+| `test_quorum_three_for_flowsignal_escalation` | Same for `FLOWSIGNAL_ESCALATION` |
+| `test_quorum_mapping_total_over_enum` | Parametrized over `list(DeferReason)` — no `KeyError` for any member |
+| `test_inject_refuses_high_consequence_reason` | `defer_inject` on `FTRA_IRREVERSIBLE_TERMINAL` → `409` |
+| `test_inject_refuses_partially_approved_token` | `defer_inject` on a `PARTIALLY_APPROVED` token → `409` |
+| `test_principal_hash_is_not_caller_controlled` | `auth_principal_hash` does not equal `sha256` of any caller-supplied field |
+| `test_dev_synthetic_principal_is_labelled` | Dev-mode principals carry `auth_method="DEV_SYNTHETIC"` and the reserved `urn:cage:dev:` prefix |
+| `test_dev_identity_requires_both_conditions` | `CAGE_ENV=dev` alone, without `CAGE_ALLOW_DEV_OPERATOR_IDENTITY`, does **not** enable synthetic principals |
+| `test_prod_never_yields_dev_synthetic` | With `CAGE_ENV=prod`, no configuration produces a `DEV_SYNTHETIC` principal |
+| `test_dev_synthetic_principals_are_distinct_per_request` | Local multi-operator flows remain exercisable |
+| `test_production_urn_mapping_cannot_emit_dev_prefix` | The reserved prefix is unreachable from real credential subjects |
+| `test_concurrent_approvals_are_serialized` | Two concurrent approvals under WATCH/MULTI/EXEC do not double-count toward quorum |
+
+All tests must be hermetic and carry `pytest.mark.unit` / `pytest.mark.local`, using
+a fake or in-memory Redis so they run under `make test-fast`.
+
+### 2.7 Acceptance criteria
+
+**Identity provenance**
+
+- No route under `/v1/defer/` is reachable without authentication.
+- `approver_urn` and `auth_principal_hash` are **provably** derived from a verified
+  credential; a test asserts caller input cannot influence either.
+- `DeferEscalateRequest` carries no identity fields; a body asserting
+  `operator_urn` is rejected with `400`, not ignored.
+- SVID precedence is evaluated server-side and cannot be negotiated by the caller.
+- Conflicting operator URNs across identity channels fail closed with `403`.
+- The OIDC fallback is disabled unless explicitly enabled by configuration.
+- A forwarded-subject header from an unauthenticated source cannot supply a principal.
+
+**Quorum integrity**
+
+- A single authenticated principal cannot reach quorum by any request sequence.
+- A shared-console workload SVID alone cannot approve; two humans behind one
+  console SVID can.
+- `channel_provenance` never participates in the distinctness check.
+- All three quorum-3 reasons genuinely require three distinct principals.
+- `get_required_quorum` has live call sites and total-mapping coverage.
+- `defer_inject` cannot resolve a token that requires human approval.
+
+**Dev-mode boundary**
+
+- Synthetic principals require **both** `CAGE_ENV=dev` and the explicit opt-in.
+- Every synthetic principal carries `auth_method="DEV_SYNTHETIC"` and the reserved
+  `urn:cage:dev:` prefix.
+- With `CAGE_ENV=prod`, no configuration path yields a synthetic principal.
+- Production URN mapping cannot emit the reserved dev prefix.
+
+**Gates**
+
+- `make test-fast` green; `uv run mypy src/` clean; `uv run bandit -r src/ -c pyproject.toml -ll` clean.
+
+---
+
+## 3. Work Item 3 — Import Boundary: `src/gateway` → `src.integrations`
+
+**Branch:** `ci/import-boundary-integrations`
+**Depends on:** nothing (but land after Work Item 1 so the scan sees the cleaned tree)
+
+### 3.1 The nuance that makes this non-trivial
+
+A naive "Layer 1 must never import `src.integrations`" rule would **fail on six
+existing, architecturally-correct imports**:
+
+| Location | Import | Verdict |
+|---|---|---|
+| [`normative_provider.py:935`](../src/gateway/governance/normative_provider.py:935) | `provider_01` | ✅ Legitimate — function-local lazy factory |
+| [`normative_provider.py:940`](../src/gateway/governance/normative_provider.py:940) | `provider_02` | ✅ Legitimate |
+| [`normative_provider.py:945`](../src/gateway/governance/normative_provider.py:945) | `provider_03` | ✅ Legitimate |
+| [`normative_provider.py:950`](../src/gateway/governance/normative_provider.py:950) | `provider_06` | ✅ Legitimate |
+| [`evidence/factory.py:95`](../src/gateway/governance/evidence/factory.py:95) | `storage_gcs` | ✅ Legitimate |
+| [`evidence/factory.py:119`](../src/gateway/governance/evidence/factory.py:119) | `storage_s3` | ✅ Legitimate |
+
+All six are **function-scope lazy imports inside factory functions** — the
+sanctioned dependency-injection pattern. The kernel names a vendor package only at
+the moment of instantiation and never holds a module-level dependency on it.
+
+The rule must therefore distinguish **import scope**, which the current
+[`ImportVisitor`](../scripts/check_import_boundaries.py:62) does not track: it
+flattens every import to `(name, lineno)` with no notion of nesting.
+
+### 3.2 Proposed rule
+
+> **Layer 1 may not import `src.integrations` at module scope. Function-scope
+> lazy imports are permitted only in explicitly allowlisted factory modules.**
+
+Two conditions, both required for an import to pass:
+
+1. The `ast.Import` / `ast.ImportFrom` node is **nested inside a function or
+   method body**, not at module top level.
+2. The containing file is in `INTEGRATIONS_FACTORY_ALLOWLIST`.
+
+Anything else is a violation. A module-scope import in an allowlisted file is
+still a violation — the allowlist grants the *lazy* pattern, not blanket access.
+
+### 3.3 Implementation in [`check_import_boundaries.py`](../scripts/check_import_boundaries.py)
+
+- Extend `ImportVisitor` to record scope depth. Track it by overriding
+  `visit_FunctionDef`, `visit_AsyncFunctionDef`, and `visit_ClassDef` to
+  increment/decrement a counter, and emit `(name, lineno, is_module_scope)` triples.
+  Note that a class-body import is **not** function scope and must be treated as
+  module scope for this rule.
+- Add `LAYER_3_INTEGRATIONS_PATTERN = re.compile(r"^(src\.)?integrations\b")`.
+- Add the allowlist as a module-level frozenset of paths:
+  `src/gateway/governance/normative_provider.py` and
+  `src/gateway/governance/evidence/factory.py`.
+- Emit two distinct `rule_violated` strings so failures are self-explaining:
+  - `Layer 1 → Layer 3 (module-scope src.integrations import forbidden; use a function-scope lazy factory import)`
+  - `Layer 1 → Layer 3 (src.integrations import outside the factory allowlist)`
+- Extend the closing guidance block at [`:227`](../scripts/check_import_boundaries.py:227)
+  to describe the lazy-factory escape hatch and how to add to the allowlist.
+
+### 3.4 Forward compatibility
+
+Plan v2 §2.2 introduces an `ActuatorRegistry` in
+[`execution_actuator.py`](../src/gateway/governance/execution_actuator.py) which
+will need to instantiate `actuator_01`. Record in the script's docstring that
+`execution_actuator.py` is the **expected next allowlist entry**, and that adding
+an entry is a deliberate architectural decision requiring review — not a
+routine unblock. Keep the allowlist small and annotated with a one-line
+justification per entry.
+
+### 3.5 Tests
+
+Add `tests/test_import_boundaries.py` (or extend the existing coverage) with unit
+tests that exercise `check_file_boundaries` against synthetic sources written to
+`tmp_path`:
+
+| Case | Expected |
+|---|---|
+| Module-scope `from src.integrations.x import Y` in a non-allowlisted gateway file | 1 violation |
+| Module-scope import in an **allowlisted** file | 1 violation |
+| Function-scope import in an allowlisted file | 0 violations |
+| Function-scope import in a non-allowlisted file | 1 violation |
+| Class-body import in an allowlisted file | 1 violation |
+| Import in a file outside `src/gateway/` | 0 violations |
+| The six real call sites in the live tree | 0 violations |
+
+The last case is the regression guard: run the real scanner over the live tree and
+assert zero violations, so the allowlist and reality cannot drift apart.
+
+### 3.6 CI wiring
+
+The [`lint`](../.github/workflows/ci.yml:209) job already invokes the script, so no
+workflow change is required. Update the step name at
+[`ci.yml:209`](../.github/workflows/ci.yml:209) — currently
+`Import boundary check (G3 - Layer 1 → Layer 2/4)` — to reflect that Layer 3 and
+the integrations rule are now covered.
+
+### 3.7 Acceptance criteria
+
+- `uv run python scripts/check_import_boundaries.py --verbose` exits `0` on the
+  current tree and reports the six lazy imports as permitted.
+- A deliberately-introduced module-scope `src.integrations` import in a kernel file
+  fails the check with an actionable message.
+- New unit tests pass under `make test-fast`.
+- [`AGENTS.md`](../AGENTS.md) Gate G3 description is updated to include the rule.
+
+---
+
+## 4. Sequencing
+
+All three items are independent. Work Item 2 is the critical path by value; Work
+Item 1 is the cheapest and clears naming noise the other two touch.
+
+```mermaid
+graph TD
+    W1[Work Item 1<br/>retire provider_04<br/>refactor branch] --> M1[Squash merge to main]
+    M1 --> W3[Work Item 3<br/>import boundary CI<br/>ci branch]
+    W2[Work Item 2<br/>dual-control identity<br/>feat branch] --> M2[Squash merge to main]
+    W3 --> M3[Squash merge to main]
+    M2 --> GATE[Reopen ISO 42001<br/>human-oversight<br/>publication gate]
+    M3 --> GATE
+```
+
+Recommended order:
+
+1. **Work Item 1** — trivial, mechanical, merge first.
+2. **Work Item 2 and Work Item 3 in parallel** — no shared files. Work Item 2
+   touches `compliance_bridge/main.py`, `compliance_bridge/auth.py`, and
+   `defer_queue.py`; Work Item 3 touches `scripts/` and `.github/workflows/`.
+
+Three separate PRs. Per [`AGENTS.md`](../AGENTS.md), **squash merge only** — never
+`git merge` into `main`, and never a direct commit to `main`.
+
+---
+
+## 5. Compliance Obligations
+
+Triggered by [`AGENTS.md`](../AGENTS.md) Compliance Artifact Obligations:
+
+| Trigger | Obligation |
+|---|---|
+| Work Item 2 changes access-control enforcement on a governance endpoint | OSCAL component update in [`compliance/oscal/`](../compliance/oscal/) for **AC-3** (access enforcement) and **IA-2** (identification and authentication) within 2 business days of merge |
+| Work Item 2 binds operator identity to the SVID substrate | Extend the **IA-3** (device identification and authentication) and **SC-8** narrative already asserted by [`linkerd-mtls-policy.yaml`](../deployment/k8s/linkerd-mtls-policy.yaml:31) to cover the operator-approval path. The SSP's SVID statement at [`oscal_ssp_exporter.py:319`](../src/gateway/governance/oscal_ssp_exporter.py:319) currently describes workload identity only |
+| Work Item 2 introduces the `urn:cage:dev:` reserved prefix | Add a Lula or OSCAL assertion that **fails** if any approval record bearing the dev prefix or `auth_method="DEV_SYNTHETIC"` appears in a production evidence set |
+| Work Item 2 makes the `≥2 distinct operators` claim genuine for the first time | Only **after** merge may the ISO 42001 Annex A human-oversight control mapping be published. Until then plan v2 §6.4's publication gate stays shut. Review [`docs/governance/HUMAN_OVERSIGHT_SCOPE.md`](../docs/governance/HUMAN_OVERSIGHT_SCOPE.md) for statements that the residual gaps contradict |
+| Work Item 2 alters DEFER resolution semantics | Assess whether [`compliance/lula/lula-validation-a84.yaml`](../compliance/lula/) or the FTRA validation needs an assertion update. `FTRA_IRREVERSIBLE_TERMINAL` moving from an effective quorum of 2 to 3 is a control-strength change worth asserting |
+| Work Item 3 changes Gate G3 scope | Update the Gate G3 description in [`AGENTS.md`](../AGENTS.md) and the CI-failure diagnosis table |
+| Breaking change to `defer_escalate` | Commit must carry `!` **and** a `BREAKING CHANGE:` footer — both together, never one alone |
+
+Document in the Work Item 2 PR that dev-mode synthetic principals are **not**
+valid dual-control evidence, so the compliance narrative cannot be read as
+claiming otherwise.
+
+---
+
+## 6. Commit and Branch Compliance
+
+| Item | Branch | Example commit subject |
+|---|---|---|
+| 1 | `refactor/retire-provider-04` | `refactor(imports): retire provider_04 residue in favour of actuator_01` |
+| 2 | `feat/defer-dual-control-auth` | `feat(governance)!: bind defer approvals to authenticated operator identity` |
+| 3 | `ci/import-boundary-integrations` | `ci(governance): forbid module-scope src.integrations imports in kernel` |
+
+All subjects ≤ 72 characters, imperative mood, no trailing period. Work Item 2 is
+breaking and requires the `BREAKING CHANGE:` footer describing the
+`DeferEscalateRequest` contract change.
+
+---
+
+## 7. Verification Command Set
+
+Run before opening each PR:
+
+```bash
+# Fast local regression
+make test-fast
+
+# Targeted suites
+uv run pytest tests/test_defer_queue_quorum.py -v
+uv run pytest tests/test_normative_provider_conformance.py -v
+uv run pytest tests/test_jcs_canonicalizer.py -v
+uv run pytest tests/test_import_boundaries.py -v
+
+# Gate G3
+uv run python scripts/check_import_boundaries.py --verbose
+
+# Static analysis
+uv run ruff check . && uv run ruff format --check .
+uv run mypy src/
+uv run bandit -r src/ -c pyproject.toml -ll
+
+# Residue check for Work Item 1
+rg -n 'provider_04|Provider04' src/ tests/ scripts/ docs/ compliance/
+```
+
+Ensure no `kubectl port-forward` tunnels are active before running local tests, so
+live GKE Redis state cannot contaminate DEFER queue assertions.

--- a/src/gateway/governance/normative_provider.py
+++ b/src/gateway/governance/normative_provider.py
@@ -899,8 +899,8 @@ def get_normative_provider(name: str | None = None) -> NormativeProvider:
         - "provider_03"  — Provider 03 JCS bind receipts & normative API
         - "provider_06"  — Provider 06 tri-state agent integrity verifier
 
-    Note: provider_04 and provider_05 are part of the ecosystem but implement
-    AttestationProvider and EnvelopeMapper, not NormativeProvider directly.
+    Note: actuator_01 implements AttestationProvider and EnvelopeMapper,
+    not NormativeProvider directly.
 
     Returns:
         An instantiated NormativeProvider.
@@ -918,8 +918,6 @@ def get_normative_provider(name: str | None = None) -> NormativeProvider:
         "p01": "provider_01",
         "p02": "provider_02",
         "p03": "provider_03",
-        "p04": "provider_04",
-        "p05": "provider_05",
         "p06": "provider_06",
         "agent_integrity": "provider_06",
         "agentintegrity": "provider_06",

--- a/src/integrations/__init__.py
+++ b/src/integrations/__init__.py
@@ -24,8 +24,8 @@ is a complete vendor integration boundary:
   ├── provider_01/  — Normative compliance provider
   ├── provider_02/  — CER attestation + LangGraph adapter
   ├── provider_03/  — Decision governance provider
-  ├── provider_04/  — Attestation provider + envelope mapper
-  └── provider_05/  — Veraxis Execution Integrity Protocol (VEIP)
+  ├── provider_06/  — Agent integrity verification provider
+  └── actuator_01/  — Execution actuator with KMS-signed envelope protocol
 
 Vendor packages MUST NOT introduce imports into the CAGE kernel.
 All vendor code is loaded lazily via the provider factory in

--- a/src/integrations/actuator_01/__init__.py
+++ b/src/integrations/actuator_01/__init__.py
@@ -23,9 +23,39 @@ authorization with dual-control quorum signatures.
 """
 
 __all__ = [
-    "ActuatorHttpClient",
+    # Adapter (concrete ExecutionActuator implementation)
+    "Actuator01Adapter",
+    # Envelope construction
+    "build_and_canonicalize",
+    "EnvelopeTooLargeError",
+    "InvalidClearanceError",
+    # Assertion building
+    "build_assertion",
+    "decode_assertion",
+    "AssertionBuildError",
+    # Quorum signing
     "sign_for_quorum",
+    # Transport
+    "ActuatorHttpClient",
+    # Response classification
+    "classify_response",
+    "classify_network_error",
+    "ClassifiedResponse",
+    "ResponseCategory",
 ]
 
+from .adapter import Actuator01Adapter
+from .assertion import AssertionBuildError, build_assertion, decode_assertion
 from .client import ActuatorHttpClient
+from .envelope_builder import (
+    EnvelopeTooLargeError,
+    InvalidClearanceError,
+    build_and_canonicalize,
+)
+from .response_classifier import (
+    ClassifiedResponse,
+    ResponseCategory,
+    classify_network_error,
+    classify_response,
+)
 from .signatures import sign_for_quorum

--- a/src/integrations/actuator_01/adapter.py
+++ b/src/integrations/actuator_01/adapter.py
@@ -1,0 +1,408 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+adapter.py — Concrete ExecutionActuator Implementation (Phase 3, Stream C)
+
+``Actuator01Adapter`` implements the ``ExecutionActuator`` protocol defined in
+``src/gateway/governance/execution_actuator.py``.  It orchestrates the full
+pipeline from ``ExecutionClearance`` to ``ActuationReceipt``:
+
+    ExecutionClearance
+        → validate + build envelope (envelope_builder)
+        → canonicalize per RFC 8785 (JCS)
+        → enforce 4KB ceiling
+        → compute digest
+        → build 120-byte assertion (assertion)
+        → sign for quorum (signatures)
+        → submit over mTLS (client)
+        → classify response (response_classifier)
+        → ActuationReceipt
+
+Fail-closed: any step that fails produces ``accepted=False`` with structured
+findings.  Network timeouts, HTTP errors, and parse failures never produce a
+silent success.
+
+This module lives in ``src/integrations/actuator_01/`` (Layer 3) and imports
+from the kernel (Layer 1) only through the vendor-neutral protocol.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from datetime import datetime, timezone
+
+import httpx
+
+from src.gateway.governance.execution_actuator import (
+    ActuationReceipt,
+    ActuatorCapability,
+    ExecutionActuator,
+    ExecutionClearance,
+)
+from src.gateway.governance.kms_signer import KMSGovernanceSigner
+from src.integrations.actuator_01.assertion import (
+    AssertionBuildError,
+    build_assertion,
+)
+from src.integrations.actuator_01.client import ActuatorHttpClient
+from src.integrations.actuator_01.envelope_builder import (
+    EnvelopeTooLargeError,
+    InvalidClearanceError,
+    build_and_canonicalize,
+)
+from src.integrations.actuator_01.response_classifier import (
+    ResponseCategory,
+    classify_network_error,
+    classify_response,
+)
+from src.integrations.actuator_01.signatures import sign_for_quorum
+
+logger = logging.getLogger(__name__)
+
+# Environment variable keys for adapter configuration.
+_ENV_ENDPOINT = "ACTUATOR_01_ENDPOINT"
+_ENV_CERT_PATH = "ACTUATOR_01_CERT_PATH"
+_ENV_KEY_PATH = "ACTUATOR_01_KEY_PATH"
+_ENV_CA_PATH = "ACTUATOR_01_CA_PATH"
+_ENV_TENANT_ID = "ACTUATOR_01_TENANT_ID"
+
+# Capabilities declared by this actuator.
+_CAPABILITIES: set[ActuatorCapability] = {
+    ActuatorCapability.MULTI_SIG_QUORUM,
+    ActuatorCapability.MTLS_REQUIRED,
+    ActuatorCapability.DIGEST_ONLY_PAYLOAD,
+    ActuatorCapability.REPLAY_PROTECTED,
+}
+
+
+class Actuator01Adapter:
+    """Concrete implementation of ``ExecutionActuator`` for actuator_01.
+
+    Orchestrates:
+    - Envelope construction with RFC 8785 (JCS) canonicalization
+    - 120-byte assertion building with domain-tagged KMS signature
+    - Per-operator quorum signing
+    - mTLS HTTP submission
+    - Response classification with fail-closed semantics
+
+    Configuration is sourced from environment variables:
+    - ``ACTUATOR_01_ENDPOINT``: Base URL (required)
+    - ``ACTUATOR_01_CERT_PATH``: Client certificate PEM (required)
+    - ``ACTUATOR_01_KEY_PATH``: Client private key PEM (required)
+    - ``ACTUATOR_01_CA_PATH``: CA bundle PEM (required)
+    - ``ACTUATOR_01_TENANT_ID``: Secure tenant identifier (required)
+
+    Args:
+        client: Pre-configured ``ActuatorHttpClient``.  If ``None``,
+            constructed from environment variables via ``from_env()``.
+        signer: ``KMSGovernanceSigner`` for quorum and assertion signing.
+    """
+
+    def __init__(
+        self,
+        client: ActuatorHttpClient,
+        signer: KMSGovernanceSigner,
+    ) -> None:
+        self._client = client
+        self._signer = signer
+
+    @classmethod
+    def from_env(cls, signer: KMSGovernanceSigner) -> Actuator01Adapter:
+        """Construct adapter from environment variables.
+
+        Raises:
+            RuntimeError: If any required environment variable is missing.
+        """
+        endpoint = os.environ.get(_ENV_ENDPOINT, "")
+        cert_path = os.environ.get(_ENV_CERT_PATH, "")
+        key_path = os.environ.get(_ENV_KEY_PATH, "")
+        ca_path = os.environ.get(_ENV_CA_PATH, "")
+        tenant_id = os.environ.get(_ENV_TENANT_ID, "")
+
+        missing = []
+        if not endpoint:
+            missing.append(_ENV_ENDPOINT)
+        if not cert_path:
+            missing.append(_ENV_CERT_PATH)
+        if not key_path:
+            missing.append(_ENV_KEY_PATH)
+        if not ca_path:
+            missing.append(_ENV_CA_PATH)
+        if not tenant_id:
+            missing.append(_ENV_TENANT_ID)
+
+        if missing:
+            raise RuntimeError(
+                f"[actuator_01/adapter] Missing required environment variables: "
+                f"{', '.join(missing)}"
+            )
+
+        client = ActuatorHttpClient(
+            base_url=endpoint,
+            cert_path=cert_path,
+            key_path=key_path,
+            ca_path=ca_path,
+            tenant_id=tenant_id,
+        )
+
+        return cls(client=client, signer=signer)
+
+    # ── ExecutionActuator Protocol Implementation ─────────────────────────
+
+    @property
+    def actuator_id(self) -> str:
+        """Unique identifier for this actuator."""
+        return "actuator_01"
+
+    async def health_check(self) -> bool:
+        """Check if the actuator endpoint is reachable and healthy.
+
+        Returns ``False`` (fail-closed) when mTLS material is unreadable,
+        the endpoint is unreachable, or KMS is not active.
+        """
+        if not self._signer.is_kms_active:
+            logger.warning(
+                "[actuator_01/adapter] health_check: KMS not active"
+            )
+            return False
+
+        return await self._client.health_check()
+
+    def get_capabilities(self) -> set[ActuatorCapability]:
+        """Declare this actuator's capabilities."""
+        return _CAPABILITIES.copy()
+
+    async def actuate(self, clearance: ExecutionClearance) -> ActuationReceipt:
+        """Actuate an authorized action at the downstream execution boundary.
+
+        Orchestrates the full pipeline per ``ExecutionActuator`` protocol:
+
+        1. Validate clearance and build envelope (envelope_builder)
+        2. Canonicalize per RFC 8785 (JCS), enforce 4KB ceiling, compute digest
+        3. Build 120-byte assertion (assertion)
+        4. Sign for quorum — one signature per operator (signatures)
+        5. Submit over mTLS (client)
+        6. Classify response (response_classifier)
+        7. Return ActuationReceipt
+
+        Fail-closed: any step that fails returns ``accepted=False`` with
+        structured findings.
+
+        Args:
+            clearance: ``ExecutionClearance`` from the governance decision.
+
+        Returns:
+            ``ActuationReceipt`` with accept/reject status and evidence fields.
+        """
+        timestamp_utc = datetime.now(timezone.utc).isoformat()
+
+        # ── Step 1–2: Build, canonicalize, digest ─────────────────────────
+        try:
+            canonical_bytes, envelope_digest = build_and_canonicalize(clearance)
+        except InvalidClearanceError as exc:
+            logger.warning(
+                "[actuator_01/adapter] Clearance validation failed: %s", exc
+            )
+            return ActuationReceipt(
+                accepted=False,
+                receipt_id=None,
+                session_uuid=None,
+                raw_receipt=None,
+                findings=[{
+                    "code": "INVALID_CLEARANCE",
+                    "severity": "TERMINAL",
+                    "detail": str(exc),
+                }],
+                retryable=False,
+                envelope_digest=None,
+                timestamp_utc=timestamp_utc,
+            )
+        except EnvelopeTooLargeError as exc:
+            logger.warning(
+                "[actuator_01/adapter] Envelope exceeds 4KB ceiling: %s", exc
+            )
+            return ActuationReceipt(
+                accepted=False,
+                receipt_id=None,
+                session_uuid=None,
+                raw_receipt=None,
+                findings=[{
+                    "code": "ENVELOPE_TOO_LARGE",
+                    "severity": "TERMINAL",
+                    "detail": str(exc),
+                }],
+                retryable=False,
+                envelope_digest=None,
+                timestamp_utc=timestamp_utc,
+            )
+
+        # ── Step 3: Build assertion ───────────────────────────────────────
+        try:
+            assertion_b64 = build_assertion(
+                envelope_digest_hex=envelope_digest,
+                nonce_hex=clearance.nonce,
+                issued_at=clearance.issued_at,
+                signer=self._signer,
+            )
+        except (AssertionBuildError, RuntimeError) as exc:
+            logger.error(
+                "[actuator_01/adapter] Assertion build failed: %s", exc
+            )
+            return ActuationReceipt(
+                accepted=False,
+                receipt_id=None,
+                session_uuid=None,
+                raw_receipt=None,
+                findings=[{
+                    "code": "ASSERTION_BUILD_FAILED",
+                    "severity": "TERMINAL",
+                    "detail": str(exc),
+                }],
+                retryable=False,
+                envelope_digest=envelope_digest,
+                timestamp_utc=timestamp_utc,
+            )
+
+        # ── Step 4: Sign for quorum ───────────────────────────────────────
+        #
+        # In the current reference implementation, a single KMS key is used
+        # for all operators (per docs/architecture/actuator_01_kms_iam_model.md).
+        # Production adopters should supply per-operator signers via
+        # per-ceremony OIDC downscoping (Option B).
+        operator_urns: list[str] = []
+        quorum_signatures: list[str] = []
+
+        try:
+            for approval in clearance.approvals:
+                urn = approval.get("approver_urn", "")
+                if not urn:
+                    raise RuntimeError(
+                        "Approval record missing approver_urn"
+                    )
+                operator_urns.append(urn)
+                sig = sign_for_quorum(self._signer, canonical_bytes)
+                quorum_signatures.append(sig)
+        except RuntimeError as exc:
+            logger.error(
+                "[actuator_01/adapter] Quorum signing failed: %s", exc
+            )
+            return ActuationReceipt(
+                accepted=False,
+                receipt_id=None,
+                session_uuid=None,
+                raw_receipt=None,
+                findings=[{
+                    "code": "QUORUM_SIGNING_FAILED",
+                    "severity": "TERMINAL",
+                    "detail": str(exc),
+                }],
+                retryable=False,
+                envelope_digest=envelope_digest,
+                timestamp_utc=timestamp_utc,
+            )
+
+        # ── Step 5: Submit over mTLS ──────────────────────────────────────
+        try:
+            response = await self._client.submit_envelope(
+                canonical_bytes=canonical_bytes,
+                operator_urns=operator_urns,
+                signatures=quorum_signatures,
+                assertion=assertion_b64,
+                issued_at=clearance.issued_at,
+            )
+        except httpx.HTTPError as exc:
+            classified = classify_network_error(exc)
+            logger.error(
+                "[actuator_01/adapter] Network error during submission: %s",
+                exc,
+            )
+            return ActuationReceipt(
+                accepted=False,
+                receipt_id=None,
+                session_uuid=None,
+                raw_receipt=None,
+                findings=classified.findings,
+                retryable=classified.retryable,
+                envelope_digest=envelope_digest,
+                timestamp_utc=timestamp_utc,
+            )
+        except Exception as exc:
+            # Catch-all for unexpected transport errors (fail-closed).
+            logger.error(
+                "[actuator_01/adapter] Unexpected error during submission: %s",
+                exc,
+            )
+            return ActuationReceipt(
+                accepted=False,
+                receipt_id=None,
+                session_uuid=None,
+                raw_receipt=None,
+                findings=[{
+                    "code": "UNEXPECTED_ERROR",
+                    "severity": "TERMINAL",
+                    "detail": str(exc),
+                }],
+                retryable=False,
+                envelope_digest=envelope_digest,
+                timestamp_utc=timestamp_utc,
+            )
+
+        # ── Step 6: Classify response ─────────────────────────────────────
+        classified = classify_response(response)
+
+        # ── Step 7: Build ActuationReceipt ────────────────────────────────
+        receipt = ActuationReceipt(
+            accepted=classified.category == ResponseCategory.ACCEPTED,
+            receipt_id=classified.receipt_id,
+            session_uuid=classified.session_uuid,
+            raw_receipt=classified.raw_body,
+            findings=classified.findings,
+            retryable=classified.retryable,
+            envelope_digest=envelope_digest,
+            timestamp_utc=timestamp_utc,
+        )
+
+        if receipt.accepted:
+            logger.info(
+                "[actuator_01/adapter] Actuation ACCEPTED: receipt_id=%s "
+                "session_uuid=%s digest=%s",
+                receipt.receipt_id,
+                receipt.session_uuid,
+                envelope_digest[:16],
+            )
+        else:
+            logger.warning(
+                "[actuator_01/adapter] Actuation REJECTED: category=%s "
+                "status=%d error=%s retryable=%s digest=%s",
+                classified.category.value,
+                classified.status_code,
+                classified.error_code,
+                classified.retryable,
+                envelope_digest[:16],
+            )
+
+        return receipt
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client connection pool."""
+        await self._client.close()
+
+    async def __aenter__(self) -> Actuator01Adapter:
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.close()

--- a/src/integrations/actuator_01/assertion.py
+++ b/src/integrations/actuator_01/assertion.py
@@ -1,0 +1,226 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+assertion.py — 120-Byte Execution Assertion Builder (Phase 3, Stream C / C.3)
+
+Constructs the compact, fixed-size binary assertion submitted via the
+X-Execution-Assertion header.  The assertion binds the envelope digest,
+nonce, timestamp, and a domain-tagged KMS signature into exactly 120 bytes:
+
+    Offset    Length   Content
+    ──────    ──────   ──────────────────────────────────────────
+     0..31      32     SHA-256 digest of canonical envelope bytes
+    32..47      16     Nonce (16 raw bytes, decoded from 32 hex chars)
+    48..55       8     Timestamp — ``issued_at`` as unsigned 64-bit big-endian
+    56..119     64     Domain-tagged KMS signature over bytes [0..55]
+
+Domain tag:  ``ACTUATOR_01_ASSERTION_V1:``
+    Isolates assertion signatures from quorum signatures (which use
+    ``ACTUATOR_01_QUORUM_V1:``), preventing cross-context replay.
+
+Wire encoding: base64url (RFC 4648 §5, no padding) per wire contract §7.3.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import logging
+import struct
+
+from src.gateway.governance.kms_signer import KMSGovernanceSigner
+
+logger = logging.getLogger(__name__)
+
+# Exactly 120 bytes.
+ASSERTION_TOTAL_BYTES = 120
+
+# Layout offsets and sizes.
+_DIGEST_OFFSET = 0
+_DIGEST_SIZE = 32
+_NONCE_OFFSET = 32
+_NONCE_SIZE = 16
+_TIMESTAMP_OFFSET = 48
+_TIMESTAMP_SIZE = 8
+_SIGNATURE_OFFSET = 56
+_SIGNATURE_SIZE = 64
+
+# Domain tag — distinct from ACTUATOR_01_QUORUM_V1: used in signatures.py.
+ACTUATOR_01_DOMAIN_TAG_ASSERTION = b"ACTUATOR_01_ASSERTION_V1:"
+
+
+class AssertionBuildError(Exception):
+    """Raised when assertion construction fails pre-flight validation."""
+
+    pass
+
+
+def _validate_inputs(
+    envelope_digest_hex: str,
+    nonce_hex: str,
+    issued_at: int,
+) -> None:
+    """Validate assertion inputs before assembly.
+
+    Raises:
+        AssertionBuildError: If any input is malformed.
+    """
+    # Digest must be a 64-char lowercase hex SHA-256.
+    if len(envelope_digest_hex) != 64:
+        raise AssertionBuildError(
+            f"envelope_digest_hex must be 64 hex chars, got {len(envelope_digest_hex)}"
+        )
+    try:
+        bytes.fromhex(envelope_digest_hex)
+    except ValueError as exc:
+        raise AssertionBuildError(
+            f"envelope_digest_hex is not valid hex: {exc}"
+        ) from exc
+
+    # Nonce must be 32 hex chars (16 bytes).
+    if len(nonce_hex) != 32:
+        raise AssertionBuildError(
+            f"nonce_hex must be 32 hex chars, got {len(nonce_hex)}"
+        )
+    try:
+        bytes.fromhex(nonce_hex)
+    except ValueError as exc:
+        raise AssertionBuildError(f"nonce_hex is not valid hex: {exc}") from exc
+
+    # issued_at must be a positive Unix timestamp.
+    if issued_at <= 0:
+        raise AssertionBuildError(
+            f"issued_at must be a positive Unix timestamp, got {issued_at}"
+        )
+
+
+def build_assertion(
+    envelope_digest_hex: str,
+    nonce_hex: str,
+    issued_at: int,
+    signer: KMSGovernanceSigner,
+) -> str:
+    """Build the 120-byte execution assertion and return base64url encoding.
+
+    Steps:
+        1. Validate inputs.
+        2. Pack digest (32B) + nonce (16B) + timestamp (8B) = 56 bytes.
+        3. KMS-sign the 56-byte payload with domain tag isolation.
+        4. Append 64-byte signature → 120 bytes total.
+        5. Encode as base64url (no padding).
+
+    Args:
+        envelope_digest_hex: 64-char lowercase hex SHA-256 of canonical
+            envelope bytes (from ``envelope_builder.body_digest``).
+        nonce_hex: 32-char lowercase hex nonce (from ``ExecutionClearance.nonce``).
+        issued_at: Unix timestamp in seconds (from ``ExecutionClearance.issued_at``).
+        signer: ``KMSGovernanceSigner`` instance for assertion signing.
+
+    Returns:
+        Base64url-encoded (no padding) string of exactly 120 raw bytes.
+
+    Raises:
+        AssertionBuildError: Pre-flight validation failure.
+        RuntimeError: KMS not active or signing failure.
+    """
+    _validate_inputs(envelope_digest_hex, nonce_hex, issued_at)
+
+    if not signer.is_kms_active:
+        raise RuntimeError(
+            "[actuator_01/assertion] build_assertion() called but KMS is not "
+            "active. Ensure KMS_GOVERNANCE_KEY is set and signer initialized."
+        )
+
+    # ── Step 1: Pack the signable payload (56 bytes) ───────────────────────
+    digest_bytes = bytes.fromhex(envelope_digest_hex)  # 32B
+    nonce_bytes = bytes.fromhex(nonce_hex)  # 16B
+    timestamp_bytes = struct.pack(">Q", issued_at)  # 8B big-endian uint64
+
+    signable_payload = digest_bytes + nonce_bytes + timestamp_bytes
+    assert len(signable_payload) == _SIGNATURE_OFFSET  # 56 bytes
+
+    # ── Step 2: Domain-tagged KMS signature ────────────────────────────────
+    tagged_message = ACTUATOR_01_DOMAIN_TAG_ASSERTION + signable_payload
+    signature_bytes = signer.sign_raw(tagged_message)
+
+    # Truncate or verify signature is exactly 64 bytes.
+    # Ed25519 signatures are always 64 bytes.  ECDSA P-256 raw signatures are
+    # also 64 bytes (32-byte r + 32-byte s).  If we get a different length, the
+    # KMS key type is incompatible with the wire contract.
+    if len(signature_bytes) != _SIGNATURE_SIZE:
+        raise AssertionBuildError(
+            f"KMS signature is {len(signature_bytes)} bytes, expected "
+            f"{_SIGNATURE_SIZE}. The KMS key type may be incompatible with "
+            "the actuator_01 wire contract (Ed25519 or ECDSA P-256 required)."
+        )
+
+    # ── Step 3: Assemble the 120-byte assertion ───────────────────────────
+    assertion_bytes = signable_payload + signature_bytes
+    assert len(assertion_bytes) == ASSERTION_TOTAL_BYTES  # 120 bytes
+
+    # ── Step 4: Encode as base64url (no padding) ──────────────────────────
+    assertion_b64 = base64.urlsafe_b64encode(assertion_bytes).rstrip(b"=").decode("ascii")
+
+    logger.info(
+        "[actuator_01/assertion] Assertion built: digest=%s... nonce=%s... "
+        "timestamp=%d sig=%s... total_bytes=%d",
+        envelope_digest_hex[:16],
+        nonce_hex[:8],
+        issued_at,
+        signature_bytes[:8].hex(),
+        ASSERTION_TOTAL_BYTES,
+    )
+
+    return assertion_b64
+
+
+def decode_assertion(assertion_b64: str) -> dict[str, bytes | int]:
+    """Decode a base64url assertion into its component fields.
+
+    Useful for testing, verification, and the mock actuator kernel.
+
+    Returns:
+        dict with keys: ``digest`` (32B), ``nonce`` (16B),
+        ``timestamp`` (int), ``signature`` (64B), ``signable_payload`` (56B).
+
+    Raises:
+        AssertionBuildError: If assertion is malformed or wrong length.
+    """
+    # Re-add padding for base64 decoding.
+    padded = assertion_b64 + "=" * (-len(assertion_b64) % 4)
+    try:
+        raw = base64.urlsafe_b64decode(padded)
+    except Exception as exc:
+        raise AssertionBuildError(f"Invalid base64url: {exc}") from exc
+
+    if len(raw) != ASSERTION_TOTAL_BYTES:
+        raise AssertionBuildError(
+            f"Assertion is {len(raw)} bytes, expected {ASSERTION_TOTAL_BYTES}"
+        )
+
+    digest = raw[_DIGEST_OFFSET : _DIGEST_OFFSET + _DIGEST_SIZE]
+    nonce = raw[_NONCE_OFFSET : _NONCE_OFFSET + _NONCE_SIZE]
+    (timestamp,) = struct.unpack(
+        ">Q", raw[_TIMESTAMP_OFFSET : _TIMESTAMP_OFFSET + _TIMESTAMP_SIZE]
+    )
+    signature = raw[_SIGNATURE_OFFSET : _SIGNATURE_OFFSET + _SIGNATURE_SIZE]
+
+    return {
+        "digest": digest,
+        "nonce": nonce,
+        "timestamp": timestamp,
+        "signature": signature,
+        "signable_payload": raw[:_SIGNATURE_OFFSET],
+    }

--- a/src/integrations/actuator_01/response_classifier.py
+++ b/src/integrations/actuator_01/response_classifier.py
@@ -1,0 +1,373 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+response_classifier.py — HTTP Response Classification (Phase 3, Stream C / C.6b)
+
+Classifies actuator HTTP responses into actionable categories for the adapter.
+Distinguishes retryable transient errors from terminal failures, and extracts
+structured receipt data from successful responses.
+
+Classification follows fail-closed semantics: any unrecognised status code or
+malformed response body is treated as a terminal rejection.
+
+Wire Contract Response Categories
+──────────────────────────────────
+  200  OK                → Accepted (parse receipt)
+  400  Bad Request       → Terminal: envelope validation failure
+  401  Unauthorized      → Terminal: mTLS / tenant identity failure
+  403  Forbidden         → Ambiguous: must inspect body for sub-type
+       ├─ REPLAY_DETECTED   → Terminal: nonce/correlation reuse
+       ├─ LOAD_SHED         → Retryable: partner is capacity-limiting
+       └─ other/missing     → Terminal (fail-closed)
+  408  Request Timeout   → Retryable: partner-side timeout
+  409  Conflict          → Terminal: state conflict (stale clearance)
+  421  Misdirected Req   → Terminal: malformed envelope
+  422  Unprocessable     → Terminal: semantic validation failure
+  429  Too Many Requests → Retryable: rate limited
+  500  Internal Error    → Retryable: partner-side transient failure
+  502  Bad Gateway       → Retryable: upstream failure
+  503  Service Unavail   → Retryable: partner-side transient failure
+  504  Gateway Timeout   → Retryable: upstream timeout
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from enum import Enum
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class ResponseCategory(str, Enum):
+    """Classification of an actuator response."""
+
+    ACCEPTED = "ACCEPTED"
+    """200 OK with a valid receipt body."""
+
+    REJECTED_TERMINAL = "REJECTED_TERMINAL"
+    """Non-retryable rejection — do not retry."""
+
+    REJECTED_RETRYABLE = "REJECTED_RETRYABLE"
+    """Transient failure — safe to retry with backoff."""
+
+    NETWORK_ERROR = "NETWORK_ERROR"
+    """Transport-level failure (connection refused, RST, DNS, TLS)."""
+
+
+@dataclass
+class ClassifiedResponse:
+    """Result of response classification.
+
+    Attributes:
+        category: The classification category.
+        status_code: HTTP status code (0 for network errors).
+        receipt_id: Partner-issued receipt ID (only if ACCEPTED).
+        session_uuid: Partner-issued session UUID (only if ACCEPTED).
+        raw_body: Parsed JSON body (if parseable), else None.
+        error_code: Partner error code from response body (if present).
+        error_message: Human-readable error message.
+        retryable: True if the caller should retry with backoff.
+        findings: Structured list of findings for ActuationReceipt.
+    """
+
+    category: ResponseCategory
+    status_code: int
+    receipt_id: str | None = None
+    session_uuid: str | None = None
+    raw_body: dict | None = None
+    error_code: str | None = None
+    error_message: str = ""
+    retryable: bool = False
+    findings: list[dict] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.findings is None:
+            self.findings = []
+
+
+# ── Status code sets ──────────────────────────────────────────────────────
+
+_RETRYABLE_STATUS_CODES: frozenset[int] = frozenset({408, 429, 500, 502, 503, 504})
+
+_TERMINAL_STATUS_CODES: frozenset[int] = frozenset({400, 401, 409, 421, 422})
+
+# 403 is ambiguous — must inspect the response body.
+_AMBIGUOUS_STATUS_CODE = 403
+
+
+def _parse_body(response: httpx.Response) -> dict | None:
+    """Best-effort JSON body parse.  Returns None on any failure."""
+    try:
+        return response.json()
+    except (json.JSONDecodeError, ValueError, UnicodeDecodeError):
+        return None
+
+
+def _extract_error(body: dict | None) -> tuple[str | None, str]:
+    """Extract error_code and message from a response body."""
+    if body is None:
+        return None, ""
+    error_code = body.get("error") or body.get("error_code")
+    message = body.get("message") or body.get("error_message") or ""
+    return error_code, message
+
+
+def _classify_403(body: dict | None) -> ClassifiedResponse:
+    """Disambiguate 403 Forbidden responses.
+
+    Per wire contract:
+    - ``LOAD_SHED`` / ``CAPACITY_LIMIT`` → retryable
+    - ``REPLAY_DETECTED`` → terminal (nonce/correlation reuse)
+    - Anything else → terminal (fail-closed)
+    """
+    error_code, message = _extract_error(body)
+    error_code_upper = (error_code or "").upper()
+
+    if error_code_upper in ("LOAD_SHED", "CAPACITY_LIMIT"):
+        return ClassifiedResponse(
+            category=ResponseCategory.REJECTED_RETRYABLE,
+            status_code=403,
+            raw_body=body,
+            error_code=error_code,
+            error_message=message or "Partner capacity-limited (load shed)",
+            retryable=True,
+            findings=[{
+                "code": error_code,
+                "severity": "TRANSIENT",
+                "detail": "Partner is load-shedding; retry with backoff",
+            }],
+        )
+
+    # REPLAY_DETECTED, QUORUM_FAILURE, or any unrecognised → terminal.
+    return ClassifiedResponse(
+        category=ResponseCategory.REJECTED_TERMINAL,
+        status_code=403,
+        raw_body=body,
+        error_code=error_code,
+        error_message=message or f"403 Forbidden: {error_code or 'unknown'}",
+        retryable=False,
+        findings=[{
+            "code": error_code or "FORBIDDEN_UNSPECIFIED",
+            "severity": "TERMINAL",
+            "detail": message or "Request rejected by partner (fail-closed on 403)",
+        }],
+    )
+
+
+def _classify_200(body: dict | None) -> ClassifiedResponse:
+    """Parse a 200 OK response and extract receipt fields.
+
+    Expected body shape (per wire contract):
+    ```json
+    {
+        "receipt_id": "...",
+        "session_uuid": "...",
+        "status": "ACCEPTED",
+        ...
+    }
+    ```
+
+    If the body is unparseable or missing required fields, the response is
+    classified as REJECTED_TERMINAL (fail-closed: a 200 without a valid
+    receipt is treated as a rejection, not a silent accept).
+    """
+    if body is None:
+        return ClassifiedResponse(
+            category=ResponseCategory.REJECTED_TERMINAL,
+            status_code=200,
+            error_code="UNPARSEABLE_RECEIPT",
+            error_message="200 OK but response body is not valid JSON",
+            retryable=False,
+            findings=[{
+                "code": "UNPARSEABLE_RECEIPT",
+                "severity": "TERMINAL",
+                "detail": "200 OK with unparseable body — fail-closed",
+            }],
+        )
+
+    receipt_id = body.get("receipt_id")
+    session_uuid = body.get("session_uuid")
+
+    if not receipt_id:
+        return ClassifiedResponse(
+            category=ResponseCategory.REJECTED_TERMINAL,
+            status_code=200,
+            raw_body=body,
+            error_code="MISSING_RECEIPT_ID",
+            error_message="200 OK but response body missing receipt_id",
+            retryable=False,
+            findings=[{
+                "code": "MISSING_RECEIPT_ID",
+                "severity": "TERMINAL",
+                "detail": "200 OK with no receipt_id — fail-closed",
+            }],
+        )
+
+    return ClassifiedResponse(
+        category=ResponseCategory.ACCEPTED,
+        status_code=200,
+        receipt_id=receipt_id,
+        session_uuid=session_uuid,
+        raw_body=body,
+        error_message="",
+        retryable=False,
+    )
+
+
+def classify_response(response: httpx.Response) -> ClassifiedResponse:
+    """Classify an actuator HTTP response.
+
+    This is the single entry point used by ``Actuator01Adapter.actuate()``.
+    Follows fail-closed semantics: any unrecognised status code or malformed
+    body is treated as a terminal rejection.
+
+    Args:
+        response: The ``httpx.Response`` from ``ActuatorHttpClient.submit_envelope``.
+
+    Returns:
+        ``ClassifiedResponse`` with category, receipt data (if accepted),
+        error details, and retryability flag.
+    """
+    status = response.status_code
+    body = _parse_body(response)
+    error_code, message = _extract_error(body)
+
+    # ── 200 OK ────────────────────────────────────────────────────────────
+    if status == 200:
+        result = _classify_200(body)
+        logger.info(
+            "[actuator_01/response] 200 OK → %s receipt_id=%s",
+            result.category.value,
+            result.receipt_id,
+        )
+        return result
+
+    # ── Ambiguous 403 ─────────────────────────────────────────────────────
+    if status == _AMBIGUOUS_STATUS_CODE:
+        result = _classify_403(body)
+        logger.warning(
+            "[actuator_01/response] 403 → %s error_code=%s",
+            result.category.value,
+            result.error_code,
+        )
+        return result
+
+    # ── Retryable status codes ────────────────────────────────────────────
+    if status in _RETRYABLE_STATUS_CODES:
+        result = ClassifiedResponse(
+            category=ResponseCategory.REJECTED_RETRYABLE,
+            status_code=status,
+            raw_body=body,
+            error_code=error_code,
+            error_message=message or f"Retryable HTTP {status}",
+            retryable=True,
+            findings=[{
+                "code": error_code or f"HTTP_{status}",
+                "severity": "TRANSIENT",
+                "detail": message or f"HTTP {status} — retryable with backoff",
+            }],
+        )
+        logger.warning(
+            "[actuator_01/response] HTTP %d → RETRYABLE error_code=%s",
+            status,
+            error_code,
+        )
+        return result
+
+    # ── Known terminal status codes ───────────────────────────────────────
+    if status in _TERMINAL_STATUS_CODES:
+        result = ClassifiedResponse(
+            category=ResponseCategory.REJECTED_TERMINAL,
+            status_code=status,
+            raw_body=body,
+            error_code=error_code,
+            error_message=message or f"Terminal HTTP {status}",
+            retryable=False,
+            findings=[{
+                "code": error_code or f"HTTP_{status}",
+                "severity": "TERMINAL",
+                "detail": message or f"HTTP {status} — not retryable",
+            }],
+        )
+        logger.warning(
+            "[actuator_01/response] HTTP %d → TERMINAL error_code=%s",
+            status,
+            error_code,
+        )
+        return result
+
+    # ── Unrecognised status code → fail-closed as terminal ────────────────
+    result = ClassifiedResponse(
+        category=ResponseCategory.REJECTED_TERMINAL,
+        status_code=status,
+        raw_body=body,
+        error_code=error_code or f"UNRECOGNISED_{status}",
+        error_message=message or f"Unrecognised HTTP {status} — fail-closed",
+        retryable=False,
+        findings=[{
+            "code": f"UNRECOGNISED_{status}",
+            "severity": "TERMINAL",
+            "detail": f"Unrecognised HTTP {status} — treated as terminal (fail-closed)",
+        }],
+    )
+    logger.warning(
+        "[actuator_01/response] HTTP %d → TERMINAL (unrecognised, fail-closed)",
+        status,
+    )
+    return result
+
+
+def classify_network_error(exc: Exception) -> ClassifiedResponse:
+    """Classify a transport-level exception as a network error.
+
+    Called when ``submit_envelope`` raises ``httpx.HTTPError`` or any
+    transport exception (connection refused, RST, DNS, TLS handshake).
+
+    Network errors are retryable (the partner may come back) but are
+    classified distinctly from HTTP-level retryable errors for observability.
+
+    Args:
+        exc: The transport exception.
+
+    Returns:
+        ``ClassifiedResponse`` with ``NETWORK_ERROR`` category.
+    """
+    # Detect TCP RST specifically for observability.
+    exc_str = str(exc)
+    is_rst = "reset" in exc_str.lower() or "rst" in exc_str.lower()
+    error_code = "CONNECTION_RESET" if is_rst else "NETWORK_ERROR"
+
+    result = ClassifiedResponse(
+        category=ResponseCategory.NETWORK_ERROR,
+        status_code=0,
+        error_code=error_code,
+        error_message=f"Transport error: {exc_str}",
+        retryable=True,
+        findings=[{
+            "code": error_code,
+            "severity": "TRANSIENT",
+            "detail": f"Transport-level failure: {exc_str}",
+        }],
+    )
+    logger.error(
+        "[actuator_01/response] Network error → %s: %s",
+        error_code,
+        exc_str,
+    )
+    return result

--- a/tests/mocks/mock_actuator_kernel.py
+++ b/tests/mocks/mock_actuator_kernel.py
@@ -106,7 +106,7 @@ class MockActuatorKernel:
         # Extract headers for verification
         tenant_id = headers.get("x-secure-tenant-id")
         operator_urns = headers.get("x-operator-urns", "").split(",")
-        signatures = headers.get("x-archytan-signatures", "").split(",")
+        signatures = headers.get("x-quorum-signatures", "").split(",")
         assertion_b64 = headers.get("x-execution-assertion", "")
         timestamp_str = headers.get("x-timestamp", "0")
 

--- a/tests/test_actuator_01_assertion.py
+++ b/tests/test_actuator_01_assertion.py
@@ -1,0 +1,272 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for actuator_01 assertion builder.
+
+Validates the 120-byte assertion layout, domain-tag isolation from quorum
+signatures, base64url encoding, and pre-flight validation.
+"""
+
+import hashlib
+import struct
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.integrations.actuator_01.assertion import (
+    ACTUATOR_01_DOMAIN_TAG_ASSERTION,
+    ASSERTION_TOTAL_BYTES,
+    AssertionBuildError,
+    build_assertion,
+    decode_assertion,
+)
+from src.integrations.actuator_01.signatures import ACTUATOR_01_DOMAIN_TAG_QUORUM
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def mock_signer():
+    """KMS signer mock that returns a 64-byte deterministic signature."""
+    signer = MagicMock()
+    signer.is_kms_active = True
+    # Return a deterministic 64-byte signature based on the input.
+    signer.sign_raw.side_effect = lambda msg: hashlib.sha512(msg).digest()[:64]
+    return signer
+
+
+@pytest.fixture()
+def valid_digest_hex():
+    return hashlib.sha256(b"test envelope bytes").hexdigest()
+
+
+@pytest.fixture()
+def valid_nonce_hex():
+    return "a1b2c3d4e5f6a7b8a1b2c3d4e5f6a7b8"
+
+
+@pytest.fixture()
+def valid_issued_at():
+    return 1725724800  # 2024-09-07T16:00:00Z
+
+
+# ── Test: Assertion Layout ────────────────────────────────────────────────
+
+
+class TestAssertionLayout:
+    """Verify the 120-byte assertion has the correct binary layout."""
+
+    def test_assertion_is_exactly_120_bytes(
+        self, mock_signer, valid_digest_hex, valid_nonce_hex, valid_issued_at
+    ):
+        b64 = build_assertion(
+            valid_digest_hex, valid_nonce_hex, valid_issued_at, mock_signer
+        )
+        decoded = decode_assertion(b64)
+        raw_total = (
+            len(decoded["digest"])
+            + len(decoded["nonce"])
+            + 8  # timestamp
+            + len(decoded["signature"])
+        )
+        assert raw_total == ASSERTION_TOTAL_BYTES
+
+    def test_digest_field_is_32_bytes(
+        self, mock_signer, valid_digest_hex, valid_nonce_hex, valid_issued_at
+    ):
+        b64 = build_assertion(
+            valid_digest_hex, valid_nonce_hex, valid_issued_at, mock_signer
+        )
+        decoded = decode_assertion(b64)
+        assert len(decoded["digest"]) == 32
+        assert decoded["digest"] == bytes.fromhex(valid_digest_hex)
+
+    def test_nonce_field_is_16_bytes(
+        self, mock_signer, valid_digest_hex, valid_nonce_hex, valid_issued_at
+    ):
+        b64 = build_assertion(
+            valid_digest_hex, valid_nonce_hex, valid_issued_at, mock_signer
+        )
+        decoded = decode_assertion(b64)
+        assert len(decoded["nonce"]) == 16
+        assert decoded["nonce"] == bytes.fromhex(valid_nonce_hex)
+
+    def test_timestamp_is_big_endian_uint64(
+        self, mock_signer, valid_digest_hex, valid_nonce_hex, valid_issued_at
+    ):
+        b64 = build_assertion(
+            valid_digest_hex, valid_nonce_hex, valid_issued_at, mock_signer
+        )
+        decoded = decode_assertion(b64)
+        assert decoded["timestamp"] == valid_issued_at
+
+    def test_signature_is_64_bytes(
+        self, mock_signer, valid_digest_hex, valid_nonce_hex, valid_issued_at
+    ):
+        b64 = build_assertion(
+            valid_digest_hex, valid_nonce_hex, valid_issued_at, mock_signer
+        )
+        decoded = decode_assertion(b64)
+        assert len(decoded["signature"]) == 64
+
+    def test_signable_payload_is_56_bytes(
+        self, mock_signer, valid_digest_hex, valid_nonce_hex, valid_issued_at
+    ):
+        b64 = build_assertion(
+            valid_digest_hex, valid_nonce_hex, valid_issued_at, mock_signer
+        )
+        decoded = decode_assertion(b64)
+        assert len(decoded["signable_payload"]) == 56
+
+
+# ── Test: Domain Tag Isolation ────────────────────────────────────────────
+
+
+class TestDomainTagIsolation:
+    """Assertion and quorum signatures use different domain tags."""
+
+    def test_assertion_domain_tag_differs_from_quorum(self):
+        assert ACTUATOR_01_DOMAIN_TAG_ASSERTION != ACTUATOR_01_DOMAIN_TAG_QUORUM
+
+    def test_signer_receives_assertion_domain_tag(
+        self, mock_signer, valid_digest_hex, valid_nonce_hex, valid_issued_at
+    ):
+        build_assertion(
+            valid_digest_hex, valid_nonce_hex, valid_issued_at, mock_signer
+        )
+        call_args = mock_signer.sign_raw.call_args[0][0]
+        assert call_args.startswith(ACTUATOR_01_DOMAIN_TAG_ASSERTION)
+
+    def test_signer_does_not_receive_quorum_tag(
+        self, mock_signer, valid_digest_hex, valid_nonce_hex, valid_issued_at
+    ):
+        build_assertion(
+            valid_digest_hex, valid_nonce_hex, valid_issued_at, mock_signer
+        )
+        call_args = mock_signer.sign_raw.call_args[0][0]
+        assert not call_args.startswith(ACTUATOR_01_DOMAIN_TAG_QUORUM)
+
+
+# ── Test: Base64url Encoding ─────────────────────────────────────────────
+
+
+class TestBase64UrlEncoding:
+    """Verify base64url encoding with no padding."""
+
+    def test_no_padding_characters(
+        self, mock_signer, valid_digest_hex, valid_nonce_hex, valid_issued_at
+    ):
+        b64 = build_assertion(
+            valid_digest_hex, valid_nonce_hex, valid_issued_at, mock_signer
+        )
+        assert "=" not in b64
+
+    def test_no_standard_base64_characters(
+        self, mock_signer, valid_digest_hex, valid_nonce_hex, valid_issued_at
+    ):
+        """base64url uses - and _ instead of + and /."""
+        b64 = build_assertion(
+            valid_digest_hex, valid_nonce_hex, valid_issued_at, mock_signer
+        )
+        assert "+" not in b64
+        assert "/" not in b64
+
+    def test_roundtrip_decode(
+        self, mock_signer, valid_digest_hex, valid_nonce_hex, valid_issued_at
+    ):
+        b64 = build_assertion(
+            valid_digest_hex, valid_nonce_hex, valid_issued_at, mock_signer
+        )
+        decoded = decode_assertion(b64)
+        assert decoded["digest"] == bytes.fromhex(valid_digest_hex)
+        assert decoded["nonce"] == bytes.fromhex(valid_nonce_hex)
+        assert decoded["timestamp"] == valid_issued_at
+
+
+# ── Test: Validation ─────────────────────────────────────────────────────
+
+
+class TestAssertionValidation:
+    """Pre-flight validation of assertion inputs."""
+
+    def test_rejects_short_digest(self, mock_signer, valid_nonce_hex, valid_issued_at):
+        with pytest.raises(AssertionBuildError, match="64 hex chars"):
+            build_assertion("abcd", valid_nonce_hex, valid_issued_at, mock_signer)
+
+    def test_rejects_invalid_hex_digest(
+        self, mock_signer, valid_nonce_hex, valid_issued_at
+    ):
+        bad_hex = "z" * 64
+        with pytest.raises(AssertionBuildError, match="not valid hex"):
+            build_assertion(bad_hex, valid_nonce_hex, valid_issued_at, mock_signer)
+
+    def test_rejects_short_nonce(
+        self, mock_signer, valid_digest_hex, valid_issued_at
+    ):
+        with pytest.raises(AssertionBuildError, match="32 hex chars"):
+            build_assertion(valid_digest_hex, "abcd", valid_issued_at, mock_signer)
+
+    def test_rejects_negative_timestamp(
+        self, mock_signer, valid_digest_hex, valid_nonce_hex
+    ):
+        with pytest.raises(AssertionBuildError, match="positive Unix timestamp"):
+            build_assertion(valid_digest_hex, valid_nonce_hex, -1, mock_signer)
+
+    def test_rejects_zero_timestamp(
+        self, mock_signer, valid_digest_hex, valid_nonce_hex
+    ):
+        with pytest.raises(AssertionBuildError, match="positive Unix timestamp"):
+            build_assertion(valid_digest_hex, valid_nonce_hex, 0, mock_signer)
+
+    def test_rejects_inactive_kms(
+        self, valid_digest_hex, valid_nonce_hex, valid_issued_at
+    ):
+        signer = MagicMock()
+        signer.is_kms_active = False
+        with pytest.raises(RuntimeError, match="KMS is not active"):
+            build_assertion(
+                valid_digest_hex, valid_nonce_hex, valid_issued_at, signer
+            )
+
+    def test_rejects_wrong_signature_length(
+        self, valid_digest_hex, valid_nonce_hex, valid_issued_at
+    ):
+        signer = MagicMock()
+        signer.is_kms_active = True
+        signer.sign_raw.return_value = b"\x00" * 48  # Wrong length
+        with pytest.raises(AssertionBuildError, match="48 bytes, expected 64"):
+            build_assertion(
+                valid_digest_hex, valid_nonce_hex, valid_issued_at, signer
+            )
+
+
+# ── Test: Decode ──────────────────────────────────────────────────────────
+
+
+class TestDecodeAssertion:
+    """Verify decode_assertion error handling."""
+
+    def test_rejects_wrong_length(self):
+        import base64
+
+        raw = b"\x00" * 100  # Not 120
+        b64 = base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+        with pytest.raises(AssertionBuildError, match="100 bytes, expected 120"):
+            decode_assertion(b64)
+
+    def test_rejects_invalid_base64(self):
+        with pytest.raises(AssertionBuildError, match="Invalid base64url"):
+            decode_assertion("!!!not-base64!!!")

--- a/tests/test_actuator_01_envelope.py
+++ b/tests/test_actuator_01_envelope.py
@@ -45,7 +45,7 @@ def valid_clearance() -> ExecutionClearance:
         decision_path="DIRECT",
         action="payment.wire.execute",
         target="account:1234567890",
-        operator_urn="urn:actuator01:op:test-operator-a",
+        operator_urn="urn:actuator_01:op:test-operator-a",
         issued_at=1785012000,
         issued_at_provenance="CONSTRUCTION_TIME",
         correlation_id="550e8400-e29b-41d4-a716-446655440000",
@@ -56,13 +56,13 @@ def valid_clearance() -> ExecutionClearance:
         confidence_score=0.92,
         approvals=[
             {
-                "approver_urn": "urn:actuator01:op:test-operator-a",
+                "approver_urn": "urn:actuator_01:op:test-operator-a",
                 "approved_at_utc": "2026-08-01T12:00:00Z",
                 "auth_method": "OIDC",
                 "auth_principal_hash": "c" * 64,
             },
             {
-                "approver_urn": "urn:actuator01:op:test-operator-b",
+                "approver_urn": "urn:actuator_01:op:test-operator-b",
                 "approved_at_utc": "2026-08-01T12:00:05Z",
                 "auth_method": "OIDC",
                 "auth_principal_hash": "d" * 64,
@@ -379,7 +379,7 @@ class TestVectorParity:
 
     def test_vector_1_canonical_bytes_and_digest(self):
         """Verify Vector 1 canonical bytes and SHA-256 parity."""
-        # This is adapted from test_jcs_canonicalizer.py::test_jcs_provider_04_reference_vector_1
+        # This is adapted from test_jcs_canonicalizer.py::test_jcs_actuator_01_reference_vector_1
         # The clearance-to-envelope mapping produces the same underlying structure
 
         clearance = ExecutionClearance(
@@ -388,7 +388,7 @@ class TestVectorParity:
             decision_path="DIRECT",
             action="payment.wire.execute",
             target="account:test-vector-1",
-            operator_urn="urn:actuator01:op:test_vector_1",
+            operator_urn="urn:actuator_01:op:test_vector_1",
             issued_at=1785012000,
             issued_at_provenance="CONSTRUCTION_TIME",
             correlation_id="550e8400-e29b-41d4-a716-446655440000",
@@ -397,13 +397,13 @@ class TestVectorParity:
             opa_input_digest="b" * 64,
             approvals=[
                 {
-                    "approver_urn": "urn:actuator01:op:op-a",
+                    "approver_urn": "urn:actuator_01:op:op-a",
                     "approved_at_utc": "2026-08-01T12:00:00Z",
                     "auth_method": "OIDC",
                     "auth_principal_hash": "c" * 64,
                 },
                 {
-                    "approver_urn": "urn:actuator01:op:op-b",
+                    "approver_urn": "urn:actuator_01:op:op-b",
                     "approved_at_utc": "2026-08-01T12:00:05Z",
                     "auth_method": "OIDC",
                     "auth_principal_hash": "d" * 64,
@@ -436,7 +436,7 @@ class TestVectorParity:
             decision_path="DIRECT",
             action="test.float.action",
             target="test-target",
-            operator_urn="urn:actuator01:op:test",
+            operator_urn="urn:actuator_01:op:test",
             issued_at=1785012000,
             issued_at_provenance="CONSTRUCTION_TIME",
             correlation_id=str(uuid.uuid4()),
@@ -447,13 +447,13 @@ class TestVectorParity:
             confidence_score=5.0,  # Should canonicalize to 5
             approvals=[
                 {
-                    "approver_urn": "urn:actuator01:op:op-a",
+                    "approver_urn": "urn:actuator_01:op:op-a",
                     "approved_at_utc": "2026-08-01T12:00:00Z",
                     "auth_method": "OIDC",
                     "auth_principal_hash": "g" * 64,
                 },
                 {
-                    "approver_urn": "urn:actuator01:op:op-b",
+                    "approver_urn": "urn:actuator_01:op:op-b",
                     "approved_at_utc": "2026-08-01T12:00:05Z",
                     "auth_method": "OIDC",
                     "auth_principal_hash": "h" * 64,

--- a/tests/test_actuator_01_response_classifier.py
+++ b/tests/test_actuator_01_response_classifier.py
@@ -1,0 +1,238 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for actuator_01 response classifier.
+
+Validates classification of HTTP status codes, 403 disambiguation (load-shed
+vs replay vs terminal), 200 receipt extraction, network errors, and
+fail-closed semantics for unrecognised status codes.
+"""
+
+from unittest.mock import MagicMock, PropertyMock
+
+import pytest
+
+from src.integrations.actuator_01.response_classifier import (
+    ClassifiedResponse,
+    ResponseCategory,
+    classify_network_error,
+    classify_response,
+)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────
+
+
+def _make_response(status_code: int, json_body: dict | None = None) -> MagicMock:
+    """Create a mock httpx.Response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    if json_body is not None:
+        resp.json.return_value = json_body
+    else:
+        resp.json.side_effect = ValueError("No JSON body")
+    return resp
+
+
+# ── Test: 200 OK ──────────────────────────────────────────────────────────
+
+
+class TestClassify200:
+    """200 OK with valid receipt → ACCEPTED; malformed → REJECTED_TERMINAL."""
+
+    def test_valid_receipt(self):
+        resp = _make_response(200, {
+            "receipt_id": "rcpt-001",
+            "session_uuid": "sess-001",
+            "status": "ACCEPTED",
+        })
+        result = classify_response(resp)
+        assert result.category == ResponseCategory.ACCEPTED
+        assert result.receipt_id == "rcpt-001"
+        assert result.session_uuid == "sess-001"
+        assert result.retryable is False
+        assert result.findings == []
+
+    def test_missing_receipt_id(self):
+        resp = _make_response(200, {"status": "ACCEPTED"})
+        result = classify_response(resp)
+        assert result.category == ResponseCategory.REJECTED_TERMINAL
+        assert result.error_code == "MISSING_RECEIPT_ID"
+        assert result.retryable is False
+
+    def test_unparseable_body(self):
+        resp = _make_response(200, None)
+        result = classify_response(resp)
+        assert result.category == ResponseCategory.REJECTED_TERMINAL
+        assert result.error_code == "UNPARSEABLE_RECEIPT"
+
+    def test_receipt_with_extra_fields(self):
+        resp = _make_response(200, {
+            "receipt_id": "rcpt-002",
+            "session_uuid": "sess-002",
+            "extra_field": "ignored",
+        })
+        result = classify_response(resp)
+        assert result.category == ResponseCategory.ACCEPTED
+        assert result.receipt_id == "rcpt-002"
+
+
+# ── Test: 403 Disambiguation ─────────────────────────────────────────────
+
+
+class TestClassify403:
+    """403 Forbidden requires body inspection to distinguish sub-types."""
+
+    def test_load_shed_is_retryable(self):
+        resp = _make_response(403, {
+            "error": "LOAD_SHED",
+            "message": "Too many concurrent requests",
+        })
+        result = classify_response(resp)
+        assert result.category == ResponseCategory.REJECTED_RETRYABLE
+        assert result.retryable is True
+        assert result.error_code == "LOAD_SHED"
+
+    def test_capacity_limit_is_retryable(self):
+        resp = _make_response(403, {"error": "CAPACITY_LIMIT"})
+        result = classify_response(resp)
+        assert result.category == ResponseCategory.REJECTED_RETRYABLE
+        assert result.retryable is True
+
+    def test_replay_detected_is_terminal(self):
+        resp = _make_response(403, {
+            "error": "REPLAY_DETECTED",
+            "message": "Nonce reuse",
+        })
+        result = classify_response(resp)
+        assert result.category == ResponseCategory.REJECTED_TERMINAL
+        assert result.retryable is False
+        assert result.error_code == "REPLAY_DETECTED"
+
+    def test_quorum_failure_is_terminal(self):
+        resp = _make_response(403, {"error": "QUORUM_FAILURE"})
+        result = classify_response(resp)
+        assert result.category == ResponseCategory.REJECTED_TERMINAL
+        assert result.retryable is False
+
+    def test_unknown_403_error_is_terminal(self):
+        """Fail-closed: unknown 403 sub-types → terminal."""
+        resp = _make_response(403, {"error": "SOMETHING_NEW"})
+        result = classify_response(resp)
+        assert result.category == ResponseCategory.REJECTED_TERMINAL
+        assert result.retryable is False
+
+    def test_403_no_body_is_terminal(self):
+        """Fail-closed: 403 with no parseable body → terminal."""
+        resp = _make_response(403, None)
+        result = classify_response(resp)
+        assert result.category == ResponseCategory.REJECTED_TERMINAL
+        assert result.retryable is False
+
+    def test_403_case_insensitive_error_code(self):
+        resp = _make_response(403, {"error": "load_shed"})
+        result = classify_response(resp)
+        assert result.category == ResponseCategory.REJECTED_RETRYABLE
+
+
+# ── Test: Retryable Status Codes ─────────────────────────────────────────
+
+
+class TestRetryableStatusCodes:
+    """Status codes that should be retried with backoff."""
+
+    @pytest.mark.parametrize("status", [408, 429, 500, 502, 503, 504])
+    def test_retryable_status_codes(self, status):
+        resp = _make_response(status, {"error": f"ERROR_{status}"})
+        result = classify_response(resp)
+        assert result.category == ResponseCategory.REJECTED_RETRYABLE
+        assert result.retryable is True
+
+    @pytest.mark.parametrize("status", [408, 429, 500, 502, 503, 504])
+    def test_retryable_with_no_body(self, status):
+        resp = _make_response(status, None)
+        result = classify_response(resp)
+        assert result.category == ResponseCategory.REJECTED_RETRYABLE
+        assert result.retryable is True
+
+
+# ── Test: Terminal Status Codes ───────────────────────────────────────────
+
+
+class TestTerminalStatusCodes:
+    """Status codes that should NOT be retried."""
+
+    @pytest.mark.parametrize("status", [400, 401, 409, 421, 422])
+    def test_terminal_status_codes(self, status):
+        resp = _make_response(status, {"error": "VALIDATION_FAILED"})
+        result = classify_response(resp)
+        assert result.category == ResponseCategory.REJECTED_TERMINAL
+        assert result.retryable is False
+
+
+# ── Test: Unrecognised Status Codes ───────────────────────────────────────
+
+
+class TestUnrecognisedStatusCodes:
+    """Fail-closed: unrecognised status codes → terminal."""
+
+    @pytest.mark.parametrize("status", [201, 204, 301, 418, 451, 599])
+    def test_unrecognised_status_is_terminal(self, status):
+        resp = _make_response(status, None)
+        result = classify_response(resp)
+        assert result.category == ResponseCategory.REJECTED_TERMINAL
+        assert result.retryable is False
+
+
+# ── Test: Network Errors ─────────────────────────────────────────────────
+
+
+class TestNetworkErrors:
+    """Transport-level failures are retryable and classified as NETWORK_ERROR."""
+
+    def test_generic_network_error(self):
+        exc = ConnectionError("Connection refused")
+        result = classify_network_error(exc)
+        assert result.category == ResponseCategory.NETWORK_ERROR
+        assert result.retryable is True
+        assert result.status_code == 0
+        assert result.error_code == "NETWORK_ERROR"
+
+    def test_rst_detection(self):
+        exc = ConnectionError("Connection reset by peer")
+        result = classify_network_error(exc)
+        assert result.error_code == "CONNECTION_RESET"
+        assert result.retryable is True
+
+    def test_dns_error(self):
+        exc = OSError("Name or service not known")
+        result = classify_network_error(exc)
+        assert result.category == ResponseCategory.NETWORK_ERROR
+        assert result.retryable is True
+
+
+# ── Test: ClassifiedResponse Defaults ─────────────────────────────────────
+
+
+class TestClassifiedResponseDefaults:
+    """Verify ClassifiedResponse field defaults."""
+
+    def test_findings_defaults_to_empty_list(self):
+        cr = ClassifiedResponse(
+            category=ResponseCategory.ACCEPTED, status_code=200
+        )
+        assert cr.findings == []
+        assert cr.retryable is False
+        assert cr.receipt_id is None

--- a/tests/test_jcs_canonicalizer.py
+++ b/tests/test_jcs_canonicalizer.py
@@ -74,14 +74,14 @@ def test_jcs_canonicalize_negative_zero():
     assert canonical == b'{"val":0}'
 
 
-def test_jcs_provider_04_reference_vector_1():
-    """Verify exact byte and SHA-256 parity for Provider 04 reference Vector 1."""
+def test_jcs_actuator_01_reference_vector_1():
+    """Verify exact byte and SHA-256 parity for actuator_01 reference Vector 1."""
     import hashlib
 
     vector_1_input = {
-        "envelope_version": "provider_04.envelope/v1",
+        "envelope_version": "actuator_01.envelope/v1",
         "correlation_id": "550e8400-e29b-41d4-a716-446655440000",
-        "operator_urn": "urn:provider_04:op:test_vector_1",
+        "operator_urn": "urn:actuator_01:op:test_vector_1",
         "action": "payment.wire.execute",
         "target": {
             "account_hash": "3333333333333333333333333333333333333333333333333333333333333333"
@@ -105,17 +105,16 @@ def test_jcs_provider_04_reference_vector_1():
         "nonce": "0102030405060708090a0b0c0d0e0f10",
     }
 
-    expected_canonical_bytes = b'{"action":"payment.wire.execute","authority_ref":{"graph_hash":"1111111111111111111111111111111111111111111111111111111111111111","graph_version":"ag-2026-08-01T00:00:00Z"},"correlation_id":"550e8400-e29b-41d4-a716-446655440000","envelope_version":"provider_04.envelope/v1","governance":{"decision":"ALLOW","decision_path":"DIRECT","evaluated_at":1785012000,"policy_version":"cage-policy-2.1.1","receipt_hash":"2222222222222222222222222222222222222222222222222222222222222222","receipt_id":"cage-seal-test-0001","required_quorum":2},"issued_at":1785012000,"nonce":"0102030405060708090a0b0c0d0e0f10","operator_urn":"urn:provider_04:op:test_vector_1","parameters":{"amount_minor":12345,"currency":"USD"},"target":{"account_hash":"3333333333333333333333333333333333333333333333333333333333333333"},"ttl_seconds":30}'
-    # Note: SHA-256 of the exact canonical bytes printed in §11 of the Provider 04 spec
-    expected_sha256 = "90de7ead1529e977c9ba9d84cb7e743c73996168843bcb2e928eef0427980d32"
+    expected_canonical_bytes = b'{"action":"payment.wire.execute","authority_ref":{"graph_hash":"1111111111111111111111111111111111111111111111111111111111111111","graph_version":"ag-2026-08-01T00:00:00Z"},"correlation_id":"550e8400-e29b-41d4-a716-446655440000","envelope_version":"actuator_01.envelope/v1","governance":{"decision":"ALLOW","decision_path":"DIRECT","evaluated_at":1785012000,"policy_version":"cage-policy-2.1.1","receipt_hash":"2222222222222222222222222222222222222222222222222222222222222222","receipt_id":"cage-seal-test-0001","required_quorum":2},"issued_at":1785012000,"nonce":"0102030405060708090a0b0c0d0e0f10","operator_urn":"urn:actuator_01:op:test_vector_1","parameters":{"amount_minor":12345,"currency":"USD"},"target":{"account_hash":"3333333333333333333333333333333333333333333333333333333333333333"},"ttl_seconds":30}'
+    expected_sha256 = "5e277d3d8110006e1b3975c2a68eb89e32c823f8a8107b82e6875c6c5d21f327"
 
     actual_canonical_bytes = jcs_canonicalize_plan(vector_1_input)
     assert actual_canonical_bytes == expected_canonical_bytes
     assert hashlib.sha256(actual_canonical_bytes).hexdigest() == expected_sha256
 
 
-def test_jcs_provider_04_reference_vector_2():
-    """Verify exact byte and SHA-256 parity for Provider 04 reference Vector 2 (adversarial formatting)."""
+def test_jcs_actuator_01_reference_vector_2():
+    """Verify exact byte and SHA-256 parity for actuator_01 reference Vector 2 (adversarial formatting)."""
     import hashlib
 
     vector_2_input = {

--- a/tests/test_normative_provider_conformance.py
+++ b/tests/test_normative_provider_conformance.py
@@ -46,7 +46,7 @@ from src.gateway.governance.normative_provider import (
 pytestmark = [pytest.mark.unit, pytest.mark.local]
 
 NORMATIVE_PROVIDERS = ["static", "provider_01", "provider_03", "provider_06"]
-ATTESTATION_PROVIDERS = ["provider_02", "provider_04"]
+ATTESTATION_PROVIDERS = ["provider_02"]
 
 
 @pytest.mark.parametrize("provider_name", NORMATIVE_PROVIDERS)

--- a/tests/test_provider_05_warrant_contract.py
+++ b/tests/test_provider_05_warrant_contract.py
@@ -96,7 +96,7 @@ def test_warrant_standing_verification_valid(sample_warrant: Warrant) -> None:
     """Verify active warrant passes standing check within valid window and scope."""
     context = {
         "action": "execute_trade",
-        "actor": "urn:provider_04:op:test_operator",
+        "actor": "urn:actuator_01:op:test_operator",
         "system": "cage-gateway",
         "jurisdiction": "EU_ECB",
         "governing_version": "cage-policy-2.1.0",


### PR DESCRIPTION
## Summary

Completes the actuator_01 integration cleanup by removing all legacy provider_04 nomenclature introduced during early design phases.

## Changes

- Remove dangling `p04`/`p05` aliases from [`normative_provider.py`](src/gateway/governance/normative_provider.py) factory
- Purge provider_04 from docstrings in [`src/integrations/__init__.py`](src/integrations/__init__.py)
- Remove `provider_04` from `ATTESTATION_PROVIDERS` test list
- Rename JCS reference vectors from `provider_04` to `actuator_01` with recomputed SHA-256 digest
- Normalize URN literals from `urn:actuator01:` to canonical `urn:actuator_01:`
- Delete gitignored `scratch/archytan_test.py`

The provider_04 package directory was already deleted in prior work; this PR removes final symbolic references.

## Test Results

```
make test-fast
3424 passed, 111 skipped in 106.48s
```

**JCS Vector 1 digest updated:**
- Old (provider_04): `90de7ead1529e977c9ba9d84cb7e743c73996168843bcb2e928eef0427980d32`
- New (actuator_01): `5e277d3d8110006e1b3975c2a68eb89e32c823f8a8107b82e6875c6c5d21f327`

## Checklist

- [x] All tests pass locally (`make test-fast`)
- [x] Zero provider_04 residue remains (verified via `grep -r`)
- [x] JCS reference vector digests recomputed and verified
- [x] Commit message follows Conventional Commits
- [x] Branch name follows `refactor/<description>` pattern