### PR TITLE
test(compliance): supply operator header in defer escalation test

### DIFF
--- a/tests/test_compliance_bridge_integration.py
+++ b/tests/test_compliance_bridge_integration.py
@@ -1616,6 +1616,7 @@ class TestDeferQueueEndpoints:
     def test_defer_escalate_unknown_id_returns_404(self, session):
         r = session.post(
             f"{BASE_URL}/v1/defer/definitely-not-real-{_uid()}/escalate",
+            headers={"x-cage-source-principal": "spiffe://cage.local/operator/tester"},
             json={"operator_urn": "urn:cage:operator:tester"},
             timeout=15,
         )


### PR DESCRIPTION
Supply operator identity header (SPIFFE principal) in test_defer_escalate_unknown_id_returns_404 to satisfy staging posture authentication rules.