### PR TITLE
docs(compliance): add composed OSCAL component definition

### DIFF
--- a/compliance/oscal/sp800-53-component-definition-composed.yaml
+++ b/compliance/oscal/sp800-53-component-definition-composed.yaml
@@ -1,0 +1,693 @@
+component-definition:
+  back-matter:
+    resources:
+      - rlinks:
+          - href: ../../compliance/categorization/FIPS199_CATEGORIZATION.md
+        title: FIPS 199 System Categorization
+        uuid: dce38770-251a-497c-886d-2130ff259402
+      - rlinks:
+          - href: https://www.iso.org/standard/81230.html
+        title: ISO/IEC 42001:2023 — AI Management System Standard
+        uuid: 2416a563-630a-41e1-9e8f-5b174fc771ac
+      - rlinks:
+          - href: https://github.com/defenseunicorns/lula
+        title: Lula Compliance Automation Tool
+        uuid: 7fab6ccd-37af-4a69-8ef5-2e4f5d1fa440
+      - rlinks:
+          - href: ../../compliance/lula/lula-validation-a52.yaml
+        title: 'Lula Validation: A.5.2 Social Impact Assessment'
+        uuid: 885abacf-6878-4305-a942-6b96f50175cb
+      - rlinks:
+          - href: ../../compliance/lula/lula-validation-a53.yaml
+        title: 'Lula Validation: A.5.3 Logging and Monitoring'
+        uuid: 541ad147-6eec-4e35-b906-420c803ff6f0
+      - rlinks:
+          - href: ../../compliance/lula/lula-validation-a92.yaml
+        title: 'Lula Validation: A.9.2 Data Privacy (PII)'
+        uuid: 7ac4f5f2-87ca-4632-a890-fb1ecba65119
+      - rlinks:
+          - href: ../../compliance/lula/lula-validation-au12.yaml
+          - href: ../../compliance/lula/lula-validation-ac3.yaml
+        title: 'Lula Validation: AU-12 / AC-3 Audit and Access'
+        uuid: a08c55f1-6d12-445d-b4ae-a99c8b573935
+      - rlinks:
+          - href: ../../compliance/lula/lula-validation-ir6.yaml
+        title: 'Lula Validation: IR-6 Incident Reporting'
+        uuid: bea772cc-5526-49bb-979a-d9be71de5707
+      - rlinks:
+          - href: ../../compliance/lula/lula-validation-ra5.yaml
+          - href: ../../compliance/lula/lula-validation-cm6.yaml
+        title: 'Lula Validation: RA-5 / CA-7 Risk and Monitoring'
+        uuid: 1c436570-b67f-4857-bbbf-d1ba683dae25
+      - rlinks:
+          - href: ../../compliance/lula/lula-validation-sc4.yaml
+        title: 'Lula Validation: SC-4 Fiscal Limits (OPA)'
+        uuid: ff18a36b-6dc8-4459-88e8-976fd7c10141
+      - rlinks:
+          - href: https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final
+        title: NIST SP 800-53 Rev 5 — Security and Privacy Controls
+        uuid: 34172b73-72d8-4b50-8dd8-0d31a5df3270
+      - rlinks:
+          - href: ../../compliance/ssp/SYSTEM_SECURITY_PLAN_OUTLINE.md
+        title: System Security Plan Outline
+        uuid: 21147aee-7c67-4f4c-b25e-bcc6637b5cb3
+  components:
+    - control-implementations:
+        - description: NIST SP 800-53 Rev 5 HIGH-baseline controls implemented by the Compliance Bridge
+          implemented-requirements:
+            - control-id: au-9
+              description: |
+                Protection of audit information is implemented via OSCAL Assessment Results
+                stored to MinIO/GCS through src/compliance_bridge/storage.py. S3 object
+                locking (COMPLIANCE mode) provides write-once protection of audit artifacts,
+                preventing modification or deletion for the retention period. Access to audit
+                buckets is restricted via IAM policies to the compliance-bridge service account
+                (principle of least privilege). NOTE: S3 object locking must be enabled at
+                bucket creation time — see POAM item IR-1 for current status and remediation
+                timeline. Audit files are encrypted at rest using GCS/MinIO server-side
+                encryption.
+              links:
+                - href: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home?element=AU-9
+                  rel: reference
+              props:
+                - name: implementation-status
+                  value: partial
+                - name: control-origination
+                  value: hybrid
+              uuid: 80d95b3a-12ae-4dd4-8db4-b52661335fa4
+            - control-id: ca-7
+              description: |
+                Continuous monitoring is automated via the 5-step audit pipeline in
+                src/compliance_bridge/audit_workflow.py: (1) collect OTel spans from
+                Langfuse, (2) evaluate control safety rates, (3) generate OSCAL Assessment
+                Results, (4) store to MinIO/GCS, (5) alert on failures. The pipeline
+                runs every 6 hours via deployment/k8s/lula-cron.yaml (Kubernetes CronJob).
+                Lula validation manifests in compliance/lula/ provide automated control
+                assertions (lula-validation-au12.yaml, lula-validation-ac3.yaml,
+                lula-validation-ra5.yaml, lula-validation-cm6.yaml, lula-validation-ir6.yaml).
+                Monitoring status is streamed in real-time via src/compliance_bridge/sse_events.py.
+              links:
+                - href: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home?element=CA-7
+                  rel: reference
+                - href: '#1c436570-b67f-4857-bbbf-d1ba683dae25'
+                  rel: lula
+              props:
+                - name: implementation-status
+                  value: implemented
+                - name: control-origination
+                  value: system-specific
+              uuid: 356c3f20-ff82-4a9e-9b62-83c0aa240df1
+            - control-id: ir-6
+              description: |
+                Incident reporting is implemented via src/compliance_bridge/notifier.py,
+                which delivers Slack and PagerDuty notifications when control safety rates
+                fall below threshold or critical failures are detected. Real-time security
+                events are streamed to subscribing dashboards via the SSE event bus in
+                src/compliance_bridge/sse_events.py. The notification pipeline triggers
+                on: (1) PII safety_rate < 1.0, (2) overall compliance score < 0.95,
+                (3) Lula validation failures, (4) OPA pod unavailability. Incident tickets
+                include OSCAL control ID, failure evidence, and remediation guidance links.
+              links:
+                - href: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home?element=IR-6
+                  rel: reference
+                - href: '#bea772cc-5526-49bb-979a-d9be71de5707'
+                  rel: lula
+              props:
+                - name: implementation-status
+                  value: implemented
+                - name: control-origination
+                  value: system-specific
+              uuid: 07769d00-7959-4cfe-86aa-972a537952d5
+          source: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home
+          uuid: 43e1c175-3c01-4176-9cf2-8de2549c876d
+      description: |
+        Automated OSCAL audit pipeline providing continuous monitoring, audit information protection, and incident reporting. Runs a 5-step assessment workflow every 6 hours via Kubernetes CronJob. Stores OSCAL Assessment Results to MinIO/GCS and delivers real-time compliance events via SSE and Slack/PagerDuty notifications.
+      purpose: |
+        Operationalizes continuous compliance monitoring by automating the collect-analyze-report cycle. Protects audit integrity through object storage with locking. Ensures security-relevant events are reported to responsible parties within SLA-defined timeframes.
+      responsible-roles:
+        - role-id: provider
+      title: Compliance Bridge
+      type: software
+      uuid: 7acccab0-36a0-45d3-adbe-cf31d6cec458
+    - control-implementations:
+        - description: NIST SP 800-53 Rev 5 HIGH-baseline controls inherited from GCP/GKE platform
+          implemented-requirements:
+            - control-id: ia-2
+              description: |
+                Identification and authentication is inherited from GCP Workload Identity
+                Federation. Each Kubernetes Service Account is bound to a GCP IAM Service
+                Account via Workload Identity, providing cryptographically verifiable
+                identity for all pod-level API calls to GCP services. Cluster authentication
+                is managed via GKE cluster RBAC (deployment/k8s/lula-rbac.yaml,
+                deployment/k8s/service-account.yaml). Human operator access to the GKE
+                cluster requires GCP IAM authentication with MFA enforced at the
+                organizational policy level. GCP Identity-Aware Proxy (IAP) protects
+                any externally accessible management endpoints.
+
+                Application-level operator identification (Work Item 2, 2026-09-07): Human
+                operator identity for defer escalation approval path is extracted via
+                require_operator_identity() (src/compliance_bridge/auth.py:88). Identity
+                precedence is fail-closed and evaluated (not negotiated):
+
+                1. SPIFFE SVID (primary): Extracted from mTLS client certificate SAN via
+                   Linkerd service mesh. SVID format: spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>.
+                   The SVID is populated by Linkerd into request.attributes.source.principal
+                   or x-cage-source-principal header. Principal hash derived via SHA-256
+                   of complete SVID URI (line 118).
+
+                2. OIDC JWT (gated fallback): Only accepted when CAGE_OPERATOR_IDENTITY_ALLOW_OIDC=true.
+                   Identity extracted from JWT 'sub' claim pre-validated by upstream middleware.
+                   Principal hash derived via SHA-256 of sub claim value (line 140).
+
+                3. Dev-mode synthetic: Requires dual-condition opt-in (CAGE_ENV=dev AND
+                   CAGE_OPERATOR_IDENTITY_ALLOW_DEV_SYNTHETIC=true). All synthetic principals
+                   carry auth_method="DEV_SYNTHETIC" and reserved urn:cage:dev: prefix
+                   enforcement (line 157-161). Production (CAGE_ENV=prod) never yields
+                   synthetic principals.
+
+                Identity rejection rules: Request-body identity assertion is forbidden
+                (breaking change from prior self-asserted operator_urn/session_id fields
+                removed from DeferEscalateRequest, line 1542). If no valid identity source
+                exists, require_operator_identity() fails closed with HTTP 401 (line 171-175).
+                Identity conflicts (SVID present but parse failure) degrade to next channel
+                with warning logs (line 125-126).
+
+                Principal hash binding: The auth_principal_hash field in ApprovalRecord
+                (src/gateway/governance/defer_queue.py:447, line 1580) is derived from the
+                verified credential subject, not caller-supplied session_id. This hash
+                provides tamper-evident binding between the approval record and the
+                transport-layer authentication substrate.
+
+                Alignment with IA-3 workload identity: This extends the existing SVID-based
+                workload identity (IA-3 control, already asserted in src/gateway/governance/oscal_ssp_exporter.py:319)
+                to the operator approval path. Workload SVID authenticates the channel
+                (pod-to-pod mTLS via Linkerd); OIDC sub identifies the human operator in
+                shared-console scenarios where multiple operators use the same service account.
+              links:
+                - href: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home?element=IA-2
+                  rel: reference
+                - href: ../../src/compliance_bridge/auth.py
+                  rel: implementation
+                  text: require_operator_identity() SPIFFE/OIDC extraction
+                - href: ../../deployment/k8s/linkerd-mtls-policy.yaml
+                  rel: configuration
+                  text: Linkerd mTLS SPIFFE trust domain configuration
+              props:
+                - name: implementation-status
+                  value: implemented
+                - name: control-origination
+                  value: hybrid
+                - name: inherited-from
+                  value: GCP/GKE Platform — Google Cloud Common Controls Package (workload/cluster identity)
+                - name: application-level-implementation-date
+                  value: "2026-09-07"
+              uuid: ca8f96e2-69a3-4d6b-980c-962e73e075d8
+            - control-id: sc-7
+              description: |
+                Boundary protection is inherited from GKE VPC-native networking and
+                Google Cloud Load Balancer. All ingress traffic is routed through the
+                Cloud Load Balancer, which terminates TLS and applies Cloud Armor WAF
+                rules. Kubernetes network policies in deployment/k8s/network-policy.yaml
+                and deployment/k8s/network-policy-hardening.yaml restrict pod-to-pod
+                communication to explicitly declared paths. The compliance namespace is
+                isolated via Kubernetes NetworkPolicy; only the compliance-bridge pod
+                may reach the MinIO/GCS storage endpoints. Pod Security Admission
+                in deployment/k8s/pod-security-admission.yaml enforces restricted policy.
+              links:
+                - href: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home?element=SC-7
+                  rel: reference
+              props:
+                - name: implementation-status
+                  value: inherited
+                - name: control-origination
+                  value: inherited
+                - name: inherited-from
+                  value: GCP/GKE Platform — Google Cloud Common Controls Package
+              uuid: 2d27d190-b3da-49f4-bd39-1d4f25f5d20a
+            - control-id: sc-8
+              description: |
+                Transmission confidentiality and integrity is inherited from GCP TLS
+                termination at the Cloud Load Balancer. HTTPS is enforced on all ingress
+                via deployment/k8s/ingress.yaml with TLS certificates managed by Google-
+                managed SSL certificates. Internal cluster communication between pods uses
+                Kubernetes service mesh with mTLS enforced at the service level where
+                sensitive data (audit logs, PII detection results) transits the network.
+                The GCP load balancer enforces TLS 1.2 minimum with strong cipher suites.
+                All data in transit to external services (Langfuse, Slack, PagerDuty) uses
+                HTTPS with certificate validation enforced by the HTTP client libraries.
+              links:
+                - href: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home?element=SC-8
+                  rel: reference
+              props:
+                - name: implementation-status
+                  value: inherited
+                - name: control-origination
+                  value: inherited
+                - name: inherited-from
+                  value: GCP/GKE Platform — Google Cloud Common Controls Package
+              uuid: 230de322-4b76-4a0d-b07d-267f4fa23769
+          source: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home
+          uuid: 47bd5e3c-7e9f-4006-98e8-dac390437a7e
+      description: |
+        Google Cloud Platform / Google Kubernetes Engine infrastructure providing inherited security controls. Includes VPC-native GKE networking with Cloud Load Balancer boundary protection, GCP Workload Identity Federation for authentication, and TLS termination at the load balancer for transmission confidentiality. Supplemented by Kubernetes-layer controls defined in deployment/k8s/.
+      purpose: |
+        Provides platform-level inherited security controls that the application components rely upon. Network boundary protection, identity and authentication, and transmission encryption are inherited from the GCP Common Controls Package and supplemented by cluster-level Kubernetes network policies.
+      responsible-roles:
+        - role-id: provider
+      title: GCP/GKE Infrastructure
+      type: service
+      uuid: 3014bff4-f8df-4f9f-a957-9aab57e8f87d
+    - control-implementations:
+        - description: NIST SP 800-53 Rev 5 HIGH-baseline controls implemented by the Governance Gateway
+          implemented-requirements:
+            - control-id: ac-3
+              description: |
+                Access enforcement is implemented via OPA RBAC policy evaluation on every
+                inbound API request through deployment/system_authz.rego. The governance
+                middleware in src/gateway/server/governance_middleware.py performs routing
+                seal verification before processing any request, rejecting requests with
+                invalid or missing HMAC seals. OPA allow/deny decisions are recorded in
+                structured audit logs with full request context and user identity.
+
+                Dual-control authentication enforcement (Work Item 2, 2026-09-07): All defer
+                escalation endpoints now require cryptographically-verified operator identity.
+                The /v1/defer/escalate endpoint (src/compliance_bridge/main.py:1527) enforces
+                Depends(require_internal_token) to prevent unauthenticated access. The
+                /v1/defer/inject endpoint (src/compliance_bridge/main.py:1326) also requires
+                internal token authentication. No /v1/defer/ route is reachable without
+                authentication in production (CAGE_ENV=prod/staging).
+
+                Quorum enforcement mechanism: DeferQueue.approve() (src/gateway/governance/defer_queue.py:447)
+                enforces distinctness of approver_urn values via WATCH/MULTI/EXEC atomic
+                transaction (lines 510-518). The approver_urn is provably derived from
+                transport-layer verified SPIFFE SVID (primary) or OIDC JWT subject (gated
+                fallback). Single authenticated principal cannot reach quorum - duplicate
+                approvals are rejected with ALREADY_APPROVED status (line 511-518). Required
+                quorum is auto-computed from defer_reason: quorum-3 for FTRA_IRREVERSIBLE_TERMINAL,
+                EXTERNAL_VALIDATION, and FLOWSIGNAL_ESCALATION defer reasons; quorum-2 for
+                all others (src/gateway/governance/defer_queue.py:66-80).
+
+                Protection against single-principal quorum bypass: The defer_inject endpoint
+                rejects injection attempts for quorum-3 defer reasons (line 1377-1392) and
+                rejects injection if token has partial approvals (line 1394-1405), preventing
+                circumvention of the dual-control requirement via automated data injection.
+              links:
+                - href: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-3
+                  rel: reference
+                - href: '#3dd95937-14f6-45ae-a29b-8a1d173588b0'
+                  rel: lula
+                - href: ../../src/compliance_bridge/main.py
+                  rel: implementation
+                  text: defer_escalate() and defer_inject() authentication enforcement
+                - href: ../../src/gateway/governance/defer_queue.py
+                  rel: implementation
+                  text: DeferQueue.approve() quorum enforcement
+                - href: ../../tests/test_defer_dual_control_auth.py
+                  rel: test
+                  text: Adversarial dual-control authentication test coverage
+              props:
+                - name: implementation-status
+                  value: implemented
+                - name: control-origination
+                  value: system-specific
+                - name: dual-control-implementation-date
+                  value: "2026-09-07"
+              uuid: 12e40b44-a5eb-4e0d-b319-42bab7d5d10a
+            - control-id: au-12
+              description: |
+                Audit record generation is implemented via OpenTelemetry spans in
+                src/gateway/infrastructure/telemetry.py and the provenance chain in
+                src/gateway/governance/provenance_chain.py. CAGE provides two distinct
+                auditing modes to support different consistency/availability trade-offs:
+
+                1. DECISION-TIME AUDIT (fire-and-forget, default mode):
+                   Records governance decisions asynchronously via OTel spans. Every
+                   governance decision emits a span containing ISO 42001 6-attribute
+                   evidence stamps: control_id, decision_outcome, timestamp_utc,
+                   request_id, user_role, and enforcement_tier. This mode prioritizes
+                   availability — the routing seal is issued immediately after the
+                   governance decision, without waiting for audit record persistence.
+                   Spans are exported to Langfuse asynchronously for retention.
+                   Domain tiers (like the financial package) are injected dynamically
+                   via plugin registration, and the active tier list is logged at startup.
+
+                2. EVIDENCE-OF-EXECUTION AUDIT (blocking mode, EVIDENCE_CHAIN_BLOCKING=true):
+                   Ensures evidence commit before seal issuance, providing stronger
+                   non-repudiation guarantees. When enabled via the EVIDENCE_CHAIN_BLOCKING
+                   environment variable, the provenance chain (provenance_chain.py) must
+                   successfully persist the evidence record to the backing store before
+                   the routing seal is computed and returned. This mode ties the
+                   cryptographic seal directly to a committed evidence record, ensuring
+                   that no seal can exist without a corresponding audit trail entry.
+                   The evidence record includes a hash-linked chain for time-correlation.
+
+                Key distinction: Decision-time audit records WHAT was decided; evidence-
+                of-execution audit proves THAT the decision was recorded before action.
+                The blocking mode satisfies AU-12(1) system-wide/time-correlated audit
+                trail requirements through hash-linked evidence chain correlation.
+
+                The backward-compatibility remediation (BC-01–BC-08, 2026-08-27) removed
+                all dual-schema machinery (v1.0/v1.1 support) from the evidence pipeline
+                and compliance-bridge. Hash-chain canonicalization in evidence_stream.py
+                and context_accumulator.py now uses RFC 8785 JCS (jcs_canonicalize_plan)
+                exclusively, with a /2.0 schema sentinel. The six canonical decision values
+                (ALLOW, DENY, DEFER, NARROW, PAUSE, REQUIRE_APPROVAL) are enforced in
+                provenance_chain.py (VALID_DECISIONS). The compliance-bridge aggregates
+                spans into OSCAL Assessment Results via audit_workflow.py.
+              links:
+                - href: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home?element=AU-12
+                  rel: reference
+                - href: '#a08c55f1-6d12-445d-b4ae-a99c8b573935'
+                  rel: lula
+              props:
+                - name: implementation-status
+                  value: implemented
+                - name: control-origination
+                  value: system-specific
+                - name: evidence-chain-blocking
+                  value: configurable via EVIDENCE_CHAIN_BLOCKING env var
+                - name: au-12-1-enhancement
+                  value: hash-linked evidence chain provides time-correlated audit trail
+                - name: jcs-canonicalization
+                  value: RFC 8785 JCS for deterministic cross-platform evidence integrity
+                - name: canonical-decision-vocabulary
+                  value: ALLOW, DENY, DEFER, NARROW, PAUSE, REQUIRE_APPROVAL
+              uuid: 4ccc6861-3f69-476a-9ff2-cbd215b18d46
+            - control-id: sc-12
+              description: |
+                Cryptographic key establishment is implemented via HMAC-SHA256 routing
+                seals in src/gateway/governance/contracts.py. The routing seal secret
+                is loaded from the CAGE_ROUTING_SEAL_SECRET environment variable, which
+                is backed by a Kubernetes Secret (deployment/k8s/oscal-artifact-secrets.yaml).
+                Every request must carry a valid HMAC-SHA256 seal computed over the
+                request payload; invalid seals result in immediate rejection with a 401
+                response. Key rotation is performed via Kubernetes Secret update without
+                service restart.
+              links:
+                - href: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home?element=SC-12
+                  rel: reference
+              props:
+                - name: implementation-status
+                  value: implemented
+                - name: control-origination
+                  value: system-specific
+              uuid: 61c43f8a-6693-4049-ae09-edd8b22f500a
+            - control-id: sc-13
+              description: |
+                Cryptographic protection is implemented via KMS-signed ConsequenceToken
+                JWS (src/gateway/governance/consequence_token.py) introduced in FlowSignal
+                Phase 2. ConsequenceToken.mint() uses KMSGovernanceSigner.sign_raw()
+                to produce a compact JWS with 8 claims (sub, tid, rec, act, ver, iat,
+                exp, jti). The signing algorithm is determined by the KMS key type
+                (ES256/ES384 for ECDSA, EdDSA for Ed25519, PS256/RS256 for RSA).
+                ConsequenceToken.verify() validates the JWS signature via
+                KMSGovernanceSigner.verify_raw(), rejects alg:none, and enforces
+                algorithm consistency (protected header alg must match signer.jose_alg).
+                All cryptographic operations fail closed — bad signature, expired token,
+                algorithm confusion, or malformed claims raise ConsequenceTokenError.
+                The token carries a SHA-256 digest of the RFC 8785 JCS-canonicalized
+                action payload in the 'act' claim, providing cryptographic binding
+                between governance evaluation and execution. The backward-compatibility
+                remediation (BC-01–BC-08, 2026-08-27) migrated all hash-chain modules
+                (provenance_chain.py, evidence_stream.py, context_accumulator.py) from
+                json.dumps(sort_keys=True) to RFC 8785 JCS (jcs_canonicalize_plan) for
+                deterministic cross-platform evidence integrity verification. This migration
+                was a breaking change — records written before 2026-08-27 are not verifiable
+                by the current code. No cryptographic path is excluded from JCS: the
+                WORM-bucket KMS signing payload built by _sign_record() in uca_logger.py
+                was migrated to RFC 8785 JCS with no compatibility shim and no carve-out,
+                so previously-signed WORM UCA records will not verify under the current
+                algorithm. That break is accepted because the data-at-rest
+                read-compatibility exception is dormant, not active (see the Dormant Rules
+                section of AGENTS.md).
+              links:
+                - href: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home?element=SC-13
+                  rel: reference
+              props:
+                - name: implementation-status
+                  value: implemented
+                - name: control-origination
+                  value: system-specific
+                - name: phase-2-implementation
+                  value: "true"
+              uuid: 2f94e8b5-7d3a-4c61-b9f4-8e5a9d6c3f2a
+            - control-id: si-7
+              description: |
+                Software, firmware, and information integrity is implemented via
+                ConsequenceGateway 6-step post-FRIA evaluation (src/gateway/governance/consequence_gateway.py)
+                introduced in FlowSignal Phase 2. Steps 3-4 recompute the SHA-256
+                digest of the RFC 8785 JCS-canonicalized action payload and compare
+                it to the 'act' claim in the ConsequenceToken. Digest mismatch triggers
+                ACTION_BINDING_MISMATCH rejection, closing the TOCTOU gap where the
+                action payload could be modified between governance evaluation and
+                execution. Step 5 verifies the binding hash (SHA-256 of
+                thread_id:actor_id:action_digest:authority_state_version) matches
+                the consumed marker in Redis, detecting substitution attacks where
+                a different binding is replayed under the same authority record ID.
+                All integrity failures fail closed with BLOCK decision and structured
+                reason codes. The deterministic RFC 8785 JCS canonicalization ensures
+                identical digest computation across Python/Go/JavaScript runtimes,
+                eliminating float-representation and key-ordering drift that could
+                cause spurious integrity check failures. The backward-compatibility
+                remediation (BC-01–BC-08, 2026-08-27) migrated all hash-chain modules
+                (provenance_chain.py, evidence_stream.py, context_accumulator.py) to
+                RFC 8785 JCS with no compatibility shim; previously-signed records will
+                not verify under the current code.
+              links:
+                - href: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home?element=SI-7
+                  rel: reference
+              props:
+                - name: implementation-status
+                  value: implemented
+                - name: control-origination
+                  value: system-specific
+                - name: phase-2-implementation
+                  value: "true"
+              uuid: 3a85d9c6-8e4b-5d72-a0a5-9f6b0e7d4a3b
+          source: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home
+          uuid: 6f075699-75de-4f31-a574-35bb22a194bd
+      description: |
+        Python FastAPI gateway providing three-tier semantic shielding and HMAC-SHA256 routing seal verification. Implements OPA-backed RBAC enforcement, OTel-based audit trail generation, and cryptographic request integrity verification via routing seals loaded from Kubernetes Secrets.
+      purpose: |
+        Acts as the primary ingress enforcement layer for all AI governance requests. Enforces access control via OPA, generates ISO 42001 6-attribute evidence stamps on every governance decision, and cryptographically authenticates request routing via HMAC seals.
+      responsible-roles:
+        - role-id: provider
+      title: Governance Gateway
+      type: software
+      uuid: 56654b26-d648-4e47-bbc8-19edd3ec67ba
+    - control-implementations:
+        - description: NIST SP 800-53 Rev 5 HIGH-baseline controls implemented by NeMo Guardrails
+          implemented-requirements:
+            - control-id: si-10
+              description: |
+                Information input validation is implemented via Microsoft Presidio PII detection
+                integrated into NeMo Guardrails. The rail configuration in config/rails/config.yml
+                enables detection of 16 PII entity types including PERSON, EMAIL_ADDRESS,
+                PHONE_NUMBER, US_SSN, CREDIT_CARD, IBAN_CODE, IP_ADDRESS, and more. Colang
+                rail definitions in config/rails/definitions.co enforce input blocking when
+                PII is detected. The NeMo manager in src/gateway/governance/nemo/manager.py
+                orchestrates the validation pipeline. All validation events are tagged with
+                the relevant SP 800-53 control ID and logged to OTel.
+              links:
+                - href: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home?element=SI-10
+                  rel: reference
+              props:
+                - name: implementation-status
+                  value: implemented
+                - name: control-origination
+                  value: system-specific
+              uuid: 8e46d991-dd78-416a-897d-f909cb63be8d
+            - control-id: si-3
+              description: |
+                Malicious code protection is implemented via NeMo Guardrails input/output
+                filtering in src/gateway/governance/nemo/manager.py. The jailbreak detection
+                rail analyzes prompts for known prompt injection patterns, adversarial
+                instructions, and role-confusion attacks. Output rails prevent the model
+                from generating harmful content, code execution instructions, or compliance-
+                violating responses. All detected malicious inputs are blocked, logged, and
+                trigger optional PagerDuty/Slack alerts via the compliance bridge notifier.
+              links:
+                - href: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home?element=SI-3
+                  rel: reference
+              props:
+                - name: implementation-status
+                  value: implemented
+                - name: control-origination
+                  value: system-specific
+              uuid: b1f022fc-e7f1-45e6-8972-9f5ab16f99fa
+          source: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home
+          uuid: 2de5e59a-f094-4d79-94eb-b3321211b4dc
+      description: |
+        NVIDIA NeMo Guardrails with Microsoft Presidio PII detection providing input/output validation, prompt injection detection, and malicious code protection. Configured via Colang rail definitions and integrated into the governance pipeline through src/gateway/governance/nemo/manager.py.
+      purpose: |
+        Validates all user inputs against 16 PII entity types, detects and blocks prompt injection and jailbreak attempts, and applies content safety rails to both inputs and model outputs. Provides defense-in-depth against adversarial inputs that bypass tier-1 heuristic filtering.
+      responsible-roles:
+        - role-id: provider
+      title: NeMo Guardrails
+      type: software
+      uuid: 3d19fa63-7253-4563-b757-23c89ea461ce
+    - control-implementations:
+        - description: NIST SP 800-53 Rev 5 HIGH-baseline controls implemented by OPA
+          implemented-requirements:
+            - control-id: ac-3
+              description: |
+                Access enforcement is implemented via OPA allow/deny decisions logged with
+                a full audit trail in deployment/system_authz.rego. Every request is
+                evaluated against the current policy; denied requests are logged with
+                the reason (insufficient_role, fiscal_limit_exceeded, invalid_seal) and
+                returned as structured JSON with HTTP 403. Audit logs include user identity,
+                resource requested, decision outcome, and applicable policy rules. The
+                compliance bridge ingests OPA decision logs into OSCAL Assessment Results.
+              links:
+                - href: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-3
+                  rel: reference
+                - href: '#a08c55f1-6d12-445d-b4ae-a99c8b573935'
+                  rel: lula
+              props:
+                - name: implementation-status
+                  value: implemented
+                - name: control-origination
+                  value: system-specific
+              uuid: f919c0a0-f04d-4925-8605-6a759f9ee94e
+            - control-id: ac-6
+              description: |
+                Least privilege is enforced via OPA Rego policy in deployment/system_authz.rego.
+                The policy grants permissions based on user role (junior_analyst, senior_analyst,
+                compliance_officer, admin) with graduated fiscal limits: junior analysts are
+                limited to $5,000 per trade and $10,000 daily aggregate; senior analysts to
+                $500,000 and $1,000,000 respectively. Fiscal limit checks in finance_policy.rego
+                enforce per-user-class constraints. Users cannot escalate their own permissions;
+                all role assignments are managed via Kubernetes RBAC and propagated to OPA
+                via environment configuration.
+              links:
+                - href: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home?element=AC-6
+                  rel: reference
+              props:
+                - name: implementation-status
+                  value: implemented
+                - name: control-origination
+                  value: system-specific
+              uuid: d3a6a007-74a4-4c0f-b2ba-d68bb2c395ff
+            - control-id: ia-3
+              description: |
+                Device identification and authentication is implemented via HMAC-SHA256
+                seal verification per request in src/gateway/governance/contracts.py.
+                Each client must compute an HMAC-SHA256 seal over the request payload
+                using the shared CAGE_ROUTING_SEAL_SECRET. OPA validates the seal
+                before evaluating any policy rules; requests with missing or invalid
+                seals are rejected with HTTP 401. This ensures that only authenticated
+                client systems (devices) can submit governance requests, providing
+                cryptographic device identity verification without relying solely on
+                network-layer controls.
+
+                SPIFFE workload identity (Work Item 2, 2026-09-07): Extends existing
+                SVID-based workload identity to the operator approval path. Linkerd
+                service mesh (deployment/k8s/linkerd-mtls-policy.yaml) provides mTLS
+                with SPIFFE SVID peer certificates for all pod-to-pod communication.
+                Each workload receives a SPIFFE ID in the format
+                spiffe://<trust-domain>/ns/<namespace>/sa/<service-account>.
+
+                Workload SVID authenticates the channel (pod-to-pod mTLS); OIDC sub
+                identifies the human operator in shared-console scenarios. This dual-layer
+                identity model (device via SVID, operator via OIDC) enables cryptographically
+                verifiable device authentication independent of operator identity, satisfying
+                IA-3 (device authentication) in conjunction with IA-2 (operator authentication).
+
+                The require_operator_identity() function (src/compliance_bridge/auth.py:88)
+                extracts SVID from request.attributes.source.principal (populated by
+                Linkerd) or x-cage-source-principal header (Envoy ext_authz integration).
+                This extends the workload identity assertion already documented in
+                src/gateway/governance/oscal_ssp_exporter.py:319 to cover the defer
+                escalation approval path, not just general governance requests.
+              links:
+                - href: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home?element=IA-3
+                  rel: reference
+                - href: ../../deployment/k8s/linkerd-mtls-policy.yaml
+                  rel: configuration
+                  text: Linkerd SPIFFE trust domain and mTLS policy
+                - href: ../../src/compliance_bridge/auth.py
+                  rel: implementation
+                  text: require_operator_identity() SVID extraction for approval path
+              props:
+                - name: implementation-status
+                  value: implemented
+                - name: control-origination
+                  value: system-specific
+                - name: operator-path-extension-date
+                  value: "2026-09-07"
+              uuid: 5f386745-cdda-431b-adec-850cdd899f3e
+          source: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home
+          uuid: 74b69ba2-d9a3-42d6-ac2d-89e9f88cc2e6
+      description: |
+        Open Policy Agent evaluating Rego policies (deployment/system_authz.rego, src/cage_finance/opa/trade_governance.rego) on every trade execution and governance request. Enforces RBAC role limits, fiscal thresholds, and request authentication. Decision logs are emitted to stdout and captured by Cloud Logging.
+      purpose: |
+        Provides deterministic, auditable policy enforcement independent of the LLM reasoning layer. Least-privilege access and RBAC are enforced via declarative Rego rules. HMAC seal validation per request provides cryptographic device authentication at the policy layer.
+      responsible-roles:
+        - role-id: provider
+      title: OPA Policy Engine
+      type: software
+      uuid: 0ea79813-1236-4a81-a077-71638e3f8627
+    - control-implementations:
+        - description: NIST SP 800-53 Rev 5 HIGH-baseline controls implemented by the STPA Safety Validator
+          implemented-requirements:
+            - control-id: ra-3
+              description: |
+                Risk assessment is implemented via STPA hazard analysis in
+                src/gateway/governance/stpa_validator.py. The validator identifies
+                unsafe control actions (UCAs) using the STPA methodology: for each
+                control action, it evaluates four UCA types (provided, not-provided,
+                too-early/too-late, stopped-too-soon/applied-too-long). Control Barrier
+                Functions (CBF) in src/gateway/governance/safety.py define formal safety
+                constraints with Lyapunov stability guarantees. Safety parameters
+                (thresholds, envelope bounds) are defined in
+                src/gateway/governance/safety_params.json. Risk findings are documented
+                in docs/STPA_ANALYSIS.md and tracked in docs/POAM.md.
+              links:
+                - href: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home?element=RA-3
+                  rel: reference
+                - href: '#1c436570-b67f-4857-bbbf-d1ba683dae25'
+                  rel: lula
+              props:
+                - name: implementation-status
+                  value: implemented
+                - name: control-origination
+                  value: system-specific
+              uuid: 6020e394-0647-480b-b9e5-2f05b6cb360c
+            - control-id: si-4
+              description: |
+                System monitoring is implemented via CBF real-time monitoring of all
+                inference outputs against safety envelopes defined in
+                src/gateway/governance/safety.py. The symbolic governor tracks violations
+                of fiscal limits, content safety thresholds, and STPA-derived constraints
+                on a per-request basis. Safety envelope violations are logged as OTel spans
+                with severity=WARNING or CRITICAL and trigger the compliance bridge alerting
+                pipeline. The automated auditor in scripts/automated_auditor.py performs
+                periodic assessment of monitoring coverage across all controlled components.
+              links:
+                - href: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home?element=SI-4
+                  rel: reference
+              props:
+                - name: implementation-status
+                  value: implemented
+                - name: control-origination
+                  value: system-specific
+              uuid: 42c2150e-0256-4ef0-b49b-8a7ee847f9cc
+          source: https://csrc.nist.gov/projects/cprt/api/cprt/framework/version/SP_800_53_5_1_1/home
+          uuid: a11854f4-c67e-4674-8818-817ed8c4a09a
+      description: |
+        System-Theoretic Process Analysis (STPA) hazard validator with Control Barrier Function (CBF) real-time monitoring. Performs continuous risk assessment of AI inference outputs and enforces safety envelopes on all governance decisions. Implemented in src/gateway/governance/stpa_validator.py and src/gateway/governance/safety.py.
+      purpose: |
+        Provides formal safety analysis (STPA) and real-time safety monitoring (CBF) to identify and mitigate unsafe control actions from the AI reasoning layer. Tracks safety envelope violations, escalates to the symbolic governor, and generates evidence for risk assessment documentation.
+      responsible-roles:
+        - role-id: provider
+      title: STPA Safety Validator
+      type: software
+      uuid: 4fd30a2a-c26b-4401-af55-ce57ceab042d
+  metadata:
+    last-modified: 2026-09-07T19:35:04.34178-04:00
+    oscal-version: 1.0.4
+    remarks: |
+      This component definition maps technical enforcement components to NIST SP 800-53 Rev 5 HIGH-baseline controls. Each implemented requirement links where applicable to a Lula validation manifest for automated continuous compliance assessment. Satisfies CA-2 (Security Assessment) and PL-2 (System Security Plan) documentation requirements.
+    title: Cybernetic Governance Engine — NIST SP 800-53 Rev 5 Component Definition
+    version: 1.0.0
+  uuid: 172cb046-96dc-47bb-9209-38ec37dbd579

