### PR TITLE
docs(infra): fix outdated cluster references and port forwarding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -239,7 +239,7 @@ AUDITOR_GCP_PROJECT_ID=            # Required if AUDITOR_TRACE_SOURCE=cloudtrace
 
 # --- KUBERNETES DEPLOYMENT (cloud-agnostic) ---
 # Cluster name for kubectl context (any K8s provider: k3s, EKS, AKS, GKE, etc.)
-K8S_CLUSTER_NAME=governance-cluster
+K8S_CLUSTER_NAME=cage-staging
 
 # K8s namespace
 K8S_NAMESPACE=governance-stack

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,9 +285,9 @@ This applies to all agents, contributors, and CI documentation examples.
 When running `uv run ...` as an AI agent inside a restricted terminal sandbox, the command may fail due to sandbox path boundaries (e.g. `zsh:1: operation not permitted: uv`, exit code 127) or socket connectivity resets (`connecting to sandbox server: read unix @->@: recvmsg: connection reset by peer`). When encountering this, do not switch to a different test runner like bare `python` or `pytest`; instead, configure the tool call to bypass the sandbox (e.g. `BypassSandbox: true`) so that the command executes natively in the host environment and accesses `uv`. When retrying with `BypassSandbox: true`, keep `toolAction` and `toolSummary` strictly identical.
 
 **Hermetic Local Test Execution vs. Active Port-Forwards:**
-When background port-forwards are running (such as those started via `scripts/port_forward_dev.sh`), localhost ports (Redis `6379`, OPA `8181`, Langfuse `3000`/`3001`, Gateway `8080`) are actively bridged to the live GKE development cluster. Local unit tests (`pytest tests/ -m "local or unit"`) that do not strictly isolate network sockets can inadvertently connect to the live GKE cluster and encounter live state (e.g., existing fence epochs, active cache keys), causing unexpected assertions like `assert cbf._last_seen_epoch == 42` reading live Redis epoch `17`.
+When background port-forwards are running (such as those started via `scripts/port_forward_staging.sh` or `scripts/port_forward.sh`), localhost ports (Redis `6379`, OPA `8181`, Langfuse `3000`/`3001`, Gateway `8080`) are actively bridged to the live GKE cluster. Local unit tests (`pytest tests/ -m "local or unit"`) that do not strictly isolate network sockets can inadvertently connect to the live GKE cluster and encounter live state (e.g., existing fence epochs, active cache keys), causing unexpected assertions like `assert cbf._last_seen_epoch == 42` reading live Redis epoch `17`.
 - **Before running pure local/unit tests**: Verify no background tunnels are running (`ps aux | grep port-forward`), or terminate them if isolated offline execution is desired (`pkill -f "kubectl port-forward"`).
-- **For integration testing against live GKE**: Launch `scripts/port_forward_dev.sh` and run with `tests/ --run-integration`.
+- **For integration testing against live GKE**: Launch `scripts/port_forward_staging.sh` and run with `tests/ --run-integration`.
 
 ---
 
@@ -599,14 +599,14 @@ Always launch the test suite with `--dist loadscope` (or `--dist=loadfile`) to e
    - `EU_ECB` → `europe-west1`
    - `APAC_MAS` → `asia-southeast1`
 3. **Live GKE Testing**:
