### PR TITLE
fix(security): use ARCHYTAN_ASSERTION_V1 domain tag in assertion

### DIFF
--- a/src/integrations/actuator_01/README.md
+++ b/src/integrations/actuator_01/README.md
@@ -5,9 +5,10 @@
 > has **no configured live endpoint**. Adopters should treat this as an
 > integration pattern to adapt, not a hosted service.
 >
-> **Naming note:** The vendor name for this integration is **Archytan**. The
-> package path `actuator_01` is retained for import stability across branches
-> and test fixtures.
+> **Naming & Partner Note:** **Archytan** is the reference downstream
+> execution actuator integration partner for CAGE. The package path
+> `actuator_01` is retained for import stability across branches and test
+> fixtures.
 >
 > **Formerly `provider_04`:** This integration was renamed from `provider_04`
 > to `actuator_01` to reflect its role as an execution actuator rather than a
@@ -77,8 +78,9 @@ environment variables:
 | `X-Archytan-Signatures` | Quorum signature array | Per-operator signature over the 120-byte assertion |
 | `Content-Type` | `application/json` | Envelope payload |
 
-**Note:** The header name `X-Archytan-Signatures` and the domain tag
-`ARCHYTAN_QUORUM_V1:` embedded in quorum signatures are load-bearing in the
+**Note:** The header name `X-Archytan-Signatures` and the domain tags
+`ARCHYTAN_ASSERTION_V1:` (assertion signing) and `ARCHYTAN_QUORUM_V1:`
+(quorum signing) embedded in wire signatures are load-bearing in the
 wire protocol. This makes vendor anonymization unavailable for this partner
 without a coordinated protocol change. See
 [`docs/meetings/luis_actuator_01_response.md`](../../../docs/meetings/luis_actuator_01_response.md)

--- a/src/integrations/actuator_01/assertion.py
+++ b/src/integrations/actuator_01/assertion.py
@@ -26,7 +26,7 @@ nonce, timestamp, and a domain-tagged KMS signature into exactly 120 bytes:
     48..55       8     Timestamp — ``issued_at`` as unsigned 64-bit big-endian
     56..119     64     Domain-tagged KMS signature over bytes [0..55]
 
-Domain tag:  ``ACTUATOR_01_ASSERTION_V1:``
+Domain tag:  ``ARCHYTAN_ASSERTION_V1:``
     Isolates assertion signatures from quorum signatures (which use
     ``ARCHYTAN_QUORUM_V1:``), preventing cross-context replay.
 
@@ -59,7 +59,9 @@ _SIGNATURE_OFFSET = 56
 _SIGNATURE_SIZE = 64
 
 # Domain tag — distinct from ARCHYTAN_QUORUM_V1: (quorum tag) used in signatures.py.
-ACTUATOR_01_DOMAIN_TAG_ASSERTION = b"ACTUATOR_01_ASSERTION_V1:"
+# NOTE: This is the wire-load-bearing value required by Archytan kernel verification.
+# The constant name is anonymized; the runtime value must match the kernel contract.
+ACTUATOR_01_DOMAIN_TAG_ASSERTION = b"ARCHYTAN_ASSERTION_V1:"
 
 
 class AssertionBuildError(Exception):

--- a/tests/test_actuator_01_assertion.py
+++ b/tests/test_actuator_01_assertion.py
@@ -143,6 +143,9 @@ class TestDomainTagIsolation:
     def test_assertion_domain_tag_differs_from_quorum(self):
         assert ACTUATOR_01_DOMAIN_TAG_ASSERTION != ACTUATOR_01_DOMAIN_TAG_QUORUM
 
+    def test_assertion_domain_tag_exact_value(self):
+        assert ACTUATOR_01_DOMAIN_TAG_ASSERTION == b"ARCHYTAN_ASSERTION_V1:"
+
     def test_signer_receives_assertion_domain_tag(
         self, mock_signer, valid_digest_hex, valid_nonce_hex, valid_issued_at
     ):


### PR DESCRIPTION
## Summary
Corrects the domain tag literal used in execution assertion construction to `b"ARCHYTAN_ASSERTION_V1:"`, matching Archytan kernel verification. Also explicitly credits Archytan as CAGE's reference execution actuator integration partner in `actuator_01/README.md`.

## Changes
- `src/integrations/actuator_01/assertion.py`: Update `ACTUATOR_01_DOMAIN_TAG_ASSERTION` from `b"ACTUATOR_01_ASSERTION_V1:"` to `b"ARCHYTAN_ASSERTION_V1:"`.
- `tests/test_actuator_01_assertion.py`: Add explicit unit test assertion verifying the exact `b"ARCHYTAN_ASSERTION_V1:"` domain tag.
- `src/integrations/actuator_01/README.md`: Formally document Archytan as reference downstream execution actuator partner and document both load-bearing wire domain tags.

## Testing
- `uv run pytest tests/test_actuator_01_*.py`: 138 passed in 17.79s
- `uv run ruff check .`: All checks passed