--- a/src/integrations/actuator_01/__init__.py
+++ b/src/integrations/actuator_01/__init__.py
@@ -22,6 +22,22 @@ This adapter implements the ExecutionActuator protocol for secure execution
 authorization with dual-control quorum signatures.
 """
 
+from .adapter import Actuator01Adapter
+from .assertion import AssertionBuildError, build_assertion, decode_assertion
+from .client import ActuatorHttpClient
+from .envelope_builder import (
+    EnvelopeTooLargeError,
+    InvalidClearanceError,
+    build_and_canonicalize,
+)
+from .response_classifier import (
+    ClassifiedResponse,
+    ResponseCategory,
+    classify_network_error,
+    classify_response,
+)
+from .signatures import sign_for_quorum
+
 __all__ = [
     # Adapter (concrete ExecutionActuator implementation)
     "Actuator01Adapter",
@@ -43,19 +59,3 @@ __all__ = [
     "ClassifiedResponse",
     "ResponseCategory",
 ]
-
-from .adapter import Actuator01Adapter
-from .assertion import AssertionBuildError, build_assertion, decode_assertion
-from .client import ActuatorHttpClient
-from .envelope_builder import (
-    EnvelopeTooLargeError,
-    InvalidClearanceError,
-    build_and_canonicalize,
-)
-from .response_classifier import (
-    ClassifiedResponse,
-    ResponseCategory,
-    classify_network_error,
-    classify_response,
-)
-from .signatures import sign_for_quorum

--- a/tests/test_defer_dual_control_auth.py
+++ b/tests/test_defer_dual_control_auth.py
@@ -199,8 +199,6 @@ class TestDeferInjectBypassProtection:
     @pytest.mark.asyncio
     async def test_inject_rejects_quorum_3_defer_reasons(self):
         """Verify defer_inject rejects tokens with quorum-3 defer_reason."""
-        from unittest.mock import patch
-        
         # This test would require mocking the full FastAPI request flow
         # Placeholder for integration test that validates the reason-gate
         # Expected: 403 INJECTION_FORBIDDEN for FTRA_IRREVERSIBLE_TERMINAL


### PR DESCRIPTION
Add composed OSCAL SP 800-53 component definition artifact for multi-tier compliance validation.

This PR adds the composed OSCAL component definition that aggregates control implementations across the governance stack.

**Changes:**
- Add  with full control mapping

**Testing:**
- File validated against OSCAL schema
- References existing Lula validation files

**Compliance Impact:**
- Supports NIST SP 800-53 Rev 5 control attestation
- Enables automated OSCAL SSP export
- Maintains ISO 42001 control traceability