-   Live dual-pipeline attestation, trace verification, and SLA timing are validated exclusively against live GKE clusters via port-forwarding (`scripts/port_forward_dev.sh`, forwarding ports `3000` and `3001`) with `uv run pytest tests/ --run-integration`. Local offline tests must keep telemetry tracing disabled (`-p no:langsmith -p no:langsmith_plugin`, `LANGCHAIN_TRACING_V2=false`, `LANGSMITH_TRACING=false`).
+   Live dual-pipeline attestation, trace verification, and SLA timing are validated exclusively against live GKE clusters via port-forwarding (`scripts/port_forward_staging.sh`, forwarding ports `3000` and `3001`) with `uv run pytest tests/ --run-integration`. Local offline tests must keep telemetry tracing disabled (`-p no:langsmith -p no:langsmith_plugin`, `LANGCHAIN_TRACING_V2=false`, `LANGSMITH_TRACING=false`).
 
 ### Full Integration Suite Against Live GKE
 
 The canonical way to run the full integration test suite against the live GKE staging cluster:
 
 ```bash
-# 1. Establish port-forwards to cage-staging cluster (keep running in background)
+# 1. Establish port-forwards to the staging GKE cluster (keep running in background)
 bash scripts/port_forward_staging.sh
 
 # 2. In a separate terminal, load env and run full suite
@@ -621,9 +621,9 @@ uv run pytest tests/ --run-integration -v --tb=short
 
 Key facts:
 - `scripts/port_forward_staging.sh` establishes auto-reconnecting `kubectl port-forward` tunnels: OPA (8181), Langfuse API/UI (3001/3000), vLLM fast (8001/18081), vLLM reasoning (8000/18082), Gateway (8080), backend (8081), Redis (6379), Compliance Bridge (3002).
-- Requires a valid `kubectl` context pointing to `cage-staging` cluster in `us-central1-a`.
+- Requires a valid `kubectl` context pointing to the staging GKE cluster (e.g. `<cluster-name>` in `us-central1-a`).
 - `.env` at the repo root is loaded automatically by `port_forward_staging.sh` and `tests/conftest.py`.
-- The `cage-staging` cluster serves as the integration testing environment (no separate dev cluster exists).
+- The staging cluster serves as the integration testing environment (no separate dev cluster exists).
 - Last known result (2026-08-10): **2553 passed, 51 skipped, 1 failed** in ~9m25s. The 51 skips are region/OPA-gated integration tests; the 1 failure was a test-isolation bug (cache leak in `tests/test_red_teaming.py::mock_thresholds` fixture), not a GKE connectivity issue.
 - Always use `uv run pytest`, never bare `pytest`.
 
@@ -675,4 +675,4 @@ See [`infra/targets/gcp-gke/staging.tfvars`](infra/targets/gcp-gke/staging.tfvar
 - The `local`/`unit` marker subset (~90%+ of the 2553 passing tests) already runs on every push/PR via the existing `pytest-logic` job in all three region postures (`.github/workflows/ci.yml` lines 87–134). A dedicated nightly run of the same markers adds negligible incremental regression-detection value over what is already gated on `main` before merge.
 - Tests that genuinely require live GKE (live OPA policy evaluation, Langfuse SLA timing, CMEK/pod-restart checks, real backend accuracy) **cannot be replaced** by a mock-only nightly — these are the `integration`-marked corpus and the 51 skips in the full run.
 - Existing CI already covers what a nightly would target: `pytest-logic` (mock/unit, every push), `ai600-unit-tests` (red-team mock, every push), `locust-load-test` (nightly load test).
-- **Practical guidance**: treat `pytest-logic` + `ai600-unit-tests` (GKE-independent, secret-free) as the authoritative daily regression gate. Reserve the live-GKE `integration-smoke` job, manual full-suite runs (`port_forward_dev.sh` + `uv run pytest tests/ --run-integration`), and **staging lifecycle validation** (`./scripts/staging_lifecycle.sh`) for periodic live-service validation.
+- **Practical guidance**: treat `pytest-logic` + `ai600-unit-tests` (GKE-independent, secret-free) as the authoritative daily regression gate. Reserve the live-GKE `integration-smoke` job, manual full-suite runs (`scripts/port_forward_staging.sh` + `uv run pytest tests/ --run-integration`), and **staging lifecycle validation** (`./scripts/staging_lifecycle.sh`) for periodic live-service validation.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -603,16 +603,16 @@ Always launch the test suite with `--dist loadscope` (or `--dist=loadfile`) to e
 
 ### Full Integration Suite Against Live GKE
 
-The canonical way to run the full integration test suite against the live GKE dev cluster:
+The canonical way to run the full integration test suite against the live GKE staging cluster:
 
 ```bash
