### PR TITLE
fix(integrations): correct actuator_01 wire protocol to match Archytan kernel

### DIFF
--- a/docs/meetings/luis_actuator_01_response.md
+++ b/docs/meetings/luis_actuator_01_response.md
@@ -1,0 +1,40 @@
+# Response to Luis — actuator_01 Wire Protocol Fixes
+
+**Date:** 2026-09-08  
+**Thread:** v3.0.0 actuator_01 contract review  
+**Status:** Both bugs fixed, all tests passing
+
+---
+
+Hi Luis,
+
+Thanks for the careful read of actuator_01 and catching both bugs before the harness integration — you saved us a 421 at the door for a reason that would've been painful to debug in a supervised run.
+
+## Both Bugs Fixed
+
+You were exactly right on both counts:
+
+**Bug 1 — Domain tag mismatch ([`signatures.py:32`](../../src/integrations/actuator_01/signatures.py:32)):**  
+Fixed. Was signing with `ACTUATOR_01_QUORUM_V1:`, now correctly uses `ARCHYTAN_QUORUM_V1:` to match your kernel's verification path.
+
+**Bug 2 — Header name mismatch ([`client.py:141`](../../src/integrations/actuator_01/client.py:141)):**  
+Fixed. Was sending `X-Quorum-Signatures`, now correctly sends `X-Archytan-Signatures` so it won't fail at the header check before signatures are even verified.
+
+You nailed the root cause — the anonymization pattern (anonymized constant names, wire-load-bearing runtime values per [`constants.py:19`](../../src/integrations/actuator_01/constants.py:19)) leaked into the values themselves. The fix keeps the anonymized names but restores the correct runtime wire-protocol values.
+
+All 110 actuator_01 tests pass, including updated test vectors validating the corrected domain tag and header name.
+
+## KMS IAM Model
+
+[`docs/architecture/actuator_01_kms_iam_model.md`](../architecture/actuator_01_kms_iam_model.md) is committed and up to date. It documents the single shared credential in the current reference implementation and lays out Option B (per-ceremony OIDC downscoping with zero standing IAM, credential lifetime = 30s window).
+
+**Yes to the IAM binding walkthrough.** I'd like to understand the token-exchange flow and the specific `iamcredentials.generateAccessToken` call shape for downscoping to a ceremony-scoped credential. When you have time, let's walk through:
+
+1. The IAM bindings on the operator service accounts (what role grants `iam.serviceAccounts.getAccessToken`?)
+2. Whether the ceremony-scoped token is passed via a custom `Credentials` object to the KMS client, or if there's a cleaner seam in the `google-auth` library
+3. Any gotchas around token lifetime floor/ceiling (30s is legal for access tokens, right?)
+
+The integration vector is ready on our side — envelope construction, quorum signing, and transport all align with the contract now.
+
+Thanks again,  
+Lars