-# 1. Establish port-forwards to live GKE dev cluster (keep running in background)
-bash scripts/port_forward_dev.sh
+# 1. Establish port-forwards to cage-staging cluster (keep running in background)
+bash scripts/port_forward_staging.sh
 
 # 2. In a separate terminal, load env and run full suite
 source .env
-export CAGE_ENV=dev
-export CAGE_DEPLOYMENT_REGION="${CAGE_DEPLOYMENT_REGION:-LOCAL}"
+export CAGE_ENV=staging
+export CAGE_DEPLOYMENT_REGION="${CAGE_DEPLOYMENT_REGION:-US_FED}"
 export CAGE_ROUTING_SEAL_SECRET="${CAGE_ROUTING_SEAL_SECRET:-dev-only-insecure-placeholder-not-for-production-use}"
 export GOVERNANCE_SALT="${GOVERNANCE_SALT:-dev-only-insecure-placeholder-not-for-production-use}"
 export LANGFUSE_POSTURE_DRY_RUN=true
@@ -620,9 +620,10 @@ uv run pytest tests/ --run-integration -v --tb=short
 ```
 
 Key facts:
-- `scripts/port_forward_dev.sh` establishes auto-reconnecting `kubectl port-forward` tunnels: OPA (8181), Langfuse API/UI (3001/3000), vLLM fast (8001/18081), vLLM reasoning (8000/18082), Gateway (8080), backend (18080), Redis (6379), Compliance Bridge (3002).
-- Requires a valid `kubectl` context pointing to `governance-cluster-2` in `us-central1-a`.
-- `.env` at the repo root is loaded automatically by `port_forward_dev.sh` and `tests/conftest.py`.
+- `scripts/port_forward_staging.sh` establishes auto-reconnecting `kubectl port-forward` tunnels: OPA (8181), Langfuse API/UI (3001/3000), vLLM fast (8001/18081), vLLM reasoning (8000/18082), Gateway (8080), backend (8081), Redis (6379), Compliance Bridge (3002).
+- Requires a valid `kubectl` context pointing to `cage-staging` cluster in `us-central1-a`.
+- `.env` at the repo root is loaded automatically by `port_forward_staging.sh` and `tests/conftest.py`.
+- The `cage-staging` cluster serves as the integration testing environment (no separate dev cluster exists).
 - Last known result (2026-08-10): **2553 passed, 51 skipped, 1 failed** in ~9m25s. The 51 skips are region/OPA-gated integration tests; the 1 failure was a test-isolation bug (cache leak in `tests/test_red_teaming.py::mock_thresholds` fixture), not a GKE connectivity issue.
 - Always use `uv run pytest`, never bare `pytest`.
 

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Domain specificity and jurisdictional compliance are **configuration, not core r
 | **APAC_MAS** (MAS TRM / FEAT) | `dev` / `test` | ✅ **3,747 passed** / 0 failed / 73 skipped (75.40% cov) | 2026-09-03 |
 | **APAC_MAS** (MAS TRM / FEAT) | `prod` | ✅ **211 passed** / 0 failed / 137 skipped | 2026-09-03 |
 
-Tests pass cleanly across all three regulatory postures on macOS and Linux GKE targets (`governance-cluster-2`, project `<your-gcp-project>`).
-Skipped tests represent live GKE cluster integration endpoints (evaluated via `scripts/port_forward_dev.sh` + `uv run pytest tests/ --run-integration`).
+Tests pass cleanly across all three regulatory postures on macOS and Linux GKE targets (`<cluster-name>`, project `<your-gcp-project>`).
+Skipped tests represent live GKE cluster integration endpoints (evaluated via `scripts/port_forward_staging.sh` + `uv run pytest tests/ --run-integration`).
 
 ---
 

--- a/deployment/config.yaml
+++ b/deployment/config.yaml
@@ -17,7 +17,7 @@ project:
   zone: us-central1-a # Updated to match .env
 
 cluster:
-  name: governance-cluster
+  name: cage-staging
   network: default
   machine_type: g2-standard-16
   disk_size_gb: 100

--- a/deployment/teardown.py
+++ b/deployment/teardown.py
@@ -35,7 +35,7 @@ def main():
     parser.add_argument("--region", default="us-central1", help="GCP Region")
     parser.add_argument("--zone", help="GCP Zone (optional, overrides region for GKE)")
     parser.add_argument(
-        "--cluster-name", default="governance-cluster", help="GKE Cluster Name"
+        "--cluster-name", default="cage-staging", help="GKE Cluster Name"
     )
     parser.add_argument(
         "--service-name",

--- a/docs/technical-report/01-SYSTEM-OVERVIEW.md
+++ b/docs/technical-report/01-SYSTEM-OVERVIEW.md
@@ -130,7 +130,7 @@ CAGE provides eight integrated capabilities. **Capabilities 2 and 4–8 are doma
 
 ## 5. Current Compliance Posture (NIST RMF Readiness)
 
-CAGE is in active NIST RMF implementation. As of the assessment date, the system has not been recommended for ATO. The overall risk posture is classified **HIGH**. The v3.0.0 stable release was tagged on 2026-09-07. Both application images were built via Cloud Build and deployed to GKE cluster `governance-cluster-2`, namespace `governance-stack`. The test suite reports **3,446 passed, 0 failed, 96 skipped** (3,925 collected) with statement coverage across all three regional compliance postures.
+CAGE is in active NIST RMF implementation. As of the assessment date, the system has not been recommended for ATO. The overall risk posture is classified **HIGH**. The v3.0.0 stable release was tagged on 2026-09-07. Both application images were built via Cloud Build and deployed to target GKE cluster (`<cluster-name>`), namespace `governance-stack`. The test suite reports **3,446 passed, 0 failed, 96 skipped** (3,925 collected) with statement coverage across all three regional compliance postures.
 
 ### 5.1 Control Family Readiness
 

--- a/plans/post_consolidation_roadmap.md
+++ b/plans/post_consolidation_roadmap.md
@@ -708,7 +708,7 @@ A useful framing: A proves the *gates* work; C proves the *system* works.
 **Prerequisites**
 
 - A1 complete (do not debug integration failures on top of known unit failures)
-- `kubectl` context on `governance-cluster-2` in `us-central1-a`
+- `kubectl` context pointing to target GKE cluster (e.g. `<cluster-name>` in `us-central1-a`)
 - Populated `.env` at repository root
 - Cluster provisioned and reachable
 
@@ -1320,7 +1320,7 @@ only thing standing between an adopter and understanding what was just built.
 
 | Dependency | Needed for | Notes |
 |---|---|---|
-| GKE dev cluster (`governance-cluster-2`, `us-central1-a`) | C1 | Verify it still exists before scheduling |
+| GKE cluster (`<cluster-name>`, `us-central1-a`) | C1 | Verify it still exists before scheduling |
 | `kubectl` context + cluster credentials | C1, C3 | |
 | Populated `.env` at repo root | C1 | Auto-loaded by [`port_forward_dev.sh`](../scripts/port_forward_dev.sh) and [`tests/conftest.py`](../tests/conftest.py) |
 | GCP project + KMS keyring | D1 | Only if D1 proceeds |

--- a/plans/staging_posture_cost_optimization_plan.md
+++ b/plans/staging_posture_cost_optimization_plan.md
@@ -41,7 +41,7 @@ re-validates it empirically rather than trusting it on faith.
 ### Finding 3 — prod is a template, not a running cluster
 
 [`prod.tfvars`](../infra/targets/gcp-gke/prod.tfvars) targets `cage-prod` in a
-placeholder project. The live cluster is `governance-cluster-2` in
+placeholder project. The live cluster is the GKE target cluster (`<cluster-name>`) in
 `us-central1-a`. All current spend is dev-side.
 
 ## Design Constraints

--- a/plans/veip_three_axioms_architecture.md
+++ b/plans/veip_three_axioms_architecture.md
@@ -594,7 +594,7 @@ that only read today's envelope structure.
   "expires_at": "2026-08-21T12:00:30.000Z",
   "issuer": {
     "service": "cage-gateway",
-    "instance_id": "gke-governance-cluster-2-abc123",
+    "instance_id": "gke-<cluster-name>-abc123",
     "region": "us-central1",
     "trust_domain_attestation": {
       "ca_fingerprint": "sha256:...",

--- a/scripts/port_forward.sh
+++ b/scripts/port_forward.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+# ── Unified Port-Forward Manager ─────────────────────────────────────────────
+# Manages resilient auto-reconnecting kubectl port-forwards to target GKE
+# clusters (staging, dev, or local testbeds).
+#
+# Safety Invariant:
+#   Port-forwarding against production clusters is blocked by default to
+#   prevent accidental operational or state corruption.
+#
+# Usage:
+#   ./scripts/port_forward.sh [--env staging|dev] [--daemon] [--force]
+#   ./scripts/port_forward.sh --status
+#   ./scripts/port_forward.sh --stop
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Load .env if present ─────────────────────────────────────────────────────
+if [[ -f "$REPO_ROOT/.env" ]]; then
+  set -o allexport
+  # shellcheck disable=SC1090
+  source "$REPO_ROOT/.env"
+  set +o allexport
+fi
+
+TARGET_ENV="${CAGE_ENV:-staging}"
+DAEMON=false
+FORCE=false
+ACTION="start"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --env)
+      TARGET_ENV="$2"
+      shift 2
+      ;;
+    --env=*)
+      TARGET_ENV="${1#*=}"
+      shift
+      ;;
+    --daemon|--foreground)
+      DAEMON=true
+      shift
+      ;;
+    --force)
+      FORCE=true
+      shift
+      ;;
+    --status)
+      ACTION="status"
+      shift
+      ;;
+    --stop)
+      ACTION="stop"
+      shift
+      ;;
+    -h|--help)
+      echo "Usage: $0 [--env staging|dev] [--daemon] [--force] [--status] [--stop]"
+      echo ""
+      echo "Options:"
+      echo "  --env <name>     Target environment ('staging' or 'dev', default: staging)"
+      echo "  --daemon         Keep process in foreground"
+      echo "  --force          Bypass non-matching context checks"
+      echo "  --status         Check health of port-forwards"
+      echo "  --stop           Stop active port-forward loops"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+NS="${K8S_NAMESPACE:-governance-stack}"
+LOG_DIR="/tmp/cage-pf-${TARGET_ENV}"
+PF_PIDS_FILE="/tmp/pf_${TARGET_ENV}_pids.txt"
+
+# ── Action: Stop ─────────────────────────────────────────────────────────────
+if [[ "$ACTION" == "stop" ]]; then
+  echo "[port-forward] Stopping port-forward tunnels for environment: $TARGET_ENV..."
+  if [[ -f "${PF_PIDS_FILE}" ]]; then
+    while IFS= read -r pid; do
+      kill "${pid}" 2>/dev/null || true
+    done < "${PF_PIDS_FILE}"
+    rm -f "${PF_PIDS_FILE}"
+  fi
+  pkill -f "kubectl port-forward.*$NS" 2>/dev/null || true
+  echo "[port-forward] Stopped."
+  exit 0
+fi
+
+# ── Cluster & Context Safety Validation ──────────────────────────────────────
+CURRENT_CONTEXT=$(kubectl config current-context 2>/dev/null || echo "none")
+
+if [[ "$CURRENT_CONTEXT" == "none" ]]; then
+  echo "❌ Error: Unable to determine current kubectl context. Is kubectl configured?" >&2
+  exit 1
+fi
+
+# Safety check: Prevent accidental port-forwarding to production
+if [[ "$CURRENT_CONTEXT" =~ prod && "$FORCE" != "true" ]]; then
+  echo "❌ ERROR: Current kubectl context is '$CURRENT_CONTEXT' (production)." >&2
+  echo "   Port-forwarding to production is blocked by default to prevent state pollution." >&2
+  echo "   Switch context to staging or pass --force if deliberately intended." >&2
+  exit 1
+fi
+
+# Context validation for target environment
+if [[ "$TARGET_ENV" == "staging" ]]; then
+  if [[ ! "$CURRENT_CONTEXT" =~ staging && "$FORCE" != "true" ]]; then
+    echo "❌ Error: Current kubectl context is '$CURRENT_CONTEXT'" >&2
+    echo "   Expected a staging cluster context (containing 'staging')." >&2
+    echo "   Pass --force to override or switch context with:" >&2
+    echo "   kubectl config use-context <staging-cluster-context>" >&2
+    exit 1
+  fi
+fi
+
+# ── Action: Status ───────────────────────────────────────────────────────────
+if [[ "$ACTION" == "status" ]]; then
+  echo "[port-forward] Checking port reachability for context $CURRENT_CONTEXT (env: $TARGET_ENV):"
+  for port in 8181 3001 3000 8001 8000 8080 3002 8081 6379; do
+    if nc -z localhost "$port" 2>/dev/null; then
+      echo "  ✅ localhost:$port reachable"
+    else
+      echo "  ❌ localhost:$port not reachable"
+    fi
+  done
+  exit 0
+fi
+
+# ── Teardown Stale Loops ─────────────────────────────────────────────────────
+mkdir -p "$LOG_DIR"
+echo "[port-forward] Context: $CURRENT_CONTEXT | Namespace: $NS | Env: $TARGET_ENV"
+echo "[port-forward] Clearing previous port-forwards and reconnect loops..."
+
+if [[ -f "${PF_PIDS_FILE}" ]]; then
+  while IFS= read -r pid; do
+    kill "${pid}" 2>/dev/null || true
+  done < "${PF_PIDS_FILE}"
+  rm -f "${PF_PIDS_FILE}"
+fi
+pkill -f "kubectl port-forward.*$NS" 2>/dev/null || true
+sleep 0.3
+
+# ── Auto-Reconnect Function ──────────────────────────────────────────────────
+start_pf() {
+  local name="$1"
+  local svc="$2"
+  local local_port="$3"
+  local remote_port="$4"
+  local log_path="$LOG_DIR/${name}.log"
+
+  nohup bash -c "
+    while true; do
+      kubectl port-forward -n '$NS' 'svc/$svc' '${local_port}:${remote_port}' \
+        --pod-running-timeout=5m \
+        >>'$log_path' 2>&1 || true
+      echo \"\$(date -u '+%H:%M:%S')  ⚠️  port-forward $svc (${local_port}:${remote_port}) dropped — restarting in 2s…\" \
+        | tee -a '$log_path' >&2
+      sleep 2
+    done
+  " >/dev/null 2>&1 &
+  local loop_pid=$!
+  disown "${loop_pid}" 2>/dev/null || true
+  echo "${loop_pid}" >> "${PF_PIDS_FILE}"
+  echo "[port-forward]   $name loop pid: ${loop_pid}"
+}
+
+# ── Core Services Required by Tests ──────────────────────────────────────────
+: > "${PF_PIDS_FILE}"
+
+start_pf opa          opa                       8181  8181  # OPA policy engine
+start_pf langfuse     langfuse-web              3001  3000  # Langfuse API (LLM judge evaluation)
+start_pf langfuse-web langfuse-web              3000  3000  # Langfuse UI (NextAuth)
+start_pf vllm-fast    vllm-service              8001  8000  # Fast vLLM (Qwen2.5-7B) — primary (:8001)
+start_pf vllm-fast2   vllm-service             18081  8000  # Fast vLLM — VLLM_FAST_API_BASE (:18081)
+start_pf vllm-reason  vllm-reasoning            8000  8000  # Reasoning vLLM (DeepSeek R1) — primary (:8000)
+start_pf vllm-reason2 vllm-reasoning           18082  8000  # Reasoning vLLM — VLLM_REASONING_API_BASE (:18082)
+start_pf gateway      gateway                   8080  8080  # Gateway gRPC/HTTP
+
+if kubectl get svc -n "$NS" redis-master &>/dev/null; then
+  start_pf redis        redis-master              6379  6379  # Redis (redis-master svc)
+else
+  start_pf redis        redis                     6379  6379  # Redis (redis svc)
+fi
+
+if kubectl get svc -n "$NS" compliance-bridge &>/dev/null; then
+  start_pf compliance   compliance-bridge          3002    80  # Compliance bridge — BASE_URL (:3002)
+fi
+
+if kubectl get svc -n "$NS" governed-financial-advisor &>/dev/null; then
+  start_pf backend      governed-financial-advisor 8081    80  # Governed Financial Advisor backend (:8081)
+fi
+
+echo "[port-forward] Waiting for readiness (3s)..."
+sleep 3
+
+echo "[port-forward] Status checks:"
+for port in 8181 3001 3000 8001 8000 8080 3002 8081 6379; do
+  if nc -z localhost "$port" 2>/dev/null; then
+    echo "  ✅ localhost:$port reachable"
+  else
+    echo "  ⚠️  localhost:$port not reachable yet"
+  fi
+done
+
+echo ""
+echo "[port-forward] Done. Auto-reconnect loops active."
+echo "  Context : $CURRENT_CONTEXT"
+echo "  Env     : $TARGET_ENV"
+echo "  Logs    : $LOG_DIR/"
+echo "  PIDs    : ${PF_PIDS_FILE}"
+echo "  Stop    : $0 --env $TARGET_ENV --stop"
+echo ""
+echo "To run integration tests:"
+echo "  source .env"
+echo "  export CAGE_ENV=$TARGET_ENV"
+echo "  export CAGE_DEPLOYMENT_REGION=\${CAGE_DEPLOYMENT_REGION:-US_FED}"
+echo "  uv run pytest tests/ --run-integration -v --tb=short"
+
+if [[ "$DAEMON" == "true" || "${FOREGROUND:-false}" == "true" ]]; then
+  echo "[port-forward] Running in foreground/daemon mode. Keeping tunnels active..."
+  while true; do sleep 3600; done
+fi

--- a/scripts/port_forward_staging.sh
+++ b/scripts/port_forward_staging.sh
@@ -15,8 +15,6 @@
 
 set -euo pipefail
 
-# Wrapper for port_forward.sh targeting the development environment.
-# Note: In environments without a dedicated dev cluster, integration tests run
-# against the staging cluster via scripts/port_forward_staging.sh.
+# Wrapper for port_forward.sh explicitly targeting the staging environment.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-exec "$SCRIPT_DIR/port_forward.sh" --env dev "$@"
+exec "$SCRIPT_DIR/port_forward.sh" --env staging "$@"

--- a/src/gateway/governance/governance_envelope.py
+++ b/src/gateway/governance/governance_envelope.py
@@ -30,7 +30,7 @@ Envelope Structure (RFC 8785 JCS-canonicalized):
         "expires_at": "2026-08-21T12:00:30.000Z", # ISO 8601 UTC
         "issuer": {
             "service": "cage-gateway",
-            "instance_id": "gke-governance-cluster-2-abc123",
+            "instance_id": "gke-<cluster-name>-abc123",
             "region": "us-central1"
         },
         "subject": {


### PR DESCRIPTION
Consolidate port forwarding documentation/scripts and update outdated cluster references in AGENTS.md and .env.