--- a/src/integrations/actuator_01/assertion.py
+++ b/src/integrations/actuator_01/assertion.py
@@ -28,7 +28,7 @@ nonce, timestamp, and a domain-tagged KMS signature into exactly 120 bytes:
 
 Domain tag:  ``ACTUATOR_01_ASSERTION_V1:``
     Isolates assertion signatures from quorum signatures (which use
-    ``ACTUATOR_01_QUORUM_V1:``), preventing cross-context replay.
+    ``ARCHYTAN_QUORUM_V1:``), preventing cross-context replay.
 
 Wire encoding: base64url (RFC 4648 §5, no padding) per wire contract §7.3.
 """
@@ -57,7 +57,7 @@ _TIMESTAMP_SIZE = 8
 _SIGNATURE_OFFSET = 56
 _SIGNATURE_SIZE = 64
 
-# Domain tag — distinct from ACTUATOR_01_QUORUM_V1: used in signatures.py.
+# Domain tag — distinct from ARCHYTAN_QUORUM_V1: (quorum tag) used in signatures.py.
 ACTUATOR_01_DOMAIN_TAG_ASSERTION = b"ACTUATOR_01_ASSERTION_V1:"
 
 

--- a/src/integrations/actuator_01/client.py
+++ b/src/integrations/actuator_01/client.py
@@ -102,7 +102,7 @@ class ActuatorHttpClient:
         Headers constructed per wire contract:
         - X-Secure-Tenant-ID: tenant identifier (exactly one occurrence)
         - X-Operator-URNs: comma-separated operator URNs (positionally aligned)
-        - X-Quorum-Signatures: comma-separated hex signatures (positionally aligned)
+        - X-Archytan-Signatures: comma-separated hex signatures (positionally aligned)
         - X-Execution-Assertion: base64-encoded 120-byte assertion
         - X-Timestamp: unix seconds (equals issued_at)
         - Content-Type: application/json
@@ -138,7 +138,7 @@ class ActuatorHttpClient:
             "Content-Type": "application/json",
             "X-Secure-Tenant-ID": self.tenant_id,
             "X-Operator-URNs": ",".join(operator_urns),
-            "X-Quorum-Signatures": ",".join(signatures),
+            "X-Archytan-Signatures": ",".join(signatures),
             "X-Execution-Assertion": assertion,
             "X-Timestamp": str(issued_at),
         }

--- a/src/integrations/actuator_01/signatures.py
+++ b/src/integrations/actuator_01/signatures.py
@@ -29,7 +29,9 @@ from src.gateway.governance.kms_signer import KMSGovernanceSigner
 logger = logging.getLogger(__name__)
 
 # Domain tag for quorum signatures (prevents replay as assertion signatures)
-ACTUATOR_01_DOMAIN_TAG_QUORUM = b"ACTUATOR_01_QUORUM_V1:"
+# NOTE: This is the wire-load-bearing value required by Archytan kernel verification.
+# The constant name is anonymized; the runtime value must match the kernel contract.
+ACTUATOR_01_DOMAIN_TAG_QUORUM = b"ARCHYTAN_QUORUM_V1:"
 
 
 def sign_for_quorum(

--- a/tests/test_actuator_01_client.py
+++ b/tests/test_actuator_01_client.py
@@ -127,7 +127,8 @@ class TestActuatorHttpClient:
             headers["x-operator-urns"]
             == "urn:cage:operator:alice,urn:cage:operator:bob"
         )
-        assert headers["x-quorum-signatures"] == f"sig1{'0' * 124},sig2{'0' * 124}"
+        # Wire-protocol header name matches Archytan kernel contract
+        assert headers["x-archytan-signatures"] == f"sig1{'0' * 124},sig2{'0' * 124}"
 
     @pytest.mark.asyncio
     async def test_submit_envelope_validates_quorum(self, mock_client):

--- a/tests/test_actuator_01_signatures.py
+++ b/tests/test_actuator_01_signatures.py
@@ -97,8 +97,9 @@ class TestQuorumSignatures:
         """ACTUATOR_01_DOMAIN_TAG_QUORUM is distinct and prevents cross-context replay."""
         tag = ACTUATOR_01_DOMAIN_TAG_QUORUM
 
-        # Verify it's the expected value
-        assert tag == b"ACTUATOR_01_QUORUM_V1:"
+        # Verify it's the wire-protocol value (ARCHYTAN_QUORUM_V1:)
+        # The constant name is anonymized; the runtime value matches Archytan kernel contract.
+        assert tag == b"ARCHYTAN_QUORUM_V1:"
 
         # Verify it's bytes (not string)
         assert isinstance(tag, bytes)


### PR DESCRIPTION
## Summary

Fixes two critical wire-protocol bugs identified by Luis that would cause 100% failure rate on first contact with Archytan execution kernel.

## Bug 1 — Domain Tag Mismatch

**Issue:** `signatures.py` signed with `ACTUATOR_01_QUORUM_V1:` but Archytan kernel requires `ARCHYTAN_QUORUM_V1:`

**Fix:** Updated `ACTUATOR_01_DOMAIN_TAG_QUORUM` constant to match kernel contract

**Impact:** Every quorum signature now verifies correctly against Archytan kernel

## Bug 2 — HTTP Header Mismatch

**Issue:** `client.py` sent `X-Quorum-Signatures` but kernel expects `X-Archytan-Signatures`

**Fix:** Updated `submit_envelope()` to use correct wire-protocol header name

**Impact:** Request won't fail with 421 at header check before signatures are verified

## Root Cause

Anonymization pattern (anonymized constant names, wire-load-bearing runtime values per `constants.py:19`) leaked into the values themselves instead of staying in the names only.

## Files Changed

- `src/integrations/actuator_01/signatures.py` — domain tag constant
- `src/integrations/actuator_01/client.py` — HTTP header name
- `src/integrations/actuator_01/assertion.py` — documentation comments
- `tests/test_actuator_01_signatures.py` — domain tag assertion
- `tests/test_actuator_01_client.py` — header name verification
- `docs/meetings/luis_actuator_01_response.md` — response to Luis

## Test Results

- actuator_01 tests: **110/110 passed**
- Full local/unit suite: **3,438 passed, 0 failures**

## Checklist

- [x] Follows Conventional Commits format
- [x] All tests pass locally
- [x] Wire-protocol values match Archytan kernel contract
- [x] Response to Luis documenting fixes and KMS IAM model
- [x] Ready for supervised harness integration

Credit to Luis Fernando Martinez Chavez for catching both bugs before integration testing.